### PR TITLE
Feat: Feature flags

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -29,6 +29,7 @@ import { ChainModule } from './chain/chain.module';
 import { TransferModule } from './transfer/transfer.module';
 import { RoomModule } from './room/room.module';
 import { NotificationsModule } from './notifications/notifications.module';
+import { SystemConfigModule } from './system-config/system-config.module';
 import { QueueModule } from './queue/queue.module';
 
 @Module({
@@ -89,6 +90,7 @@ import { QueueModule } from './queue/queue.module';
     TransferModule,
     RoomModule,
     NotificationsModule,
+    SystemConfigModule,
   ],
   controllers: [AppController],
   providers: [

--- a/src/database/migrations/1769800000000-CreateSystemConfigTables.ts
+++ b/src/database/migrations/1769800000000-CreateSystemConfigTables.ts
@@ -1,0 +1,215 @@
+import { MigrationInterface, QueryRunner, Table, Index } from 'typeorm';
+
+export class CreateSystemConfigTables1769800000000 implements MigrationInterface {
+  name = 'CreateSystemConfigTables1769800000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.createTable(
+      new Table({
+        name: 'system_configs',
+        columns: [
+          {
+            name: 'id',
+            type: 'uuid',
+            isPrimary: true,
+            generationStrategy: 'uuid',
+            default: 'uuid_generate_v4()',
+          },
+          {
+            name: 'key',
+            type: 'varchar',
+            length: '200',
+            isNullable: false,
+          },
+          {
+            name: 'value',
+            type: 'jsonb',
+            isNullable: false,
+          },
+          {
+            name: 'description',
+            type: 'text',
+            isNullable: true,
+          },
+          {
+            name: 'isFeatureFlag',
+            type: 'boolean',
+            default: false,
+            isNullable: false,
+          },
+          {
+            name: 'version',
+            type: 'int',
+            default: 1,
+            isNullable: false,
+          },
+          {
+            name: 'createdBy',
+            type: 'uuid',
+            isNullable: true,
+          },
+          {
+            name: 'updatedBy',
+            type: 'uuid',
+            isNullable: true,
+          },
+          {
+            name: 'createdAt',
+            type: 'timestamp',
+            default: 'CURRENT_TIMESTAMP',
+            isNullable: false,
+          },
+          {
+            name: 'updatedAt',
+            type: 'timestamp',
+            default: 'CURRENT_TIMESTAMP',
+            onUpdate: 'CURRENT_TIMESTAMP',
+            isNullable: false,
+          },
+        ],
+      }),
+      true,
+    );
+
+    await queryRunner.createTable(
+      new Table({
+        name: 'system_config_versions',
+        columns: [
+          {
+            name: 'id',
+            type: 'uuid',
+            isPrimary: true,
+            generationStrategy: 'uuid',
+            default: 'uuid_generate_v4()',
+          },
+          {
+            name: 'configId',
+            type: 'uuid',
+            isNullable: false,
+          },
+          {
+            name: 'key',
+            type: 'varchar',
+            length: '200',
+            isNullable: false,
+          },
+          {
+            name: 'version',
+            type: 'int',
+            isNullable: false,
+          },
+          {
+            name: 'value',
+            type: 'jsonb',
+            isNullable: false,
+          },
+          {
+            name: 'createdBy',
+            type: 'uuid',
+            isNullable: true,
+          },
+          {
+            name: 'createdAt',
+            type: 'timestamp',
+            default: 'CURRENT_TIMESTAMP',
+            isNullable: false,
+          },
+        ],
+      }),
+      true,
+    );
+
+    await queryRunner.createTable(
+      new Table({
+        name: 'system_config_audits',
+        columns: [
+          {
+            name: 'id',
+            type: 'uuid',
+            isPrimary: true,
+            generationStrategy: 'uuid',
+            default: 'uuid_generate_v4()',
+          },
+          {
+            name: 'configId',
+            type: 'uuid',
+            isNullable: true,
+          },
+          {
+            name: 'key',
+            type: 'varchar',
+            length: '200',
+            isNullable: false,
+          },
+          {
+            name: 'action',
+            type: 'enum',
+            enum: ['created', 'updated', 'rolled_back', 'kill_switch'],
+            isNullable: false,
+          },
+          {
+            name: 'oldValue',
+            type: 'jsonb',
+            isNullable: true,
+          },
+          {
+            name: 'newValue',
+            type: 'jsonb',
+            isNullable: true,
+          },
+          {
+            name: 'metadata',
+            type: 'jsonb',
+            isNullable: true,
+          },
+          {
+            name: 'adminId',
+            type: 'uuid',
+            isNullable: true,
+          },
+          {
+            name: 'ipAddress',
+            type: 'varchar',
+            length: '100',
+            isNullable: true,
+          },
+          {
+            name: 'userAgent',
+            type: 'text',
+            isNullable: true,
+          },
+          {
+            name: 'createdAt',
+            type: 'timestamp',
+            default: 'CURRENT_TIMESTAMP',
+            isNullable: false,
+          },
+        ],
+      }),
+      true,
+    );
+
+    await queryRunner.createIndex(
+      'system_configs',
+      new Index('UQ_system_configs_key', ['key'], { isUnique: true }),
+    );
+
+    await queryRunner.createIndex(
+      'system_config_versions',
+      new Index('UQ_system_config_versions_config_version', ['configId', 'version'], {
+        isUnique: true,
+      }),
+    );
+
+    await queryRunner.createIndex(
+      'system_config_audits',
+      new Index('IDX_system_config_audits_config_created', ['configId', 'createdAt']),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropTable('system_config_audits');
+    await queryRunner.dropTable('system_config_versions');
+    await queryRunner.dropTable('system_configs');
+  }
+}

--- a/src/system-config/dto/system-config-patch.dto.ts
+++ b/src/system-config/dto/system-config-patch.dto.ts
@@ -1,0 +1,23 @@
+import { Type } from 'class-transformer';
+import {
+  IsArray,
+  IsOptional,
+  ValidateNested,
+  ArrayMinSize,
+} from 'class-validator';
+import { SystemConfigUpdateItemDto } from './system-config-update.dto';
+import { SystemConfigRollbackDto } from './system-config-rollback.dto';
+
+export class SystemConfigPatchDto {
+  @IsOptional()
+  @IsArray()
+  @ArrayMinSize(1)
+  @ValidateNested({ each: true })
+  @Type(() => SystemConfigUpdateItemDto)
+  updates?: SystemConfigUpdateItemDto[];
+
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => SystemConfigRollbackDto)
+  rollback?: SystemConfigRollbackDto;
+}

