### PR TITLE
Feature/transfer tokens claim window

### DIFF
--- a/contracts/whsper_stellar/src/storage.rs
+++ b/contracts/whsper_stellar/src/storage.rs
@@ -38,6 +38,7 @@ pub enum DataKey {
     Claim(u64),
     ClaimsByCreator(Address),
     NextClaimId,
+    ClaimConfig,
 }
 
 #[contracttype]

--- a/contracts/whsper_stellar/src/types.rs
+++ b/contracts/whsper_stellar/src/types.rs
@@ -92,6 +92,7 @@ pub enum ContractError {
     ClaimAlreadyClaimed = 27,
     NotClaimCreator = 28,
     ClaimAlreadyCancelled = 29,
+    ClaimWindowDisabled = 30,
 }
 
 #[derive(Clone)]
@@ -211,6 +212,16 @@ pub struct Analytics {
     pub churn_rate: u32,     // as percentage
 }
 
+/// Configuration for the claim window (pending claims).
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[contracttype]
+pub struct ClaimConfig {
+    /// When true, create_pending_claim is allowed.
+    pub claim_window_enabled: bool,
+    /// Number of ledgers after which a pending claim expires.
+    pub claim_validity_ledgers: u32,
+}
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[contracttype]
 pub enum ClaimStatus {
@@ -224,11 +235,14 @@ pub enum ClaimStatus {
 pub struct Claim {
     pub id: u64,
     pub creator: Address,
+    pub recipient: Address,
     pub token: Address,
     pub amount: i128,
     pub status: ClaimStatus,
     pub created_at: u64,
     pub expires_at: u64,
+    /// When set, expiry is ledger-based (current ledger >= this = expired).
+    pub expiry_ledger: Option<u32>,
     pub claimed_by: Option<Address>,
     pub claimed_at: Option<u64>,
 }


### PR DESCRIPTION
## Summary
Adds optional use of the claim window from `transfer_tokens` and a dedicated `transfer_with_claim` entrypoint. Direct transfers stay the default; no breaking changes to the existing API.

## Changes
- **`transfer_tokens(env, sender, recipient, token, amount)`** – unchanged 5-arg API; always performs a direct transfer. Documentation updated to mention claim-window flow.
- **`transfer_with_claim(env, sender, recipient, token, amount)`** – new function that transfers via the claim window when enabled (creates a pending claim and escrows tokens). Fails with `ClaimWindowDisabled` if the claim window is disabled.
- **Internal `transfer_tokens_impl`** – shared logic for both paths; rate limiting applies in both modes.
- **Events**
  - Direct: `transfer` (sender, recipient), (token, amount).
  - Via claim: `transfer_via_claim` (sender, recipient), (token, amount), plus `claim_created` from `create_pending_claim`.

## Acceptance criteria
- [x] Existing direct transfers still work (unchanged 5-arg `transfer_tokens`).
- [x] Claim window can be used via `transfer_with_claim`.
- [x] Rate limiting applies to both direct and claim-based transfers.
- [x] Events distinguish direct (`transfer`) vs claim-based (`transfer_via_claim` / `claim_created`).
- [x] No breaking changes to existing API.

## Tests
- `test_transfer_tokens` – direct transfer (unchanged).
- `test_transfer_tokens_direct_explicit` – direct transfer only.
- `test_transfer_with_claim_and_transfer_via_claim_window` – claim window enabled; `transfer_with_claim` escrows tokens and balances/events asserted.
- `test_transfer_claim_window_disabled` – `transfer_with_claim` returns error when claim window is not enabled.
closes #181 