### PR TITLE
Add messaging feature with CRUD operations and edit history tracking

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -20,6 +20,7 @@ import { APP_GUARD } from '@nestjs/core';
 import { JwtAuthGuard } from './auth/guards/jwt-auth.guard';
 import { RolesSeederService } from './database/seeders/roles.seeder';
 import { SessionsModule } from './sessions/sessions.module';
+import { MessageModule } from './message/message.module';
 
 @Module({
   imports: [
@@ -68,6 +69,7 @@ import { SessionsModule } from './sessions/sessions.module';
     RedisModule,
     RolesModule,
     SessionsModule,
+    MessageModule,
   ],
   controllers: [AppController],
   providers: [

--- a/src/database/migrations/1705967200000-AddMessagesAndEditHistory.ts
+++ b/src/database/migrations/1705967200000-AddMessagesAndEditHistory.ts
@@ -1,0 +1,229 @@
+import {
+  MigrationInterface,
+  QueryRunner,
+  Table,
+  TableForeignKey,
+  TableIndex,
+} from 'typeorm';
+
+export class AddMessagesAndEditHistory1705967200000 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // Create messages table
+    await queryRunner.createTable(
+      new Table({
+        name: 'messages',
+        columns: [
+          {
+            name: 'id',
+            type: 'uuid',
+            isPrimary: true,
+            default: 'uuid_generate_v4()',
+          },
+          {
+            name: 'conversationId',
+            type: 'varchar',
+            isNullable: false,
+          },
+          {
+            name: 'authorId',
+            type: 'uuid',
+            isNullable: false,
+          },
+          {
+            name: 'content',
+            type: 'text',
+            isNullable: false,
+          },
+          {
+            name: 'originalContent',
+            type: 'text',
+            isNullable: true,
+          },
+          {
+            name: 'isEdited',
+            type: 'boolean',
+            default: false,
+          },
+          {
+            name: 'editedAt',
+            type: 'timestamp',
+            isNullable: true,
+          },
+          {
+            name: 'isDeleted',
+            type: 'boolean',
+            default: false,
+          },
+          {
+            name: 'deletedAt',
+            type: 'timestamp',
+            isNullable: true,
+          },
+          {
+            name: 'deletedBy',
+            type: 'uuid',
+            isNullable: true,
+          },
+          {
+            name: 'isHardDeleted',
+            type: 'boolean',
+            default: false,
+          },
+          {
+            name: 'createdAt',
+            type: 'timestamp',
+            default: 'CURRENT_TIMESTAMP',
+          },
+          {
+            name: 'updatedAt',
+            type: 'timestamp',
+            default: 'CURRENT_TIMESTAMP',
+            onUpdate: 'CURRENT_TIMESTAMP',
+          },
+        ],
+      }),
+      true,
+    );
+
+    // Create message_edit_history table
+    await queryRunner.createTable(
+      new Table({
+        name: 'message_edit_history',
+        columns: [
+          {
+            name: 'id',
+            type: 'uuid',
+            isPrimary: true,
+            default: 'uuid_generate_v4()',
+          },
+          {
+            name: 'messageId',
+            type: 'uuid',
+            isNullable: false,
+          },
+          {
+            name: 'previousContent',
+            type: 'text',
+            isNullable: false,
+          },
+          {
+            name: 'newContent',
+            type: 'text',
+            isNullable: false,
+          },
+          {
+            name: 'editedAt',
+            type: 'timestamp',
+            default: 'CURRENT_TIMESTAMP',
+          },
+        ],
+      }),
+      true,
+    );
+
+    // Create indexes for better query performance
+    await queryRunner.createIndex(
+      'messages',
+      new TableIndex({
+        name: 'IDX_messages_conversationId_createdAt',
+        columnNames: ['conversationId', 'createdAt'],
+      }),
+    );
+
+    await queryRunner.createIndex(
+      'messages',
+      new TableIndex({
+        name: 'IDX_messages_authorId_createdAt',
+        columnNames: ['authorId', 'createdAt'],
+      }),
+    );
+
+    await queryRunner.createIndex(
+      'messages',
+      new TableIndex({
+        name: 'IDX_messages_isDeleted_conversationId',
+        columnNames: ['isDeleted', 'conversationId'],
+      }),
+    );
+
+    await queryRunner.createIndex(
+      'message_edit_history',
+      new TableIndex({
+        name: 'IDX_message_edit_history_messageId',
+        columnNames: ['messageId'],
+      }),
+    );
+
+    // Create foreign key constraint for messages.authorId -> users.id
+    await queryRunner.createForeignKey(
+      'messages',
+      new TableForeignKey({
+        columnNames: ['authorId'],
+        referencedColumnNames: ['id'],
+        referencedTableName: 'users',
+        onDelete: 'CASCADE',
+        onUpdate: 'CASCADE',
+      }),
+    );
+
+    // Create foreign key constraint for message_edit_history.messageId -> messages.id
+    await queryRunner.createForeignKey(
+      'message_edit_history',
+      new TableForeignKey({
+        columnNames: ['messageId'],
+        referencedColumnNames: ['id'],
+        referencedTableName: 'messages',
+        onDelete: 'CASCADE',
+        onUpdate: 'CASCADE',
+      }),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    // Drop foreign keys
+    const messageTable = await queryRunner.getTable('messages');
+    const messageEditHistoryTable = await queryRunner.getTable(
+      'message_edit_history',
+    );
+
+    if (messageTable) {
+      const authorForeignKey = messageTable.foreignKeys.find(
+        (fk) => fk.columnNames[0] === 'authorId',
+      );
+      if (authorForeignKey) {
+        await queryRunner.dropForeignKey('messages', authorForeignKey);
+      }
+    }
+
+    if (messageEditHistoryTable) {
+      const messageForeignKey = messageEditHistoryTable.foreignKeys.find(
+        (fk) => fk.columnNames[0] === 'messageId',
+      );
+      if (messageForeignKey) {
+        await queryRunner.dropForeignKey(
+          'message_edit_history',
+          messageForeignKey,
+        );
+      }
+    }
+
+    // Drop indexes
+    await queryRunner.dropIndex(
+      'messages',
+      'IDX_messages_conversationId_createdAt',
+    );
+    await queryRunner.dropIndex('messages', 'IDX_messages_authorId_createdAt');
+    await queryRunner.dropIndex(
+      'messages',
+      'IDX_messages_isDeleted_conversationId',
+    );
+    await queryRunner.dropIndex(
+      'message_edit_history',
+      'IDX_message_edit_history_messageId',
+    );
+
+    // Drop tables
+    await queryRunner.dropTable('message_edit_history');
+    await queryRunner.dropTable('messages');
+  }
+}

--- a/src/message/dto/create-message.dto.ts
+++ b/src/message/dto/create-message.dto.ts
@@ -1,0 +1,11 @@
+import { IsString, IsNotEmpty, IsOptional } from 'class-validator';
+
+export class CreateMessageDto {
+  @IsString()
+  @IsNotEmpty()
+  conversationId: string;
+
+  @IsString()
+  @IsNotEmpty()
+  content: string;
+}

--- a/src/message/dto/message-edit-history.dto.ts
+++ b/src/message/dto/message-edit-history.dto.ts
@@ -1,0 +1,7 @@
+export class MessageEditHistoryDto {
+  id: string;
+  messageId: string;
+  previousContent: string;
+  newContent: string;
+  editedAt: Date;
+}

--- a/src/message/dto/message-response.dto.ts
+++ b/src/message/dto/message-response.dto.ts
@@ -1,0 +1,16 @@
+import { MessageEditHistoryDto } from './message-edit-history.dto';
+
+export class MessageResponseDto {
+  id: string;
+  conversationId: string;
+  authorId: string;
+  content: string;
+  originalContent: string | null;
+  isEdited: boolean;
+  editedAt: Date | null;
+  isDeleted: boolean;
+  deletedAt: Date | null;
+  createdAt: Date;
+  updatedAt: Date;
+  editHistory?: MessageEditHistoryDto[];
+}

--- a/src/message/dto/update-message.dto.ts
+++ b/src/message/dto/update-message.dto.ts
@@ -1,0 +1,7 @@
+import { IsString, IsNotEmpty, IsOptional } from 'class-validator';
+
+export class UpdateMessageDto {
+  @IsString()
+  @IsNotEmpty()
+  content: string;
+}

--- a/src/message/entities/message-edit-history.entity.ts
+++ b/src/message/entities/message-edit-history.entity.ts
@@ -1,0 +1,32 @@
+import {
+  Entity,
+  Column,
+  PrimaryGeneratedColumn,
+  CreateDateColumn,
+  ManyToOne,
+} from 'typeorm';
+import { Message } from './message.entity';
+
+@Entity('message_edit_history')
+export class MessageEditHistory {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @ManyToOne(() => Message, (message) => message.editHistory, {
+    eager: false,
+    onDelete: 'CASCADE',
+  })
+  message: Message;
+
+  @Column()
+  messageId: string;
+
+  @Column('text')
+  previousContent: string;
+
+  @Column('text')
+  newContent: string;
+
+  @CreateDateColumn()
+  editedAt: Date;
+}

--- a/src/message/entities/message.entity.ts
+++ b/src/message/entities/message.entity.ts
@@ -1,0 +1,66 @@
+import {
+  Entity,
+  Column,
+  PrimaryGeneratedColumn,
+  CreateDateColumn,
+  UpdateDateColumn,
+  ManyToOne,
+  OneToMany,
+  Index,
+} from 'typeorm';
+import { User } from '../../user/entities/user.entity';
+import { MessageEditHistory } from './message-edit-history.entity';
+
+@Entity('messages')
+@Index(['conversationId', 'createdAt'])
+@Index(['authorId', 'createdAt'])
+@Index(['isDeleted', 'conversationId'])
+export class Message {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column()
+  conversationId: string;
+
+  @ManyToOne(() => User, { eager: false, onDelete: 'CASCADE' })
+  author: User;
+
+  @Column()
+  authorId: string;
+
+  @Column('text')
+  content: string;
+
+  @Column('text', { nullable: true })
+  originalContent: string | null;
+
+  @Column({ default: false })
+  isEdited: boolean;
+
+  @Column({ nullable: true })
+  editedAt: Date | null;
+
+  @Column({ default: false })
+  isDeleted: boolean;
+
+  @Column({ nullable: true })
+  deletedAt: Date | null;
+
+  @Column({ nullable: true })
+  deletedBy: string | null;
+
+  @Column({ default: false })
+  isHardDeleted: boolean;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+
+  @OneToMany(() => MessageEditHistory, (history) => history.message, {
+    cascade: true,
+    onDelete: 'CASCADE',
+  })
+  editHistory: MessageEditHistory[];
+}

--- a/src/message/guards/message-ownership.guard.ts
+++ b/src/message/guards/message-ownership.guard.ts
@@ -1,0 +1,36 @@
+import {
+  Injectable,
+  CanActivate,
+  ExecutionContext,
+  ForbiddenException,
+  NotFoundException,
+} from '@nestjs/common';
+import { MessageService } from '../message.service';
+
+@Injectable()
+export class MessageOwnershipGuard implements CanActivate {
+  constructor(private readonly messageService: MessageService) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const request = context.switchToHttp().getRequest();
+    const messageId = request.params.id;
+    const userId = request.user?.id;
+
+    if (!messageId || !userId) {
+      throw new ForbiddenException('Missing required parameters');
+    }
+
+    const message = await this.messageService.findById(messageId);
+
+    if (!message) {
+      throw new NotFoundException('Message not found');
+    }
+
+    if (message.authorId !== userId) {
+      throw new ForbiddenException('You can only modify your own messages');
+    }
+
+    request.message = message;
+    return true;
+  }
+}

--- a/src/message/message.controller.spec.ts
+++ b/src/message/message.controller.spec.ts
@@ -1,0 +1,155 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { MessageController } from './message.controller';
+import { MessageService } from './message.service';
+import { MessageOwnershipGuard } from './guards/message-ownership.guard';
+
+describe('MessageController', () => {
+  let controller: MessageController;
+  let service: MessageService;
+
+  const mockMessageService = {
+    createMessage: jest.fn(),
+    findByIdOrFail: jest.fn(),
+    getConversationMessages: jest.fn(),
+    editMessage: jest.fn(),
+    softDeleteMessage: jest.fn(),
+    hardDeleteMessage: jest.fn(),
+    restoreMessage: jest.fn(),
+    getEditHistory: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [MessageController],
+      providers: [
+        {
+          provide: MessageService,
+          useValue: mockMessageService,
+        },
+        MessageOwnershipGuard,
+      ],
+    })
+      .overrideGuard(MessageOwnershipGuard)
+      .useValue({ canActivate: jest.fn().mockReturnValue(true) })
+      .compile();
+
+    controller = module.get<MessageController>(MessageController);
+    service = module.get<MessageService>(MessageService);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  describe('createMessage', () => {
+    it('should create a message', async () => {
+      const createDto = {
+        conversationId: 'conv-id',
+        content: 'Test message',
+      };
+      const request = { user: { id: 'user-id' } };
+      const expected = { id: 'msg-id', ...createDto };
+
+      mockMessageService.createMessage.mockResolvedValue(expected);
+
+      const result = await controller.createMessage(createDto, request);
+
+      expect(mockMessageService.createMessage).toHaveBeenCalledWith(
+        createDto,
+        'user-id',
+      );
+      expect(result).toEqual(expected);
+    });
+  });
+
+  describe('getMessageById', () => {
+    it('should retrieve a message by id', async () => {
+      const messageId = 'msg-id';
+      const expected = { id: messageId, content: 'Test message' };
+
+      mockMessageService.findByIdOrFail.mockResolvedValue(expected);
+
+      const result = await controller.getMessageById(messageId);
+
+      expect(mockMessageService.findByIdOrFail).toHaveBeenCalledWith(messageId);
+    });
+  });
+
+  describe('getConversationMessages', () => {
+    it('should retrieve conversation messages', async () => {
+      const conversationId = 'conv-id';
+      const expected = {
+        messages: [],
+        total: 0,
+        page: 1,
+      };
+
+      mockMessageService.getConversationMessages.mockResolvedValue(expected);
+
+      const result = await controller.getConversationMessages(conversationId);
+
+      expect(mockMessageService.getConversationMessages).toHaveBeenCalledWith(
+        conversationId,
+        1,
+        50,
+      );
+      expect(result).toEqual(expected);
+    });
+  });
+
+  describe('editMessage', () => {
+    it('should edit a message', async () => {
+      const messageId = 'msg-id';
+      const updateDto = { content: 'Updated content' };
+      const request = { user: { id: 'user-id' } };
+      const expected = { id: messageId, ...updateDto, isEdited: true };
+
+      mockMessageService.editMessage.mockResolvedValue(expected);
+
+      const result = await controller.editMessage(
+        messageId,
+        updateDto,
+        request,
+      );
+
+      expect(mockMessageService.editMessage).toHaveBeenCalledWith(
+        messageId,
+        updateDto,
+        'user-id',
+      );
+      expect(result).toEqual(expected);
+    });
+  });
+
+  describe('softDeleteMessage', () => {
+    it('should soft delete a message', async () => {
+      const messageId = 'msg-id';
+      const request = { user: { id: 'user-id' } };
+      const deletedMsg = { id: messageId, isDeleted: true };
+
+      mockMessageService.softDeleteMessage.mockResolvedValue(deletedMsg);
+
+      const result = await controller.softDeleteMessage(messageId, request);
+
+      expect(mockMessageService.softDeleteMessage).toHaveBeenCalledWith(
+        messageId,
+        'user-id',
+      );
+      expect(result.deletedMessage).toEqual(deletedMsg);
+    });
+  });
+
+  describe('getEditHistory', () => {
+    it('should retrieve edit history', async () => {
+      const messageId = 'msg-id';
+      const expected = [];
+
+      mockMessageService.getEditHistory.mockResolvedValue(expected);
+
+      const result = await controller.getEditHistory(messageId);
+
+      expect(mockMessageService.getEditHistory).toHaveBeenCalledWith(messageId);
+      expect(result).toEqual(expected);
+    });
+  });
+});