--- a/src/system-config/dto/system-config-rollback.dto.ts
+++ b/src/system-config/dto/system-config-rollback.dto.ts
@@ -1,0 +1,11 @@
+import { IsInt, IsNotEmpty, IsString, Min } from 'class-validator';
+
+export class SystemConfigRollbackDto {
+  @IsString()
+  @IsNotEmpty()
+  key: string;
+
+  @IsInt()
+  @Min(1)
+  version: number;
+}

--- a/src/system-config/dto/system-config-update.dto.ts
+++ b/src/system-config/dto/system-config-update.dto.ts
@@ -1,0 +1,18 @@
+import { IsBoolean, IsDefined, IsOptional, IsString, IsNotEmpty } from 'class-validator';
+
+export class SystemConfigUpdateItemDto {
+  @IsString()
+  @IsNotEmpty()
+  key: string;
+
+  @IsDefined()
+  value: any;
+
+  @IsOptional()
+  @IsString()
+  description?: string;
+
+  @IsOptional()
+  @IsBoolean()
+  isFeatureFlag?: boolean;
+}

--- a/src/system-config/entities/system-config-audit.entity.ts
+++ b/src/system-config/entities/system-config-audit.entity.ts
@@ -1,0 +1,51 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  Index,
+} from 'typeorm';
+
+export enum SystemConfigAuditAction {
+  CREATED = 'created',
+  UPDATED = 'updated',
+  ROLLED_BACK = 'rolled_back',
+  KILL_SWITCH = 'kill_switch',
+}
+
+@Entity('system_config_audits')
+@Index(['configId', 'createdAt'])
+export class SystemConfigAudit {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ type: 'uuid', nullable: true })
+  configId: string | null;
+
+  @Column({ type: 'varchar', length: 200 })
+  key: string;
+
+  @Column({ type: 'enum', enum: SystemConfigAuditAction })
+  action: SystemConfigAuditAction;
+
+  @Column({ type: 'jsonb', nullable: true })
+  oldValue: Record<string, any> | string | number | boolean | null;
+
+  @Column({ type: 'jsonb', nullable: true })
+  newValue: Record<string, any> | string | number | boolean | null;
+
+  @Column({ type: 'jsonb', nullable: true })
+  metadata: Record<string, any> | null;
+
+  @Column({ type: 'uuid', nullable: true })
+  adminId: string | null;
+
+  @Column({ type: 'varchar', length: 100, nullable: true })
+  ipAddress: string | null;
+
+  @Column({ type: 'text', nullable: true })
+  userAgent: string | null;
+
+  @CreateDateColumn()
+  createdAt: Date;
+}

