### PR TITLE
feat: Base crud operations

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -26,6 +26,7 @@ import { SessionsModule } from './sessions/sessions.module';
 import { MessageModule } from './message/message.module';
 import { RewardsModule } from './rewards/rewards.module';
 import { ChainModule } from './chain/chain.module';
+import { RoomModule } from './room/room.module';
 
 @Module({
   imports: [
@@ -77,6 +78,7 @@ import { ChainModule } from './chain/chain.module';
     MessageModule,
     RewardsModule,
     ChainModule,
+    RoomModule,
   ],
   controllers: [AppController],
   providers: [

--- a/src/room/constants/room-member.constants.ts
+++ b/src/room/constants/room-member.constants.ts
@@ -24,6 +24,18 @@ export enum MemberPermission {
 }
 
 export const ROLE_PERMISSIONS: Record<MemberRole, MemberPermission[]> = {
+  [MemberRole.OWNER]: [
+    MemberPermission.SEND_MESSAGE,
+    MemberPermission.EDIT_MESSAGE,
+    MemberPermission.DELETE_MESSAGE,
+    MemberPermission.INVITE_MEMBERS,
+    MemberPermission.KICK_MEMBERS,
+    MemberPermission.MANAGE_ROLES,
+    MemberPermission.CHANGE_ROOM_SETTINGS,
+    MemberPermission.VIEW_ANALYTICS,
+    MemberPermission.PIN_MESSAGE,
+    MemberPermission.MANAGE_INVITATIONS,
+  ],
   [MemberRole.ADMIN]: [
     MemberPermission.SEND_MESSAGE,
     MemberPermission.EDIT_MESSAGE,

--- a/src/room/dto/create-room.dto.ts
+++ b/src/room/dto/create-room.dto.ts
@@ -1,13 +1,33 @@
-import { IsString, IsOptional, IsBoolean, IsNumber } from 'class-validator';
+import {
+  IsString,
+  IsOptional,
+  IsBoolean,
+  IsNumber,
+  IsEnum,
+  IsInt,
+  Min,
+  Max,
+  MinLength,
+  MaxLength,
+  IsDateString,
+} from 'class-validator';
+import { RoomType } from '../entities/room.entity';
+import { ROOM_MEMBER_CONSTANTS } from '../constants/room-member.constants';
 
 export class CreateRoomDto {
   @IsString()
-  @IsOptional()
-  name?: string;
+  @MinLength(3)
+  @MaxLength(80)
+  name!: string;
 
   @IsString()
   @IsOptional()
+  @MaxLength(500)
   description?: string;
+
+  @IsEnum(RoomType)
+  @IsOptional()
+  roomType?: RoomType;
 
   @IsBoolean()
   @IsOptional()
@@ -44,4 +64,24 @@ export class CreateRoomDto {
   @IsNumber()
   @IsOptional()
   accessDurationDays?: number;
+
+  @IsInt()
+  @Min(ROOM_MEMBER_CONSTANTS.MIN_MAX_MEMBERS)
+  @Max(ROOM_MEMBER_CONSTANTS.MAX_MAX_MEMBERS)
+  @IsOptional()
+  maxMembers?: number;
+
+  @IsBoolean()
+  @IsOptional()
+  isActive?: boolean;
+
+  @IsInt()
+  @Min(1)
+  @Max(10080)
+  @IsOptional()
+  durationMinutes?: number;
+
+  @IsDateString()
+  @IsOptional()
+  expiresAt?: string;
 }

--- a/src/room/entities/room-member.entity.ts
+++ b/src/room/entities/room-member.entity.ts
@@ -13,6 +13,7 @@ import { Room } from './room.entity';
 import { User } from '../../user/entities/user.entity';
 
 export enum MemberRole {
+  OWNER = 'OWNER',
   ADMIN = 'ADMIN',
   MODERATOR = 'MODERATOR',
   MEMBER = 'MEMBER',

--- a/src/room/entities/room.entity.ts
+++ b/src/room/entities/room.entity.ts
@@ -7,8 +7,18 @@ import {
   OneToMany,
   CreateDateColumn,
   UpdateDateColumn,
+  JoinColumn,
 } from 'typeorm';
 import { RoomPayment } from './room-payment.entity';
+import { RoomMember } from './room-member.entity';
+import { ROOM_MEMBER_CONSTANTS } from '../constants/room-member.constants';
+
+export enum RoomType {
+  PUBLIC = 'PUBLIC',
+  PRIVATE = 'PRIVATE',
+  TOKEN_GATED = 'TOKEN_GATED',
+  TIMED = 'TIMED',
+}
 
 @Entity('rooms')
 export class Room {
@@ -19,46 +29,91 @@ export class Room {
   name!: string;
 
   @Column({ type: 'text', nullable: true })
-  description!: string;
+  description?: string;
 
-  @ManyToOne(() => User)
-  owner!: User;
+  @Column({ type: 'uuid', nullable: true })
+  ownerId?: string;
 
   @ManyToOne(() => User, { nullable: true })
+  @JoinColumn({ name: 'ownerId' })
+  owner?: User;
+
+  @Column({ type: 'uuid', nullable: true })
+  creatorId?: string;
+
+  @ManyToOne(() => User, { nullable: true })
+  @JoinColumn({ name: 'creatorId' })
   creator?: User;
+
+  @Column({
+    type: 'enum',
+    enum: RoomType,
+    default: RoomType.PUBLIC,
+  })
+  roomType!: RoomType;
 
   @Column({ default: false })
   isPrivate!: boolean;
 
   @Column({ type: 'varchar', nullable: true })
-  icon!: string;
+  icon?: string;
+
+  @Column({ type: 'int', default: ROOM_MEMBER_CONSTANTS.DEFAULT_MAX_MEMBERS })
+  maxMembers!: number;
+
+  @Column({ default: true })
+  isActive!: boolean;
 
   @Column({ default: 0 })
   memberCount!: number;
 
   @Column({ name: 'is_token_gated', default: false })
-  isTokenGated: boolean;
+  isTokenGated!: boolean;
 
   @Column('decimal', { precision: 18, scale: 8, name: 'entry_fee', default: 0 })
-  entryFee: string;
+  entryFee!: string;
 
   @Column({ name: 'token_address', nullable: true })
-  tokenAddress: string;
+  tokenAddress?: string;
 
   @Column({ name: 'payment_required', default: false })
-  paymentRequired: boolean;
+  paymentRequired!: boolean;
 
   @Column({ name: 'free_trial_enabled', default: false })
-  freeTrialEnabled: boolean;
+  freeTrialEnabled!: boolean;
 
   @Column({ name: 'free_trial_duration_hours', default: 24 })
-  freeTrialDurationHours: number;
+  freeTrialDurationHours!: number;
 
   @Column({ name: 'access_duration_days', nullable: true })
-  accessDurationDays: number;
+  accessDurationDays?: number;
+
+  @Column({ type: 'bigint', nullable: true })
+  expiryTimestamp?: number | null;
+
+  @Column({ type: 'int', nullable: true })
+  durationMinutes?: number | null;
+
+  @Column({ default: false })
+  isExpired!: boolean;
+
+  @Column({ default: false })
+  warningNotificationSent!: boolean;
+
+  @Column({ type: 'int', default: 0 })
+  extensionCount!: number;
+
+  @Column({ default: false })
+  isDeleted!: boolean;
+
+  @Column({ type: 'timestamp', nullable: true })
+  deletedAt?: Date;
 
   @OneToMany(() => RoomPayment, payment => payment.room)
-  payments: RoomPayment[];
+  payments!: RoomPayment[];
+
+  @OneToMany(() => RoomMember, (member) => member.room)
+  members!: RoomMember[];
 
   @CreateDateColumn()
   createdAt!: Date;

--- a/src/room/guards/room-admin.guard.ts
+++ b/src/room/guards/room-admin.guard.ts
@@ -28,7 +28,7 @@ export class RoomAdminGuard implements CanActivate {
       where: { userId, roomId },
     });
 
-    if (!member || member.role !== MemberRole.ADMIN) {
+    if (!member || ![MemberRole.ADMIN, MemberRole.OWNER].includes(member.role)) {
       throw new ForbiddenException('Only room admins can perform this action');
     }
 

--- a/src/room/guards/room-moderator.guard.ts
+++ b/src/room/guards/room-moderator.guard.ts
@@ -30,7 +30,7 @@ export class RoomModeratorGuard implements CanActivate {
 
     if (
       !member ||
-      (member.role !== MemberRole.ADMIN && member.role !== MemberRole.MODERATOR)
+      ![MemberRole.ADMIN, MemberRole.MODERATOR, MemberRole.OWNER].includes(member.role)
     ) {
       throw new ForbiddenException(
         'Only room admins and moderators can perform this action',

--- a/src/room/repositories/room-member.repository.ts
+++ b/src/room/repositories/room-member.repository.ts
@@ -41,7 +41,9 @@ export class RoomMemberRepository extends Repository<RoomMember> {
   async findAdmins(roomId: string): Promise<RoomMember[]> {
     return await this.createQueryBuilder('rm')
       .where('rm.roomId = :roomId', { roomId })
-      .andWhere('rm.role = :role', { role: MemberRole.ADMIN })
+      .andWhere('rm.role IN (:...roles)', {
+        roles: [MemberRole.ADMIN, MemberRole.OWNER],
+      })
       .andWhere('rm.status = :status', { status: MemberStatus.ACTIVE })
       .leftJoinAndSelect('rm.user', 'user')
       .getMany();

--- a/src/room/repositories/room.repository.ts
+++ b/src/room/repositories/room.repository.ts
@@ -1,0 +1,34 @@
+import { Injectable } from '@nestjs/common';
+import { DataSource, Repository } from 'typeorm';
+import { Room } from '../entities/room.entity';
+
+@Injectable()
+export class RoomRepository extends Repository<Room> {
+  constructor(private dataSource: DataSource) {
+    super(Room, dataSource.createEntityManager());
+  }
+
+  async findActiveById(roomId: string): Promise<Room | null> {
+    return this.findOne({ where: { id: roomId, isDeleted: false } });
+  }
+
+  async findActiveWithOwner(roomId: string): Promise<Room | null> {
+    return this.findOne({
+      where: { id: roomId, isDeleted: false },
+      relations: ['owner'],
+    });
+  }
+
+  async isNameTaken(name: string): Promise<boolean> {
+    const count = await this.count({ where: { name, isDeleted: false } });
+    return count > 0;
+  }
+
+  async softDeleteRoom(roomId: string): Promise<void> {
+    await this.update(roomId, {
+      isDeleted: true,
+      deletedAt: new Date(),
+      isActive: false,
+    });
+  }
+}

--- a/src/room/room.controller.ts
+++ b/src/room/room.controller.ts
@@ -8,9 +8,10 @@ import {
   Body,
   UseGuards,
   Query,
-  CurrentUser,
+  HttpCode,
+  HttpStatus,
 } from '@nestjs/common';
-import { RoomSettingsService } from './room.service';
+import { RoomSettingsService, RoomService } from './room.service';
 import { UpdateRoomSettingsDto } from './dto/room-settings.dto';
 import { WithdrawFundsDto } from './dto/withdraw-funds.dto';
 import { RoomPaymentService } from './services/room-payment.service';
@@ -20,6 +21,43 @@ import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { RoleGuard } from '../roles/guards/role.guard';
 import { Roles } from '../roles/decorators/roles.decorator';
 import { RoleType } from '../roles/entities/role.entity';
+import { CreateRoomDto } from './dto/create-room.dto';
+import { UpdateRoomDto } from './dto/update-room.dto';
+import { CurrentUser } from '../auth/decorators/current-user.decorator';
+
+@Controller('rooms')
+@UseGuards(JwtAuthGuard)
+export class RoomController {
+  constructor(private roomService: RoomService) {}
+
+  @Post()
+  async createRoom(@Body() dto: CreateRoomDto, @CurrentUser() user: any) {
+    return this.roomService.createRoom(user.id, dto);
+  }
+
+  @Get(':id')
+  async getRoom(@Param('id') roomId: string) {
+    return this.roomService.getRoom(roomId);
+  }
+
+  @Patch(':id')
+  async updateRoom(
+    @Param('id') roomId: string,
+    @Body() dto: UpdateRoomDto,
+    @CurrentUser() user: any,
+  ) {
+    return this.roomService.updateRoom(roomId, user.id, dto);
+  }
+
+  @Delete(':id')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  async deleteRoom(
+    @Param('id') roomId: string,
+    @CurrentUser() user: any,
+  ) {
+    await this.roomService.softDeleteRoom(roomId, user.id);
+  }
+}
 
 @Controller('rooms/:roomId/settings')
 export class RoomSettingsController {

--- a/src/room/room.module.ts
+++ b/src/room/room.module.ts
@@ -17,13 +17,17 @@ import { RoomWhitelist } from './entities/room-whitelist.entity';
 import { RoomEmergencyPause } from './entities/room-emergency-pause.entity';
 
 // Controllers
-import { RoomController } from './room.controller';
+import {
+  RoomController,
+  RoomPaymentController,
+  RoomSettingsController,
+} from './room.controller';
 import { RoomMemberController } from './room-member.controller';
 import { RoomInvitationController } from './room-invitation.controller';
 import { RoomRoleController } from './room-role.controller';
 
 // Services
-import { RoomService } from './room.service';
+import { RoomService, RoomSettingsService } from './room.service';
 import { RoomMemberService } from './services/room-member.service';
 import { RoomInvitationService } from './services/room-invitation.service';
 import { MemberPermissionsService } from './services/member-permissions.service';
@@ -36,6 +40,7 @@ import { RoomRoleService } from './services/room-role.service';
 // Repositories
 import { RoomMemberRepository } from './repositories/room-member.repository';
 import { RoomInvitationRepository } from './repositories/room-invitation.repository';
+import { RoomRepository } from './repositories/room.repository';
 
 // Guards
 import { MemberGuard } from './guards/member.guard';
@@ -71,12 +76,15 @@ import { PaymentExpirationJob } from './jobs/payment-expiration.job';
   ],
   controllers: [
     RoomController,
+    RoomSettingsController,
+    RoomPaymentController,
     RoomMemberController,
     RoomInvitationController,
     RoomRoleController,
   ],
   providers: [
     RoomService,
+    RoomSettingsService,
     RoomMemberService,
     RoomInvitationService,
     MemberPermissionsService,
@@ -87,6 +95,7 @@ import { PaymentExpirationJob } from './jobs/payment-expiration.job';
     RoomRoleService,
     RoomMemberRepository,
     RoomInvitationRepository,
+    RoomRepository,
     MemberGuard,
     MemberPermissionGuard,
     RoomAdminGuard,

--- a/src/room/services/member-permissions.service.ts
+++ b/src/room/services/member-permissions.service.ts
@@ -77,7 +77,7 @@ export class MemberPermissionsService {
       where: { userId: initiatorId, roomId },
     });
 
-    if (!initiator || initiator.role !== MemberRole.ADMIN) {
+    if (!initiator || ![MemberRole.ADMIN, MemberRole.OWNER].includes(initiator.role)) {
       throw new ForbiddenException(ERROR_MESSAGES.INSUFFICIENT_PERMISSIONS);
     }
 
@@ -108,7 +108,7 @@ export class MemberPermissionsService {
       where: { userId: initiatorId, roomId },
     });
 
-    if (!initiator || initiator.role !== MemberRole.ADMIN) {
+    if (!initiator || ![MemberRole.ADMIN, MemberRole.OWNER].includes(initiator.role)) {
       throw new ForbiddenException(ERROR_MESSAGES.INSUFFICIENT_PERMISSIONS);
     }
 
@@ -140,7 +140,7 @@ export class MemberPermissionsService {
       where: { userId: initiatorId, roomId },
     });
 
-    if (!initiator || initiator.role !== MemberRole.ADMIN) {
+    if (!initiator || ![MemberRole.ADMIN, MemberRole.OWNER].includes(initiator.role)) {
       throw new ForbiddenException(ERROR_MESSAGES.INSUFFICIENT_PERMISSIONS);
     }
 
@@ -177,7 +177,7 @@ export class MemberPermissionsService {
       where: { userId: initiatorId, roomId },
     });
 
-    if (!initiator || initiator.role !== MemberRole.ADMIN) {
+    if (!initiator || ![MemberRole.ADMIN, MemberRole.OWNER].includes(initiator.role)) {
       throw new ForbiddenException(ERROR_MESSAGES.INSUFFICIENT_PERMISSIONS);
     }
 
@@ -231,7 +231,7 @@ export class MemberPermissionsService {
       where: { userId: initiatorId, roomId },
     });
 
-    if (!initiator || initiator.role !== MemberRole.ADMIN) {
+    if (!initiator || ![MemberRole.ADMIN, MemberRole.OWNER].includes(initiator.role)) {
       throw new ForbiddenException(ERROR_MESSAGES.INSUFFICIENT_PERMISSIONS);
     }
 

--- a/src/room/services/room-role.service.ts
+++ b/src/room/services/room-role.service.ts
@@ -61,7 +61,7 @@ export class RoomRoleService {
 
         // Prevent changing owner role
         const room = await this.roomRepository.findOne({ where: { id: roomId } });
-        if (room.ownerId === userId && newRole !== MemberRole.ADMIN) {
+        if (room.ownerId === userId && newRole !== MemberRole.OWNER) {
             throw new ForbiddenException('Cannot change owner role');
         }
 
@@ -71,7 +71,7 @@ export class RoomRoleService {
         });
 
         if (
-            initiatorMember.role !== MemberRole.ADMIN &&
+            ![MemberRole.ADMIN, MemberRole.OWNER].includes(initiatorMember.role) &&
             member.role === MemberRole.ADMIN
         ) {
             throw new ForbiddenException(


### PR DESCRIPTION
closes #18 

I added a base room CRUD endpoints with ownership enforcement, plus room type/settings fields and DTO validation. 

The `Room` entity now captures type, max members, active state, and soft delete markers to support validation and soft delete behaviour.

Lastly, I wired `RoomModule` into `AppModule`, added a custom room repository and extended member role support to include `OWNER` across guards/permissions