### PR TITLE
initiate pending claim

### DIFF
--- a/contracts/whsper_stellar/src/storage.rs
+++ b/contracts/whsper_stellar/src/storage.rs
@@ -38,6 +38,7 @@ pub enum DataKey {
     Claim(u64),
     ClaimsByCreator(Address),
     NextClaimId,
+    ClaimConfig,
 }
 
 #[contracttype]

--- a/contracts/whsper_stellar/src/types.rs
+++ b/contracts/whsper_stellar/src/types.rs
@@ -92,6 +92,7 @@ pub enum ContractError {
     ClaimAlreadyClaimed = 27,
     NotClaimCreator = 28,
     ClaimAlreadyCancelled = 29,
+    ClaimWindowDisabled = 30,
 }
 
 #[derive(Clone)]
@@ -211,6 +212,16 @@ pub struct Analytics {
     pub churn_rate: u32,     // as percentage
 }
 
+/// Configuration for the claim window (pending claims).
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[contracttype]
+pub struct ClaimConfig {
+    /// When true, create_pending_claim is allowed.
+    pub claim_window_enabled: bool,
+    /// Number of ledgers after which a pending claim expires.
+    pub claim_validity_ledgers: u32,
+}
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[contracttype]
 pub enum ClaimStatus {
@@ -224,11 +235,14 @@ pub enum ClaimStatus {
 pub struct Claim {
     pub id: u64,
     pub creator: Address,
+    pub recipient: Address,
     pub token: Address,
     pub amount: i128,
     pub status: ClaimStatus,
     pub created_at: u64,
     pub expires_at: u64,
+    /// When set, expiry is ledger-based (current ledger >= this = expired).
+    pub expiry_ledger: Option<u32>,
     pub claimed_by: Option<Address>,
     pub claimed_at: Option<u64>,
 }


### PR DESCRIPTION
## Summary
Implements the core flow for pending claims: creating a claim record and escrowing tokens instead of transferring them immediately to the recipient.

## Changes
- **`create_pending_claim(env, creator, recipient, token, amount)`** in `contracts/whsper_stellar/src/lib.rs`
  - Requires creator auth (`creator.require_auth()`).
  - Requires claim window to be enabled via `ClaimConfig`; returns `ClaimWindowDisabled` otherwise.
  - Generates a unique, sequential claim ID via `next_claim_id()`.
  - Computes expiry as `current_ledger + claim_validity_ledgers` and stores it in `Claim.expiry_ledger`.
  - Escrows tokens: transfers from creator to the contract before storing the claim.
  - Stores the new `Claim` (with `recipient` and `expiry_ledger`) and indexes by creator (`ClaimsByCreator`).
  - Emits `claim_created` with creator, recipient, token, amount, claim_id, expiry_ledger, and timestamp.
- **Claim config**
  - New `ClaimConfig` (claim_window_enabled, claim_validity_ledgers) and `DataKey::ClaimConfig`.
  - Admin-only `set_claim_config` / `get_claim_config`.
- **Claim model**
  - `Claim` extended with `recipient` and optional `expiry_ledger`; `admin_cancel_expired_claim` supports ledger-based expiry when set.
- **Tests**
  - All `Claim` usages in tests updated to include `recipient` and `expiry_ledger` where applicable.

## Acceptance criteria
- [x] Claim ID is unique and sequential.
- [x] Tokens are escrowed in the contract.
- [x] Expiry is computed from current ledger + `claim_validity_ledgers`.
- [x] Event includes relevant claim data (creator, recipient, token, amount, claim_id, expiry_ledger, timestamp).
- [x] Creator authentication is required.

closes #176 