### PR TITLE
Implement getter functions for claim information

### DIFF
--- a/contracts/whsper_stellar/src/lib.rs
+++ b/contracts/whsper_stellar/src/lib.rs
@@ -1042,6 +1042,97 @@ impl BaseContract {
         env.storage().instance().get(&DataKey::ClaimConfig)
     }
 
+    /// Read-only: Get claim by ID. Returns ClaimNotFound for non-existent claims.
+    pub fn get_pending_claim(env: Env, claim_id: u64) -> Result<Claim, ContractError> {
+        env.storage()
+            .instance()
+            .get(&DataKey::Claim(claim_id))
+            .ok_or(ContractError::ClaimNotFound)
+    }
+
+    /// Read-only: Get claims for a recipient. Paginated with MAX_PAGE_SIZE cap.
+    /// When only_pending is Some(true), returns only Pending claims; otherwise all.
+    pub fn get_claims_by_recipient(
+        env: Env,
+        recipient: Address,
+        limit: u32,
+        only_pending: Option<bool>,
+    ) -> Vec<Claim> {
+        Self::get_claims_list(
+            &env,
+            &DataKey::ClaimsByRecipient(recipient),
+            limit,
+            only_pending,
+        )
+    }
+
+    /// Read-only: Get claims created by an address. Paginated with MAX_PAGE_SIZE cap.
+    /// When only_pending is Some(true), returns only Pending claims; otherwise all.
+    pub fn get_claims_by_creator(
+        env: Env,
+        creator: Address,
+        limit: u32,
+        only_pending: Option<bool>,
+    ) -> Vec<Claim> {
+        Self::get_claims_list(
+            &env,
+            &DataKey::ClaimsByCreator(creator),
+            limit,
+            only_pending,
+        )
+    }
+
+    fn get_claims_list(
+        env: &Env,
+        key: &DataKey,
+        limit: u32,
+        only_pending: Option<bool>,
+    ) -> Vec<Claim> {
+        let max = if limit > MAX_PAGE_SIZE {
+            MAX_PAGE_SIZE
+        } else {
+            limit
+        };
+
+        let claim_ids: Vec<u64> = env
+            .storage()
+            .instance()
+            .get(key)
+            .unwrap_or(Vec::new(env));
+
+        let mut claims = Vec::new(env);
+        let filter_pending = only_pending == Some(true);
+
+        for id in claim_ids.iter() {
+            if (claims.len() as u32) >= max {
+                break;
+            }
+            if let Some(claim) = env.storage().instance().get::<_, Claim>(&DataKey::Claim(id)) {
+                if filter_pending && claim.status != ClaimStatus::Pending {
+                    continue;
+                }
+                claims.push_back(claim);
+            }
+        }
+
+        claims
+    }
+
+    /// Read-only: Get claim window config for UI. Returns default when not set.
+    pub fn get_claim_window_config(env: Env) -> ClaimWindowConfig {
+        env.storage()
+            .instance()
+            .get(&DataKey::ClaimConfig)
+            .map(|config: ClaimConfig| ClaimWindowConfig {
+                claim_validity_ledgers: config.claim_validity_ledgers as u64,
+                enabled: config.claim_window_enabled,
+            })
+            .unwrap_or(ClaimWindowConfig {
+                claim_validity_ledgers: 0,
+                enabled: false,
+            })
+    }
+
     pub fn update_admin(env: Env, new_admin: Address) {
         let admin: Address = env
             .storage()
@@ -1673,6 +1764,17 @@ impl BaseContract {
         env.storage()
             .instance()
             .set(&DataKey::ClaimsByCreator(creator.clone()), &claims);
+
+        // Index by recipient
+        let mut recipient_claims: Vec<u64> = env
+            .storage()
+            .instance()
+            .get(&DataKey::ClaimsByRecipient(recipient.clone()))
+            .unwrap_or(Vec::new(&env));
+        recipient_claims.push_back(claim_id);
+        env.storage()
+            .instance()
+            .set(&DataKey::ClaimsByRecipient(recipient.clone()), &recipient_claims);
 
         env.events().publish(
             (Symbol::new(&env, "claim_created"), claim_id),

--- a/contracts/whsper_stellar/src/storage.rs
+++ b/contracts/whsper_stellar/src/storage.rs
@@ -38,6 +38,7 @@ pub enum DataKey {
     RoomInvitations(u64),
     Claim(u64),
     ClaimsByCreator(Address),
+    ClaimsByRecipient(Address),
     NextClaimId,
     ClaimConfig,
 }


### PR DESCRIPTION
## Add read-only claim query functions for UI/frontend integration

### Summary
Adds read-only helpers so the frontend can query pending claim data without authentication.

### New Functions

| Function | Signature | Description |
|----------|-----------|-------------|
| `get_pending_claim` | `(env, claim_id) -> Result<Claim, ContractError>` | Returns claim by ID; `ClaimNotFound` if missing |
| `get_claims_by_recipient` | `(env, recipient, limit, only_pending?) -> Vec<Claim>` | Claims for a recipient, paginated |
| `get_claims_by_creator` | `(env, creator, limit, only_pending?) -> Vec<Claim>` | Claims created by an address, paginated |
| `get_claim_window_config` | `(env) -> ClaimWindowConfig` | Returns claim window config (defaults if not set) |

### Changes

- **Storage:** Added `ClaimsByRecipient(Address)` index.
- **`create_pending_claim`:** Indexes new claims by recipient as well as creator.
- **Pagination:** `limit` is capped at `MAX_PAGE_SIZE` (50).
- **Filter:** `only_pending: Some(true)` restricts to pending claims.
- **No auth:** All query functions are read-only.

### Acceptance criteria
- [x] All functions return correct data
- [x] Pagination works (capped at `MAX_PAGE_SIZE`)
- [x] No authentication required (read-only)
- [x] Uses indexed lookups
- [x] Non-existent claims return `ClaimNotFound`

### Tests
- `test_get_pending_claim_success`
- `test_get_pending_claim_not_found`
- `test_get_claims_by_recipient`
- `test_get_claims_by_creator`
- `test_get_claim_window_config`
- `test_get_claims_pagination_max_page_size`

### Component
`contracts/whsper_stellar/src/lib.rs`, `storage.rs`, `test.rs`
closes #180 