--- a/src/system-config/entities/system-config-version.entity.ts
+++ b/src/system-config/entities/system-config-version.entity.ts
@@ -1,0 +1,32 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  Index,
+} from 'typeorm';
+
+@Entity('system_config_versions')
+@Index(['configId', 'version'], { unique: true })
+export class SystemConfigVersion {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ type: 'uuid' })
+  configId: string;
+
+  @Column({ type: 'varchar', length: 200 })
+  key: string;
+
+  @Column({ type: 'int' })
+  version: number;
+
+  @Column({ type: 'jsonb' })
+  value: Record<string, any> | string | number | boolean | null;
+
+  @Column({ type: 'uuid', nullable: true })
+  createdBy: string | null;
+
+  @CreateDateColumn()
+  createdAt: Date;
+}

--- a/src/system-config/entities/system-config.entity.ts
+++ b/src/system-config/entities/system-config.entity.ts
@@ -1,0 +1,42 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+  Index,
+} from 'typeorm';
+
+@Entity('system_configs')
+@Index(['key'], { unique: true })
+export class SystemConfig {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ type: 'varchar', length: 200 })
+  key: string;
+
+  @Column({ type: 'jsonb' })
+  value: Record<string, any> | string | number | boolean | null;
+
+  @Column({ type: 'text', nullable: true })
+  description: string | null;
+
+  @Column({ default: false })
+  isFeatureFlag: boolean;
+
+  @Column({ type: 'int', default: 1 })
+  version: number;
+
+  @Column({ type: 'uuid', nullable: true })
+  createdBy: string | null;
+
+  @Column({ type: 'uuid', nullable: true })
+  updatedBy: string | null;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/src/system-config/interfaces/feature-flag.interface.ts
+++ b/src/system-config/interfaces/feature-flag.interface.ts
@@ -1,0 +1,14 @@
+export interface FeatureFlagVariant {
+  name: string;
+  weight: number;
+  payload?: Record<string, any>;
+}
+
+export interface FeatureFlagConfig {
+  enabled: boolean;
+  rolloutPercent?: number;
+  targetUsers?: string[];
+  excludedUsers?: string[];
+  variants?: FeatureFlagVariant[];
+  killSwitch?: boolean;
+}

--- a/src/system-config/system-config.controller.ts
+++ b/src/system-config/system-config.controller.ts
@@ -1,0 +1,67 @@
+import {
+  Body,
+  Controller,
+  Get,
+  Patch,
+  Query,
+  UseGuards,
+  Req,
+  BadRequestException,
+} from '@nestjs/common';
+import { Request } from 'express';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { RoleGuard } from '../roles/guards/role.guard';
+import { PermissionGuard } from '../roles/guards/permission.guard';
+import { Roles } from '../roles/decorators/roles.decorator';
+import { RequirePermissions } from '../roles/decorators/permissions.decorator';
+import { RoleType } from '../roles/entities/role.entity';
+import { CurrentUser } from '../auth/decorators/current-user.decorator';
+import { SystemConfigService } from './system-config.service';
+import { SystemConfigPatchDto } from './dto/system-config-patch.dto';
+
+@Controller('admin/config')
+@UseGuards(JwtAuthGuard, RoleGuard, PermissionGuard)
+@Roles(RoleType.ADMIN)
+@RequirePermissions('admin.access')
+export class SystemConfigController {
+  constructor(private readonly systemConfigService: SystemConfigService) {}
+
+  @Get()
+  async getConfigs(@Query('isFeatureFlag') isFeatureFlag?: string) {
+    const parsedFlag =
+      isFeatureFlag === undefined ? undefined : isFeatureFlag === 'true';
+    return this.systemConfigService.getAllConfigs(parsedFlag);
+  }
+
+  @Patch()
+  async updateConfig(
+    @Body() body: SystemConfigPatchDto,
+    @CurrentUser() currentUser: any,
+    @Req() req: Request,
+  ) {
+    if (body.updates && body.rollback) {
+      throw new BadRequestException('Provide either updates or rollback, not both.');
+    }
+
+    if (!body.updates && !body.rollback) {
+      throw new BadRequestException('Provide updates or rollback in request body.');
+    }
+
+    if (body.rollback) {
+      const rolledBack = await this.systemConfigService.rollbackConfig(
+        body.rollback.key,
+        body.rollback.version,
+        currentUser?.userId || null,
+        req,
+      );
+      return { rollback: rolledBack };
+    }
+
+    const updated = await this.systemConfigService.updateConfigs(
+      body.updates || [],
+      currentUser?.userId || null,
+      req,
+    );
+    return { updated };
+  }
+}

