### PR TITLE
feat:handle message implementation

### DIFF
--- a/contracts/whsper_stellar/src/storage.rs
+++ b/contracts/whsper_stellar/src/storage.rs
@@ -24,4 +24,7 @@ pub enum DataKey {
     Room(u64),
     RoomList,
     NextRoomId,
+    Message(u64, u64),
+    NextMessageId(u64),
+    MessageCount(u64),
 }

--- a/contracts/whsper_stellar/src/types.rs
+++ b/contracts/whsper_stellar/src/types.rs
@@ -9,6 +9,17 @@ pub enum ActionType {
     TipReceived = 3,
 }
 
+#[derive(Clone)]
+#[contracttype]
+pub struct Message {
+    pub id: u64,
+    pub room_id: u64,
+    pub sender: Address,
+    pub content_hash: BytesN<32>,
+    pub timestamp: u64,
+    pub tip_amount: u64,
+}
+
 #[derive(Clone, Debug, Eq, PartialEq)]
 #[contracttype]
 pub struct RateLimitConfig {
@@ -40,6 +51,8 @@ pub enum ContractError {
     XpRateLimited = 15,
     InvalidRoomType = 16,
     UserAlreadyInRoom = 17,
+    InvalidContentHash = 18,
+    RoomMessageLimitReached = 19,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]


### PR DESCRIPTION
closes #67 

This PR adds on-chain message support to the Soroban chat contract, enabling users to send messages within rooms while storing only minimal, indexed metadata on-chain.

What’s included

Introduces a Message struct with room-scoped IDs, sender, content hash, timestamp, and optional tip amount

Implements send_message() with participant checks and automatic XP rewards

Adds efficient message indexing by room_id

Provides get_messages() with pagination for large rooms

Enforces per-room message limits to prevent abuse

Verifies off-chain content via fixed-size content hashes