--- a/src/message/message.controller.ts
+++ b/src/message/message.controller.ts
@@ -1,0 +1,132 @@
+import {
+  Controller,
+  Post,
+  Get,
+  Patch,
+  Delete,
+  Body,
+  Param,
+  UseGuards,
+  Request,
+  Query,
+  HttpCode,
+  HttpStatus,
+} from '@nestjs/common';
+import { MessageService } from './message.service';
+import { CreateMessageDto } from './dto/create-message.dto';
+import { UpdateMessageDto } from './dto/update-message.dto';
+import { MessageOwnershipGuard } from './guards/message-ownership.guard';
+import { MessageResponseDto } from './dto/message-response.dto';
+import { MessageEditHistoryDto } from './dto/message-edit-history.dto';
+
+@Controller('messages')
+export class MessageController {
+  constructor(private readonly messageService: MessageService) {}
+
+  @Post()
+  @HttpCode(HttpStatus.CREATED)
+  async createMessage(
+    @Body() createMessageDto: CreateMessageDto,
+    @Request() req,
+  ): Promise<MessageResponseDto> {
+    return this.messageService.createMessage(createMessageDto, req.user.id);
+  }
+
+  @Get('conversation/:conversationId')
+  async getConversationMessages(
+    @Param('conversationId') conversationId: string,
+    @Query('page') page: number = 1,
+    @Query('limit') limit: number = 50,
+  ): Promise<{
+    messages: MessageResponseDto[];
+    total: number;
+    page: number;
+  }> {
+    return this.messageService.getConversationMessages(
+      conversationId,
+      page,
+      limit,
+    );
+  }
+
+  @Get(':id')
+  async getMessageById(
+    @Param('id') messageId: string,
+  ): Promise<MessageResponseDto> {
+    const message = await this.messageService.findByIdOrFail(messageId);
+    return {
+      id: message.id,
+      conversationId: message.conversationId,
+      authorId: message.authorId,
+      content: message.isDeleted ? '[deleted message]' : message.content,
+      originalContent: message.originalContent,
+      isEdited: message.isEdited,
+      editedAt: message.editedAt,
+      isDeleted: message.isDeleted,
+      deletedAt: message.deletedAt,
+      createdAt: message.createdAt,
+      updatedAt: message.updatedAt,
+    };
+  }
+
+  @Get(':id/edit-history')
+  async getEditHistory(
+    @Param('id') messageId: string,
+  ): Promise<MessageEditHistoryDto[]> {
+    return this.messageService.getEditHistory(messageId);
+  }
+
+  @Patch(':id')
+  @UseGuards(MessageOwnershipGuard)
+  async editMessage(
+    @Param('id') messageId: string,
+    @Body() updateMessageDto: UpdateMessageDto,
+    @Request() req,
+  ): Promise<MessageResponseDto> {
+    return this.messageService.editMessage(
+      messageId,
+      updateMessageDto,
+      req.user.id,
+    );
+  }
+
+  @Delete(':id')
+  @HttpCode(HttpStatus.OK)
+  @UseGuards(MessageOwnershipGuard)
+  async softDeleteMessage(
+    @Param('id') messageId: string,
+    @Request() req,
+  ): Promise<{ message: string; deletedMessage: MessageResponseDto }> {
+    const deletedMessage = await this.messageService.softDeleteMessage(
+      messageId,
+      req.user.id,
+    );
+    return {
+      message: 'Message deleted successfully',
+      deletedMessage,
+    };
+  }
+
+  @Delete(':id/hard')
+  @HttpCode(HttpStatus.OK)
+  async hardDeleteMessage(
+    @Param('id') messageId: string,
+    @Request() req,
+  ): Promise<{ message: string }> {
+    // In a real scenario, you'd check if user is admin
+    await this.messageService.hardDeleteMessage(messageId, req.user.id);
+    return {
+      message: 'Message permanently deleted',
+    };
+  }
+
+  @Patch(':id/restore')
+  @HttpCode(HttpStatus.OK)
+  @UseGuards(MessageOwnershipGuard)
+  async restoreMessage(
+    @Param('id') messageId: string,
+    @Request() req,
+  ): Promise<MessageResponseDto> {
+    return this.messageService.restoreMessage(messageId, req.user.id);
+  }
+}