--- a/src/system-config/system-config.module.ts
+++ b/src/system-config/system-config.module.ts
@@ -1,0 +1,15 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { SystemConfig } from './entities/system-config.entity';
+import { SystemConfigVersion } from './entities/system-config-version.entity';
+import { SystemConfigAudit } from './entities/system-config-audit.entity';
+import { SystemConfigService } from './system-config.service';
+import { SystemConfigController } from './system-config.controller';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([SystemConfig, SystemConfigVersion, SystemConfigAudit])],
+  providers: [SystemConfigService],
+  controllers: [SystemConfigController],
+  exports: [SystemConfigService],
+})
+export class SystemConfigModule {}

--- a/src/system-config/system-config.service.ts
+++ b/src/system-config/system-config.service.ts
@@ -1,0 +1,357 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Request } from 'express';
+import { createHash } from 'crypto';
+import { CacheService } from '../cache/cache.service';
+import { SystemConfig } from './entities/system-config.entity';
+import { SystemConfigVersion } from './entities/system-config-version.entity';
+import {
+  SystemConfigAudit,
+  SystemConfigAuditAction,
+} from './entities/system-config-audit.entity';
+import { FeatureFlagConfig, FeatureFlagVariant } from './interfaces/feature-flag.interface';
+import { SystemConfigUpdateItemDto } from './dto/system-config-update.dto';
+
+const CONFIG_CACHE_KEY = 'system_config:all';
+const CONFIG_ITEM_KEY_PREFIX = 'system_config:item:';
+const GLOBAL_KILL_SWITCH_KEY = 'system.kill_switch';
+
+@Injectable()
+export class SystemConfigService {
+  private readonly cacheTtlSeconds = 60;
+
+  constructor(
+    @InjectRepository(SystemConfig)
+    private readonly configRepository: Repository<SystemConfig>,
+    @InjectRepository(SystemConfigVersion)
+    private readonly versionRepository: Repository<SystemConfigVersion>,
+    @InjectRepository(SystemConfigAudit)
+    private readonly auditRepository: Repository<SystemConfigAudit>,
+    private readonly cacheService: CacheService,
+  ) {}
+
+  async getAllConfigs(isFeatureFlag?: boolean): Promise<SystemConfig[]> {
+    const cacheKey =
+      isFeatureFlag === undefined
+        ? CONFIG_CACHE_KEY
+        : `${CONFIG_CACHE_KEY}:${isFeatureFlag ? 'flags' : 'configs'}`;
+
+    return this.cacheService.wrap(
+      cacheKey,
+      async () => {
+        if (isFeatureFlag === undefined) {
+          return this.configRepository.find({ order: { key: 'ASC' } });
+        }
+        return this.configRepository.find({
+          where: { isFeatureFlag },
+          order: { key: 'ASC' },
+        });
+      },
+      this.cacheTtlSeconds,
+    );
+  }
+
+  async getConfig(key: string): Promise<SystemConfig | null> {
+    const cacheKey = `${CONFIG_ITEM_KEY_PREFIX}${key}`;
+    return this.cacheService.wrap(
+      cacheKey,
+      async () => {
+        const config = await this.configRepository.findOne({ where: { key } });
+        return config || null;
+      },
+      this.cacheTtlSeconds,
+    );
+  }
+
+  async updateConfigs(
+    updates: SystemConfigUpdateItemDto[],
+    adminId: string | null,
+    req?: Request,
+  ): Promise<SystemConfig[]> {
+    const results: SystemConfig[] = [];
+
+    for (const update of updates) {
+      const existing = await this.configRepository.findOne({
+        where: { key: update.key },
+      });
+
+      if (!existing) {
+        const created = this.configRepository.create({
+          key: update.key,
+          value: update.value,
+          description: update.description || null,
+          isFeatureFlag: update.isFeatureFlag ?? false,
+          version: 1,
+          createdBy: adminId,
+          updatedBy: adminId,
+        });
+
+        const saved = await this.configRepository.save(created);
+        await this.saveVersion(saved, adminId);
+        await this.saveAudit({
+          configId: saved.id,
+          key: saved.key,
+          action:
+            saved.key === GLOBAL_KILL_SWITCH_KEY
+              ? SystemConfigAuditAction.KILL_SWITCH
+              : SystemConfigAuditAction.CREATED,
+          oldValue: null,
+          newValue: saved.value,
+          adminId,
+          req,
+        });
+
+        await this.invalidateCaches(saved.key);
+        results.push(saved);
+        continue;
+      }
+
+      const previousValue = existing.value;
+      existing.value = update.value;
+      existing.description = update.description ?? existing.description;
+      existing.isFeatureFlag =
+        update.isFeatureFlag === undefined ? existing.isFeatureFlag : update.isFeatureFlag;
+      existing.version = existing.version + 1;
+      existing.updatedBy = adminId;
+
+      const saved = await this.configRepository.save(existing);
+      await this.saveVersion(saved, adminId);
+      await this.saveAudit({
+        configId: saved.id,
+        key: saved.key,
+        action:
+          saved.key === GLOBAL_KILL_SWITCH_KEY
+            ? SystemConfigAuditAction.KILL_SWITCH
+            : SystemConfigAuditAction.UPDATED,
+        oldValue: previousValue,
+        newValue: saved.value,
+        adminId,
+        req,
+      });
+
+      await this.invalidateCaches(saved.key);
+      results.push(saved);
+    }
+
+    return results;
+  }
+
+  async rollbackConfig(
+    key: string,
+    version: number,
+    adminId: string | null,
+    req?: Request,
+  ): Promise<SystemConfig> {
+    const config = await this.configRepository.findOne({ where: { key } });
+    if (!config) {
+      throw new NotFoundException(`Config with key ${key} not found`);
+    }
+
+    const targetVersion = await this.versionRepository.findOne({
+      where: { configId: config.id, version },
+    });
+
+    if (!targetVersion) {
+      throw new NotFoundException(`Version ${version} not found for config ${key}`);
+    }
+
+    const previousValue = config.value;
+    config.value = targetVersion.value;
+    config.version = config.version + 1;
+    config.updatedBy = adminId;
+
+    const saved = await this.configRepository.save(config);
+    await this.saveVersion(saved, adminId);
+    await this.saveAudit({
+      configId: saved.id,
+      key: saved.key,
+      action: SystemConfigAuditAction.ROLLED_BACK,
+      oldValue: previousValue,
+      newValue: saved.value,
+      adminId,
+      metadata: { fromVersion: version, toVersion: saved.version },
+      req,
+    });
+
+    await this.invalidateCaches(saved.key);
+    return saved;
+  }
+
+  async isFeatureEnabled(flagKey: string, userId?: string | null): Promise<boolean> {
+    if (await this.isKillSwitchEnabled()) {
+      return false;
+    }
+
+    const config = await this.getConfig(flagKey);
+    if (!config || !config.isFeatureFlag) {
+      return false;
+    }
+
+    const flag = this.normalizeFlagConfig(config.value);
+    if (flag.killSwitch) {
+      return false;
+    }
+
+    if (!flag.enabled) {
+      return false;
+    }
+
+    if (userId && flag.excludedUsers?.includes(userId)) {
+      return false;
+    }
+
+    if (userId && flag.targetUsers?.includes(userId)) {
+      return true;
+    }
+
+    if (flag.rolloutPercent === undefined) {
+      return flag.enabled;
+    }
+
+    if (!userId) {
+      return flag.rolloutPercent >= 100;
+    }
+
+    const bucket = this.getDeterministicBucket(`${flagKey}:${userId}`);
+    return bucket < Math.max(0, Math.min(flag.rolloutPercent, 100));
+  }
+
+  async getFeatureVariant(
+    flagKey: string,
+    userId?: string | null,
+  ): Promise<FeatureFlagVariant | null> {
+    const enabled = await this.isFeatureEnabled(flagKey, userId);
+    if (!enabled) {
+      return null;
+    }
+
+    const config = await this.getConfig(flagKey);
+    if (!config) {
+      return null;
+    }
+
+    const flag = this.normalizeFlagConfig(config.value);
+    if (!flag.variants || flag.variants.length === 0) {
+      return { name: 'control', weight: 100 };
+    }
+
+    const variants = flag.variants.filter((variant) => variant.weight > 0);
+    const totalWeight = variants.reduce((sum, variant) => sum + variant.weight, 0);
+    if (totalWeight <= 0) {
+      return { name: 'control', weight: 100 };
+    }
+
+    const bucket = this.getDeterministicBucket(`${flagKey}:variant:${userId || 'anon'}`);
+    const scaledBucket = (bucket / 100) * totalWeight;
+    let cumulative = 0;
+
+    for (const variant of variants) {
+      cumulative += variant.weight;
+      if (scaledBucket < cumulative) {
+        return variant;
+      }
+    }
+
+    return variants[variants.length - 1];
+  }
+
+  async getAuditTrail(key?: string): Promise<SystemConfigAudit[]> {
+    return this.auditRepository.find({
+      where: key ? { key } : {},
+      order: { createdAt: 'DESC' },
+      take: 100,
+    });
+  }
+
+  private async saveVersion(config: SystemConfig, adminId: string | null) {
+    const versionEntry = this.versionRepository.create({
+      configId: config.id,
+      key: config.key,
+      version: config.version,
+      value: config.value,
+      createdBy: adminId,
+    });
+    await this.versionRepository.save(versionEntry);
+  }
+
+  private async saveAudit(params: {
+    configId: string | null;
+    key: string;
+    action: SystemConfigAuditAction;
+    oldValue: any;
+    newValue: any;
+    adminId: string | null;
+    metadata?: Record<string, any>;
+    req?: Request;
+  }) {
+    const audit = this.auditRepository.create({
+      configId: params.configId,
+      key: params.key,
+      action: params.action,
+      oldValue: params.oldValue ?? null,
+      newValue: params.newValue ?? null,
+      metadata: params.metadata ?? null,
+      adminId: params.adminId,
+      ipAddress: params.req?.ip || params.req?.socket.remoteAddress || null,
+      userAgent: params.req?.headers['user-agent'] || null,
+    });
+    await this.auditRepository.save(audit);
+  }
+
+  private async invalidateCaches(key: string): Promise<void> {
+    await this.cacheService.delete(CONFIG_CACHE_KEY);
+    await this.cacheService.delete(`${CONFIG_CACHE_KEY}:flags`);
+    await this.cacheService.delete(`${CONFIG_CACHE_KEY}:configs`);
+    await this.cacheService.delete(`${CONFIG_ITEM_KEY_PREFIX}${key}`);
+  }
+
+  private normalizeFlagConfig(value: any): FeatureFlagConfig {
+    if (typeof value === 'boolean') {
+      return { enabled: value };
+    }
+
+    if (!value || typeof value !== 'object') {
+      return { enabled: false };
+    }
+
+    const rolloutRaw = value.rolloutPercent;
+    const rolloutParsed =
+      rolloutRaw === undefined ? undefined : Number(rolloutRaw);
+    const rolloutPercent =
+      rolloutParsed === undefined || Number.isNaN(rolloutParsed)
+        ? undefined
+        : rolloutParsed;
+
+    return {
+      enabled: Boolean(value.enabled),
+      rolloutPercent,
+      targetUsers: Array.isArray(value.targetUsers) ? value.targetUsers : undefined,
+      excludedUsers: Array.isArray(value.excludedUsers) ? value.excludedUsers : undefined,
+      variants: Array.isArray(value.variants) ? value.variants : undefined,
+      killSwitch: Boolean(value.killSwitch),
+    };
+  }
+
+  private async isKillSwitchEnabled(): Promise<boolean> {
+    const killSwitch = await this.getConfig(GLOBAL_KILL_SWITCH_KEY);
+    if (!killSwitch) {
+      return false;
+    }
+    const value = killSwitch.value;
+    if (typeof value === 'boolean') {
+      return value;
+    }
+    if (value && typeof value === 'object') {
+      return Boolean(value.enabled);
+    }
+    return false;
+  }
+
+  private getDeterministicBucket(seed: string): number {
+    const hash = createHash('sha256').update(seed).digest('hex');
+    const slice = hash.slice(0, 8);
+    const bucket = parseInt(slice, 16) % 100;
+    return bucket;
+  }
+}


### PR DESCRIPTION
closes #48 

This PR adds a dedicated config store with versions and audits, a service that evaluates feature flags with percentage rollouts, user targeting, A/B variants and a global emergency kill switch.