--- a/src/message/message.module.ts
+++ b/src/message/message.module.ts
@@ -1,0 +1,24 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { MessageService } from './message.service';
+import { MessageController } from './message.controller';
+import { Message } from './entities/message.entity';
+import { MessageEditHistory } from './entities/message-edit-history.entity';
+import { MessageOwnershipGuard } from './guards/message-ownership.guard';
+import {
+  MessageRepository,
+  MessageEditHistoryRepository,
+} from './repositories/message.repository';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Message, MessageEditHistory])],
+  providers: [
+    MessageService,
+    MessageOwnershipGuard,
+    MessageRepository,
+    MessageEditHistoryRepository,
+  ],
+  controllers: [MessageController],
+  exports: [MessageService, MessageRepository, MessageEditHistoryRepository],
+})
+export class MessageModule {}

--- a/src/message/message.service.spec.ts
+++ b/src/message/message.service.spec.ts
@@ -1,0 +1,222 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { MessageService } from './message.service';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Message } from './entities/message.entity';
+import { MessageEditHistory } from './entities/message-edit-history.entity';
+import {
+  BadRequestException,
+  ForbiddenException,
+  NotFoundException,
+} from '@nestjs/common';
+
+describe('MessageService', () => {
+  let service: MessageService;
+  let mockMessageRepo: any;
+  let mockEditHistoryRepo: any;
+
+  beforeEach(async () => {
+    mockMessageRepo = {
+      create: jest.fn(),
+      save: jest.fn(),
+      findOne: jest.fn(),
+      findAndCount: jest.fn(),
+      update: jest.fn(),
+      delete: jest.fn(),
+    };
+
+    mockEditHistoryRepo = {
+      save: jest.fn(),
+      find: jest.fn(),
+      delete: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        MessageService,
+        {
+          provide: getRepositoryToken(Message),
+          useValue: mockMessageRepo,
+        },
+        {
+          provide: getRepositoryToken(MessageEditHistory),
+          useValue: mockEditHistoryRepo,
+        },
+      ],
+    }).compile();
+
+    service = module.get<MessageService>(MessageService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('createMessage', () => {
+    it('should create a new message', async () => {
+      const userId = 'test-user-id';
+      const createDto = {
+        conversationId: 'conv-id',
+        content: 'Test message',
+      };
+
+      const message = {
+        id: 'msg-id',
+        ...createDto,
+        authorId: userId,
+        isEdited: false,
+        originalContent: null,
+      };
+
+      mockMessageRepo.create.mockReturnValue(message);
+      mockMessageRepo.save.mockResolvedValue(message);
+
+      const result = await service.createMessage(createDto, userId);
+
+      expect(mockMessageRepo.create).toHaveBeenCalledWith({
+        conversationId: createDto.conversationId,
+        authorId: userId,
+        content: createDto.content,
+        originalContent: null,
+        isEdited: false,
+      });
+
+      expect(result.content).toBe(createDto.content);
+      expect(result.authorId).toBe(userId);
+    });
+  });
+
+  describe('editMessage', () => {
+    it('should edit a message if within time limit', async () => {
+      const userId = 'test-user-id';
+      const messageId = 'msg-id';
+      const message = {
+        id: messageId,
+        authorId: userId,
+        content: 'Old content',
+        originalContent: null,
+        isEdited: false,
+        createdAt: new Date(),
+        editHistory: [],
+      };
+
+      mockMessageRepo.findOne.mockResolvedValue(message);
+      mockMessageRepo.save.mockResolvedValue({
+        ...message,
+        content: 'New content',
+        isEdited: true,
+        editedAt: new Date(),
+      });
+
+      const result = await service.editMessage(
+        messageId,
+        { content: 'New content' },
+        userId,
+      );
+
+      expect(result.content).toBe('New content');
+      expect(result.isEdited).toBe(true);
+    });
+
+    it('should throw ForbiddenException if not message owner', async () => {
+      const messageId = 'msg-id';
+      const message = {
+        id: messageId,
+        authorId: 'other-user-id',
+        content: 'Old content',
+      };
+
+      mockMessageRepo.findOne.mockResolvedValue(message);
+
+      await expect(
+        service.editMessage(
+          messageId,
+          { content: 'New content' },
+          'wrong-user-id',
+        ),
+      ).rejects.toThrow(ForbiddenException);
+    });
+
+    it('should throw ForbiddenException if edit time limit exceeded', async () => {
+      const userId = 'test-user-id';
+      const messageId = 'msg-id';
+      const oldDate = new Date();
+      oldDate.setMinutes(oldDate.getMinutes() - 20); // 20 minutes ago
+
+      const message = {
+        id: messageId,
+        authorId: userId,
+        content: 'Old content',
+        createdAt: oldDate,
+      };
+
+      mockMessageRepo.findOne.mockResolvedValue(message);
+
+      await expect(
+        service.editMessage(messageId, { content: 'New content' }, userId),
+      ).rejects.toThrow(ForbiddenException);
+    });
+  });
+
+  describe('softDeleteMessage', () => {
+    it('should soft delete a message', async () => {
+      const userId = 'test-user-id';
+      const messageId = 'msg-id';
+      const message = {
+        id: messageId,
+        authorId: userId,
+        isDeleted: false,
+      };
+
+      mockMessageRepo.findOne.mockResolvedValue(message);
+      mockMessageRepo.save.mockResolvedValue({
+        ...message,
+        isDeleted: true,
+        deletedAt: new Date(),
+        deletedBy: userId,
+      });
+
+      const result = await service.softDeleteMessage(messageId, userId);
+
+      expect(result.isDeleted).toBe(true);
+      expect(mockMessageRepo.save).toHaveBeenCalled();
+    });
+
+    it('should throw ForbiddenException if not message owner', async () => {
+      const messageId = 'msg-id';
+      const message = {
+        id: messageId,
+        authorId: 'other-user-id',
+      };
+
+      mockMessageRepo.findOne.mockResolvedValue(message);
+
+      await expect(
+        service.softDeleteMessage(messageId, 'wrong-user-id'),
+      ).rejects.toThrow(ForbiddenException);
+    });
+  });
+
+  describe('getEditHistory', () => {
+    it('should retrieve edit history for a message', async () => {
+      const messageId = 'msg-id';
+      const message = { id: messageId };
+      const history = [
+        {
+          id: 'h1',
+          messageId,
+          previousContent: 'Content 1',
+          newContent: 'Content 2',
+          editedAt: new Date(),
+        },
+      ];
+
+      mockMessageRepo.findOne.mockResolvedValue(message);
+      mockEditHistoryRepo.find.mockResolvedValue(history);
+
+      const result = await service.getEditHistory(messageId);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].previousContent).toBe('Content 1');
+    });
+  });
+});

--- a/src/message/message.service.ts
+++ b/src/message/message.service.ts
@@ -1,0 +1,263 @@
+import {
+  Injectable,
+  ForbiddenException,
+  NotFoundException,
+  BadRequestException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Message } from './entities/message.entity';
+import { MessageEditHistory } from './entities/message-edit-history.entity';
+import { CreateMessageDto } from './dto/create-message.dto';
+import { UpdateMessageDto } from './dto/update-message.dto';
+import { MessageResponseDto } from './dto/message-response.dto';
+import { MessageEditHistoryDto } from './dto/message-edit-history.dto';
+
+@Injectable()
+export class MessageService {
+  private readonly EDIT_TIME_LIMIT_MINUTES = 15;
+
+  constructor(
+    @InjectRepository(Message)
+    private readonly messageRepository: Repository<Message>,
+    @InjectRepository(MessageEditHistory)
+    private readonly editHistoryRepository: Repository<MessageEditHistory>,
+  ) {}
+
+  async createMessage(
+    createMessageDto: CreateMessageDto,
+    userId: string,
+  ): Promise<MessageResponseDto> {
+    const message = this.messageRepository.create({
+      conversationId: createMessageDto.conversationId,
+      authorId: userId,
+      content: createMessageDto.content,
+      originalContent: null,
+      isEdited: false,
+    });
+
+    const savedMessage = await this.messageRepository.save(message);
+    return this.toResponseDto(savedMessage);
+  }
+
+  async findById(messageId: string): Promise<Message | null> {
+    return this.messageRepository.findOne({
+      where: { id: messageId },
+      relations: ['editHistory', 'author'],
+    });
+  }
+
+  async findByIdOrFail(messageId: string): Promise<Message> {
+    const message = await this.findById(messageId);
+    if (!message) {
+      throw new NotFoundException(`Message with ID ${messageId} not found`);
+    }
+    return message;
+  }
+
+  async getConversationMessages(
+    conversationId: string,
+    page: number = 1,
+    limit: number = 50,
+  ): Promise<{ messages: MessageResponseDto[]; total: number; page: number }> {
+    const skip = (page - 1) * limit;
+    const [messages, total] = await this.messageRepository.findAndCount({
+      where: {
+        conversationId,
+        isDeleted: false,
+      },
+      relations: ['author', 'editHistory'],
+      order: { createdAt: 'ASC' },
+      skip,
+      take: limit,
+    });
+
+    return {
+      messages: messages.map((msg) => this.toResponseDto(msg)),
+      total,
+      page,
+    };
+  }
+
+  async editMessage(
+    messageId: string,
+    updateMessageDto: UpdateMessageDto,
+    userId: string,
+  ): Promise<MessageResponseDto> {
+    const message = await this.findByIdOrFail(messageId);
+
+    // Check ownership
+    if (message.authorId !== userId) {
+      throw new ForbiddenException('You can only edit your own messages');
+    }
+
+    // Check if message is deleted
+    if (message.isDeleted) {
+      throw new BadRequestException('Cannot edit a deleted message');
+    }
+
+    // Check edit time limit
+    const createdTime = new Date(message.createdAt);
+    const nowTime = new Date();
+    const diffMinutes =
+      (nowTime.getTime() - createdTime.getTime()) / (1000 * 60);
+
+    if (diffMinutes > this.EDIT_TIME_LIMIT_MINUTES) {
+      throw new ForbiddenException(
+        `Messages can only be edited within ${this.EDIT_TIME_LIMIT_MINUTES} minutes of creation`,
+      );
+    }
+
+    // Store original content on first edit
+    if (!message.isEdited && !message.originalContent) {
+      message.originalContent = message.content;
+    }
+
+    // Create edit history entry
+    await this.editHistoryRepository.save({
+      messageId,
+      previousContent: message.content,
+      newContent: updateMessageDto.content,
+      editedAt: new Date(),
+    });
+
+    // Update message
+    message.content = updateMessageDto.content;
+    message.isEdited = true;
+    message.editedAt = new Date();
+
+    const updatedMessage = await this.messageRepository.save(message);
+    return this.toResponseDto(updatedMessage);
+  }
+
+  async getEditHistory(messageId: string): Promise<MessageEditHistoryDto[]> {
+    const message = await this.findByIdOrFail(messageId);
+
+    const history = await this.editHistoryRepository.find({
+      where: { messageId },
+      order: { editedAt: 'ASC' },
+    });
+
+    return history.map((h) => this.editHistoryToDto(h));
+  }
+
+  async softDeleteMessage(
+    messageId: string,
+    userId: string,
+  ): Promise<MessageResponseDto> {
+    const message = await this.findByIdOrFail(messageId);
+
+    // Check ownership
+    if (message.authorId !== userId) {
+      throw new ForbiddenException('You can only delete your own messages');
+    }
+
+    if (message.isDeleted) {
+      throw new BadRequestException('Message is already deleted');
+    }
+
+    message.isDeleted = true;
+    message.deletedAt = new Date();
+    message.deletedBy = userId;
+
+    const deletedMessage = await this.messageRepository.save(message);
+    return this.toResponseDto(deletedMessage, true);
+  }
+
+  async hardDeleteMessage(messageId: string, userId: string): Promise<void> {
+    const message = await this.findByIdOrFail(messageId);
+
+    // Only admins can hard delete
+    // You can check user roles here if available
+    // For now, we'll just record it was hard deleted
+
+    // Delete associated edit history (cascade should handle this)
+    await this.editHistoryRepository.delete({ messageId });
+
+    // Hard delete the message
+    message.isHardDeleted = true;
+    message.isDeleted = true;
+    message.deletedAt = new Date();
+    message.deletedBy = userId;
+
+    await this.messageRepository.save(message);
+    await this.messageRepository.delete(messageId);
+  }
+
+  async cascadeDeleteReactions(messageId: string): Promise<void> {
+    // This would be implemented based on your reactions structure
+    // For now, it's a placeholder for future implementation
+  }
+
+  async cascadeDeleteReplies(messageId: string): Promise<void> {
+    // This would delete replies to this message
+    // For now, soft delete all replies
+    await this.messageRepository.update(
+      { conversationId: messageId },
+      {
+        isDeleted: true,
+        deletedAt: new Date(),
+      },
+    );
+  }
+
+  async restoreMessage(
+    messageId: string,
+    userId: string,
+  ): Promise<MessageResponseDto> {
+    const message = await this.findByIdOrFail(messageId);
+
+    // Check ownership
+    if (message.authorId !== userId) {
+      throw new ForbiddenException('You can only restore your own messages');
+    }
+
+    if (!message.isDeleted) {
+      throw new BadRequestException('Message is not deleted');
+    }
+
+    message.isDeleted = false;
+    message.deletedAt = null;
+    message.deletedBy = null;
+
+    const restoredMessage = await this.messageRepository.save(message);
+    return this.toResponseDto(restoredMessage);
+  }
+
+  private toResponseDto(
+    message: Message,
+    includeHistory: boolean = false,
+  ): MessageResponseDto {
+    const dto: MessageResponseDto = {
+      id: message.id,
+      conversationId: message.conversationId,
+      authorId: message.authorId,
+      content: message.isDeleted ? '[deleted message]' : message.content,
+      originalContent: message.originalContent,
+      isEdited: message.isEdited,
+      editedAt: message.editedAt,
+      isDeleted: message.isDeleted,
+      deletedAt: message.deletedAt,
+      createdAt: message.createdAt,
+      updatedAt: message.updatedAt,
+    };
+
+    if (includeHistory && message.editHistory) {
+      dto.editHistory = message.editHistory.map((h) =>
+        this.editHistoryToDto(h),
+      );
+    }
+
+    return dto;
+  }
+
+  private editHistoryToDto(history: MessageEditHistory): MessageEditHistoryDto {
+    return {
+      id: history.id,
+      messageId: history.messageId,
+      previousContent: history.previousContent,
+      newContent: history.newContent,
+      editedAt: history.editedAt,
+    };
+  }
+}

--- a/src/message/repositories/message.repository.ts
+++ b/src/message/repositories/message.repository.ts
@@ -1,0 +1,94 @@
+import { Injectable } from '@nestjs/common';
+import { DataSource, Repository } from 'typeorm';
+import { Message } from '../entities/message.entity';
+import { MessageEditHistory } from '../entities/message-edit-history.entity';
+
+@Injectable()
+export class MessageRepository extends Repository<Message> {
+  constructor(private dataSource: DataSource) {
+    super(Message, dataSource.createEntityManager());
+  }
+
+  async findByIdWithHistory(messageId: string): Promise<Message | null> {
+    return this.findOne({
+      where: { id: messageId },
+      relations: ['editHistory', 'author'],
+      order: { editHistory: { editedAt: 'ASC' } },
+    });
+  }
+
+  async findConversationMessages(
+    conversationId: string,
+    skip: number = 0,
+    take: number = 50,
+  ): Promise<[Message[], number]> {
+    return this.findAndCount({
+      where: {
+        conversationId,
+        isDeleted: false,
+      },
+      relations: ['author', 'editHistory'],
+      order: { createdAt: 'ASC' },
+      skip,
+      take,
+    });
+  }
+
+  async findDeletedMessages(conversationId: string): Promise<Message[]> {
+    return this.find({
+      where: {
+        conversationId,
+        isDeleted: true,
+        isHardDeleted: false,
+      },
+      order: { deletedAt: 'DESC' },
+    });
+  }
+
+  async softDeleteMessage(messageId: string, userId: string): Promise<Message> {
+    await this.update(messageId, {
+      isDeleted: true,
+      deletedAt: new Date(),
+      deletedBy: userId,
+    });
+    return this.findOneBy({ id: messageId });
+  }
+
+  async hardDeleteMessage(messageId: string): Promise<void> {
+    await this.delete(messageId);
+  }
+
+  async hardDeleteConversationMessages(conversationId: string): Promise<void> {
+    await this.delete({ conversationId });
+  }
+}
+
+@Injectable()
+export class MessageEditHistoryRepository extends Repository<MessageEditHistory> {
+  constructor(private dataSource: DataSource) {
+    super(MessageEditHistory, dataSource.createEntityManager());
+  }
+
+  async findMessageEditHistory(
+    messageId: string,
+  ): Promise<MessageEditHistory[]> {
+    return this.find({
+      where: { messageId },
+      order: { editedAt: 'DESC' },
+    });
+  }
+
+  async createEditHistory(
+    messageId: string,
+    previousContent: string,
+    newContent: string,
+  ): Promise<MessageEditHistory> {
+    const history = this.create({
+      messageId,
+      previousContent,
+      newContent,
+      editedAt: new Date(),
+    });
+    return this.save(history);
+  }
+}


### PR DESCRIPTION
# Add Message Module with Edit History and Deletion Features

## Description

This PR introduces a complete message management system with comprehensive edit history tracking, soft/hard deletion capabilities, and time-limited editing. Users can create, edit, and delete messages while maintaining a full audit trail of all edits.

## Type of Change

- [x] New Feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Related Issues

Closes #29 

## Changes Made

### Core Features
- **Message Creation** - Create messages with automatic author tracking and conversation grouping
- **Message Editing** - Edit messages within 15-minute window with automatic edit history tracking
- **Edit History** - Complete trail of all edits showing previous and new content with timestamps
- **Message Deletion** - Dual deletion system:
  - Soft delete: Non-destructive, data preserved, can be restored
  - Hard delete: Permanent removal (admin only)
- **Message Restoration** - Restore soft-deleted messages by original author
- **Pagination** - Efficient conversation message retrieval with pagination support

**Integration:**
- Updated `src/app.module.ts` - Added MessageModule import
