### PR TITLE
feat(admin): implement webhook subscription system

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,165 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What This Is
+
+**Gasless Gossip** ("whspr_stellar") — a gamified, on-chain messaging platform. The root of this repo is a **NestJS backend** (not inside an `api/` subfolder as the README implies). Additional components:
+
+- `contracts/whsper_stellar/` — Rust/Soroban smart contracts for Stellar blockchain
+- `django-app/` — A separate Django REST + Channels messaging API (standalone)
+
+## Commands
+
+### Development
+```bash
+npm run start:dev        # Start NestJS in watch mode
+npm run start:debug      # Start with debug + watch
+npm run build            # Compile TypeScript
+npm run start:prod       # Run compiled output
+```
+
+### Testing
+```bash
+npm run test             # Unit tests (*.spec.ts in src/)
+npm run test:watch       # Unit tests in watch mode
+npm run test:cov         # Unit tests with coverage
+npm run test:e2e         # E2E tests (*.e2e-spec.ts in test/)
+npm run test:e2e:admin   # E2E tests matching "admin" pattern
+
+# Run a single test file
+npx jest src/path/to/file.spec.ts
+
+# E2E test setup (run migrations + seed test DB)
+npm run test:e2e:setup
+```
+
+### Linting & Formatting
+```bash
+npm run lint             # ESLint with auto-fix
+npm run format           # Prettier format
+```
+
+### Database Migrations
+```bash
+npm run migration:run                                          # Apply pending migrations
+npm run migration:revert                                       # Revert last migration
+npm run migration:generate -- src/database/migrations/Name    # Generate migration from entity diff
+npm run migration:create -- src/database/migrations/Name      # Create empty migration
+```
+
+`synchronize: false` is enforced — always use migrations, never rely on auto-sync.
+
+## Architecture
+
+### Core NestJS Modules (`src/`)
+
+| Module | Path | Purpose |
+|--------|------|---------|
+| `auth` | `src/auth/` | User JWT authentication (access + refresh tokens via `JwtStrategy` and `JwtRefreshStrategy`) |
+| `user` | `src/user/` | Core user entity + CRUD |
+| `users` | `src/users/` | Extended user profile (note: two separate user modules exist) |
+| `admin` | `src/admin/` | Admin dashboard: audit logs, IP whitelist, broadcast, platform config, withdrawal management |
+| `room` | `src/room/` | Chat rooms: token-gated, timed, paid access; analytics, invitations, roles |
+| `message` | `src/message/` | Message CRUD, reactions, edit history |
+| `transfer` | `src/transfer/` | P2P token transfers (no fees) |
+| `chain` | `src/chain/` | EVM blockchain integration (ethers.js), multi-chain (BNB, Celo, Base, Ethereum) |
+| `gasless` | `src/gasless/` | Account abstraction / sponsored transactions |
+| `notifications` | `src/notifications/` | Push notifications, broadcast notifications, delivery tracking |
+| `quest` | `src/quest/` | Quest/achievement system, XP tracking |
+| `rewards` | `src/rewards/` | Reward distribution |
+| `leaderboard` | `src/leaderboard/` | Leaderboard rankings |
+| `moderation` | `src/moderation/` | Content moderation, spam detection, flagged messages, room moderation settings |
+| `sessions` | `src/sessions/` | User session management |
+| `queue` | `src/queue/` | Bull queue management (Redis-backed async jobs) |
+| `redis` | `src/redis/` | Shared Redis client module |
+| `system-config` | `src/system-config/` | Platform-wide config (maintenance mode, etc.) |
+| `health` | `src/health/` | Health check endpoint |
+
+### Global Guards (applied to every route)
+
+1. **`JwtAuthGuard`** — Requires valid JWT. Use `@Public()` decorator to opt out.
+2. **`UserThrottlerGuard`** — Rate limiting via Redis (10 req/60s default). Use `@RateLimit()` to override.
+3. **`MaintenanceGuard`** — Blocks requests when maintenance mode is active.
+
+### Admin vs User Authentication
+
+Two separate JWT systems:
+- **User JWT**: `JWT_SECRET` / `JWT_EXPIRES_IN` — standard user auth
+- **Admin JWT**: `ADMIN_JWT_SECRET` / `ADMIN_JWT_EXPIRES_IN` — separate secret for admin panel
+
+Admin routes are under `/admin/*` and additionally protected by `IpWhitelistMiddleware`.
+
+Swagger docs (non-production only): `http://localhost:3000/admin/docs`
+
+### Admin Module Substructure
+
+`src/admin/` has its own `auth/` subdirectory (`AdminAuthModule`) with separate strategies. Key services:
+- `AuditLogService` — logs all admin actions
+- `IpWhitelistService` — restricts admin access by IP
+- `AdminBroadcastService` / `BroadcastDeliveryStatsService` — platform-wide notifications
+- `AdminQuestService` — quest management
+- Scheduled jobs: `AuditLogRetentionJob`, `TemporaryBanCleanupJob`, `AutoUnbanProcessor`
+- WebSocket gateway: `AdminEventStreamGateway` for real-time admin events
+
+### Event Flow
+
+- **Bull queues** handle async jobs (wallet creation, notifications, anomaly detection checks every 10 min)
+- **`EventEmitterModule`** (`@nestjs/event-emitter`) handles intra-module events
+- **Socket.io** WebSockets for real-time messaging and admin event streams
+
+### Database
+
+- PostgreSQL via TypeORM
+- Data source config: `src/config/data-source.ts` (production), `src/config/data-source-test.ts` (test)
+- Migrations in `src/database/migrations/`
+- Seeders in `src/database/seeders/`
+- On startup, `RolesSeederService.seed()` runs to ensure roles/permissions exist
+
+## Required Environment Variables
+
+```env
+# Database
+DATABASE_HOST, DATABASE_PORT, DATABASE_USER, DATABASE_PASSWORD, DATABASE_NAME
+
+# Auth
+JWT_SECRET, JWT_EXPIRES_IN
+ADMIN_JWT_SECRET, ADMIN_JWT_EXPIRES_IN, ADMIN_JWT_REFRESH_EXPIRES_IN
+
+# Redis
+REDIS_HOST, REDIS_PORT, REDIS_PASSWORD (optional), REDIS_DB
+
+# Blockchain (EVM)
+EVM_RPC_URL, EVM_PRIVATE_KEY
+# Per-chain (optional): CHAIN_{ETHEREUM,BNB,CELO,BASE}_RPC_URL, CHAIN_{...}_CONTRACT_ADDRESS
+
+# Storage
+PINATA_JWT, PINATA_GATEWAY_URL
+
+# Admin behavior
+ADMIN_MAX_LOGIN_ATTEMPTS, ADMIN_LOCKOUT_DURATION_MS, ADMIN_LARGE_TRANSACTION_THRESHOLD
+```
+
+## Anomaly Detection
+
+Located in `src/Security alerts and anomaly detection/` (note: unusual directory name with spaces). Runs as a cron job every 10 minutes detecting: spam, wash trading, early withdrawals, IP registration fraud, admin logins from new IPs.
+
+## Django App
+
+`django-app/` is an independent Django 4.2 + DRF + Channels app. Run it separately:
+```bash
+cd django-app
+python manage.py runserver         # REST API on :8000
+daphne gassless_gossip.asgi:application  # WebSocket support
+pytest                              # Tests (97% coverage)
+```
+
+## Stellar Smart Contract
+
+`contracts/whsper_stellar/` is a Rust crate using the Soroban SDK. Build/test separately with Cargo.
+
+## Notes
+
+- Several `src/` subdirectories have names with spaces (e.g., `src/AdminGuard and Role-based Access Control decorators/`, `src/Security alerts and anomaly detection/`). These are stale feature-branch leftovers; the live code is in the standard module directories.
+- Coverage threshold enforced at 80% lines for admin module unit tests.
+- Commit messages follow Conventional Commits: `feat:`, `fix:`, `docs:`, `refactor:`, `test:`, `chore:`.

--- a/src/admin/admin.module.ts
+++ b/src/admin/admin.module.ts
@@ -52,6 +52,11 @@ import { Notification } from '../notifications/entities/notification.entity';
 import { AdminBroadcastService } from './services/admin-broadcast.service';
 import { NotificationDelivery } from '../notifications/entities/notification-delivery.entity';
 import { BroadcastDeliveryStatsService } from './services/broadcast-delivery-stats.service';
+import { WebhookSubscription } from './entities/webhook-subscription.entity';
+import { WebhookDelivery } from './entities/webhook-delivery.entity';
+import { WebhookService } from './services/webhook.service';
+import { WebhookDeliveryProcessor } from './jobs/webhook-delivery.processor';
+import { WebhookController } from './controllers/webhook.controller';
 
 @Module({
   imports: [
@@ -88,9 +93,11 @@ import { BroadcastDeliveryStatsService } from './services/broadcast-delivery-sta
       BroadcastNotification,
       Notification,
       NotificationDelivery,
+      WebhookSubscription,
+      WebhookDelivery,
     ]),
   ],
-  controllers: [AdminController, IpWhitelistController],
+  controllers: [AdminController, IpWhitelistController, WebhookController],
   providers: [
     AdminConfigService,
     AdminService,
@@ -105,6 +112,8 @@ import { BroadcastDeliveryStatsService } from './services/broadcast-delivery-sta
     QueueService,
     AdminBroadcastService,
     BroadcastDeliveryStatsService,
+    WebhookService,
+    WebhookDeliveryProcessor,
   ],
   exports: [
     AdminConfigService,
@@ -113,6 +122,7 @@ import { BroadcastDeliveryStatsService } from './services/broadcast-delivery-sta
     AdminQuestService,
     AdminBroadcastService,
     BroadcastDeliveryStatsService,
+    WebhookService,
   ],
 })
 export class AdminModule {

--- a/src/admin/controllers/webhook.controller.ts
+++ b/src/admin/controllers/webhook.controller.ts
@@ -1,0 +1,121 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Patch,
+  Delete,
+  Body,
+  Param,
+  Query,
+  UseGuards,
+  Req,
+  HttpCode,
+  HttpStatus,
+} from '@nestjs/common';
+import {
+  ApiTags,
+  ApiBearerAuth,
+  ApiOperation,
+  ApiResponse,
+  ApiParam,
+} from '@nestjs/swagger';
+import { Request } from 'express';
+import { RoleGuard } from '../../roles/guards/role.guard';
+import { Roles } from '../../roles/decorators/roles.decorator';
+import { UserRole } from '../../roles/entities/role.entity';
+import { CurrentUser } from '../../auth/decorators/current-user.decorator';
+import { WebhookService } from '../services/webhook.service';
+import { CreateWebhookDto } from '../dto/webhook/create-webhook.dto';
+import { UpdateWebhookDto } from '../dto/webhook/update-webhook.dto';
+import { GetWebhookDeliveriesDto } from '../dto/webhook/get-webhook-deliveries.dto';
+
+@ApiTags('admin-webhooks')
+@ApiBearerAuth()
+@UseGuards(RoleGuard)
+@Roles(UserRole.SUPER_ADMIN)
+@Controller('admin/webhooks')
+export class WebhookController {
+  constructor(private readonly webhookService: WebhookService) {}
+
+  @Get()
+  @ApiOperation({ summary: 'List all webhook subscriptions' })
+  @ApiResponse({ status: 200, description: 'List of webhook subscriptions' })
+  async findAll() {
+    return this.webhookService.findAll();
+  }
+
+  @Post()
+  @ApiOperation({ summary: 'Create a webhook subscription' })
+  @ApiResponse({
+    status: 201,
+    description: 'Subscription created. The secret is returned only once.',
+  })
+  async create(
+    @Body() dto: CreateWebhookDto,
+    @CurrentUser() user: any,
+    @Req() req: Request,
+  ) {
+    const adminId = (user?.user ?? user)?.id;
+    return this.webhookService.create(dto, adminId, req);
+  }
+
+  @Patch(':id')
+  @ApiOperation({ summary: 'Update a webhook subscription' })
+  @ApiParam({ name: 'id', description: 'Webhook subscription ID' })
+  async update(
+    @Param('id') id: string,
+    @Body() dto: UpdateWebhookDto,
+    @CurrentUser() user: any,
+    @Req() req: Request,
+  ) {
+    const adminId = (user?.user ?? user)?.id;
+    return this.webhookService.update(id, dto, adminId, req);
+  }
+
+  @Delete(':id')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOperation({ summary: 'Delete a webhook subscription' })
+  @ApiParam({ name: 'id', description: 'Webhook subscription ID' })
+  async remove(
+    @Param('id') id: string,
+    @CurrentUser() user: any,
+    @Req() req: Request,
+  ) {
+    const adminId = (user?.user ?? user)?.id;
+    await this.webhookService.remove(id, adminId, req);
+  }
+
+  @Post(':id/test')
+  @ApiOperation({ summary: 'Send a test ping to the webhook URL' })
+  @ApiParam({ name: 'id', description: 'Webhook subscription ID' })
+  @ApiResponse({ status: 200, description: 'Test result with response status and body' })
+  async test(
+    @Param('id') id: string,
+    @CurrentUser() user: any,
+    @Req() req: Request,
+  ) {
+    const adminId = (user?.user ?? user)?.id;
+    return this.webhookService.testWebhook(id, adminId, req);
+  }
+
+  @Get(':id/deliveries')
+  @ApiOperation({ summary: 'Get paginated delivery history for a webhook subscription' })
+  @ApiParam({ name: 'id', description: 'Webhook subscription ID' })
+  async getDeliveries(
+    @Param('id') id: string,
+    @Query() query: GetWebhookDeliveriesDto,
+  ) {
+    return this.webhookService.getDeliveries(id, query);
+  }
+
+  @Post('deliveries/:deliveryId/retry')
+  @ApiOperation({ summary: 'Manually retry a failed delivery' })
+  @ApiParam({ name: 'deliveryId', description: 'Delivery ID' })
+  async retryDelivery(
+    @Param('deliveryId') deliveryId: string,
+    @CurrentUser() user: any,
+  ) {
+    const adminId = (user?.user ?? user)?.id;
+    return this.webhookService.retryDelivery(deliveryId, adminId);
+  }
+}

--- a/src/admin/dto/webhook/create-webhook.dto.ts
+++ b/src/admin/dto/webhook/create-webhook.dto.ts
@@ -1,0 +1,35 @@
+import {
+  IsString,
+  IsArray,
+  IsEnum,
+  IsOptional,
+  IsUrl,
+  MaxLength,
+  ArrayNotEmpty,
+} from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { WebhookEvent } from '../../enums/webhook-event.enum';
+
+export class CreateWebhookDto {
+  @ApiProperty({ example: 'https://example.com/webhook' })
+  @IsUrl({ require_tls: true, require_protocol: true, protocols: ['https'] }, {
+    message: 'url must be a valid HTTPS URL',
+  })
+  url: string;
+
+  @ApiProperty({
+    enum: WebhookEvent,
+    isArray: true,
+    example: ['user.registered', 'transaction.confirmed'],
+  })
+  @IsArray()
+  @ArrayNotEmpty()
+  @IsEnum(WebhookEvent, { each: true })
+  events: string[];
+
+  @ApiPropertyOptional({ maxLength: 255 })
+  @IsOptional()
+  @IsString()
+  @MaxLength(255)
+  description?: string;
+}

--- a/src/admin/dto/webhook/get-webhook-deliveries.dto.ts
+++ b/src/admin/dto/webhook/get-webhook-deliveries.dto.ts
@@ -1,0 +1,50 @@
+import {
+  IsEnum,
+  IsOptional,
+  IsDateString,
+  IsInt,
+  Min,
+  Max,
+  IsString,
+} from 'class-validator';
+import { Type } from 'class-transformer';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { WebhookDeliveryStatus } from '../../entities/webhook-delivery.entity';
+import { WebhookEvent } from '../../enums/webhook-event.enum';
+
+export class GetWebhookDeliveriesDto {
+  @ApiPropertyOptional({ enum: WebhookDeliveryStatus })
+  @IsOptional()
+  @IsEnum(WebhookDeliveryStatus)
+  status?: WebhookDeliveryStatus;
+
+  @ApiPropertyOptional({ enum: WebhookEvent })
+  @IsOptional()
+  @IsString()
+  event?: string;
+
+  @ApiPropertyOptional({ example: '2024-01-01T00:00:00.000Z' })
+  @IsOptional()
+  @IsDateString()
+  startDate?: string;
+
+  @ApiPropertyOptional({ example: '2024-12-31T23:59:59.999Z' })
+  @IsOptional()
+  @IsDateString()
+  endDate?: string;
+
+  @ApiPropertyOptional({ default: 1 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  page?: number = 1;
+
+  @ApiPropertyOptional({ default: 20, maximum: 100 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  limit?: number = 20;
+}

--- a/src/admin/dto/webhook/update-webhook.dto.ts
+++ b/src/admin/dto/webhook/update-webhook.dto.ts
@@ -1,0 +1,43 @@
+import {
+  IsString,
+  IsArray,
+  IsEnum,
+  IsOptional,
+  IsBoolean,
+  IsUrl,
+  MaxLength,
+  ArrayNotEmpty,
+} from 'class-validator';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { WebhookEvent } from '../../enums/webhook-event.enum';
+
+export class UpdateWebhookDto {
+  @ApiPropertyOptional({ example: 'https://example.com/webhook' })
+  @IsOptional()
+  @IsUrl({ require_tls: true, require_protocol: true, protocols: ['https'] }, {
+    message: 'url must be a valid HTTPS URL',
+  })
+  url?: string;
+
+  @ApiPropertyOptional({
+    enum: WebhookEvent,
+    isArray: true,
+    example: ['user.registered'],
+  })
+  @IsOptional()
+  @IsArray()
+  @ArrayNotEmpty()
+  @IsEnum(WebhookEvent, { each: true })
+  events?: string[];
+
+  @ApiPropertyOptional({ maxLength: 255 })
+  @IsOptional()
+  @IsString()
+  @MaxLength(255)
+  description?: string;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsBoolean()
+  isActive?: boolean;
+}

--- a/src/admin/entities/audit-log.entity.ts
+++ b/src/admin/entities/audit-log.entity.ts
@@ -60,6 +60,10 @@ export enum AuditAction {
   ROOM_DELETED = 'room.deleted',
   ROOM_RESTORED = 'room.restored',
   BROADCAST_NOTIFICATION = 'broadcast.notification',
+  WEBHOOK_CREATED = 'webhook.created',
+  WEBHOOK_UPDATED = 'webhook.updated',
+  WEBHOOK_DELETED = 'webhook.deleted',
+  WEBHOOK_TESTED = 'webhook.tested',
 }
 
 export enum AuditEventType {

--- a/src/admin/entities/webhook-delivery.entity.ts
+++ b/src/admin/entities/webhook-delivery.entity.ts
@@ -1,0 +1,64 @@
+import {
+  Entity,
+  Column,
+  PrimaryGeneratedColumn,
+  CreateDateColumn,
+  UpdateDateColumn,
+  ManyToOne,
+  JoinColumn,
+  Index,
+} from 'typeorm';
+import { WebhookSubscription } from './webhook-subscription.entity';
+
+export enum WebhookDeliveryStatus {
+  PENDING = 'pending',
+  DELIVERED = 'delivered',
+  FAILED = 'failed',
+}
+
+@Entity('webhook_deliveries')
+@Index(['subscriptionId', 'createdAt'])
+@Index(['status', 'createdAt'])
+@Index(['event', 'createdAt'])
+export class WebhookDelivery {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ name: 'subscriptionId', type: 'uuid' })
+  subscriptionId: string;
+
+  @ManyToOne(() => WebhookSubscription, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'subscriptionId' })
+  subscription: WebhookSubscription;
+
+  @Column()
+  event: string;
+
+  @Column('jsonb')
+  payload: Record<string, any>;
+
+  @Column({
+    type: 'enum',
+    enum: WebhookDeliveryStatus,
+    default: WebhookDeliveryStatus.PENDING,
+  })
+  status: WebhookDeliveryStatus;
+
+  @Column({ type: 'int', nullable: true })
+  responseStatus: number | null;
+
+  @Column({ type: 'text', nullable: true })
+  responseBody: string | null;
+
+  @Column({ type: 'int', default: 0 })
+  attemptCount: number;
+
+  @Column({ type: 'timestamp', nullable: true })
+  lastAttemptAt: Date | null;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/src/admin/entities/webhook-subscription.entity.ts
+++ b/src/admin/entities/webhook-subscription.entity.ts
@@ -1,0 +1,50 @@
+import {
+  Entity,
+  Column,
+  PrimaryGeneratedColumn,
+  CreateDateColumn,
+  UpdateDateColumn,
+  ManyToOne,
+  JoinColumn,
+  Index,
+} from 'typeorm';
+import { User } from '../../user/entities/user.entity';
+
+@Entity('webhook_subscriptions')
+@Index(['isActive', 'createdAt'])
+@Index(['createdById'])
+export class WebhookSubscription {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column()
+  url: string;
+
+  @Column()
+  secret: string;
+
+  @Column('simple-array')
+  events: string[];
+
+  @Column({ default: true })
+  isActive: boolean;
+
+  @Column({ type: 'text', nullable: true })
+  description: string | null;
+
+  @Column({ type: 'int', default: 0 })
+  consecutiveFailures: number;
+
+  @Column({ name: 'createdById', type: 'uuid' })
+  createdById: string;
+
+  @ManyToOne(() => User, { onDelete: 'RESTRICT' })
+  @JoinColumn({ name: 'createdById' })
+  createdBy: User;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/src/admin/enums/webhook-event.enum.ts
+++ b/src/admin/enums/webhook-event.enum.ts
@@ -1,0 +1,11 @@
+export enum WebhookEvent {
+  USER_REGISTERED = 'user.registered',
+  USER_BANNED = 'user.banned',
+  USER_LEVEL_UP = 'user.level_up',
+  ROOM_CREATED = 'room.created',
+  ROOM_CLOSED = 'room.closed',
+  TRANSACTION_CONFIRMED = 'transaction.confirmed',
+  TRANSACTION_FAILED = 'transaction.failed',
+  PLATFORM_MAINTENANCE_START = 'platform.maintenance_start',
+  PLATFORM_MAINTENANCE_END = 'platform.maintenance_end',
+}

--- a/src/admin/jobs/webhook-delivery.processor.ts
+++ b/src/admin/jobs/webhook-delivery.processor.ts
@@ -1,0 +1,42 @@
+import { Process, Processor, OnQueueFailed } from '@nestjs/bull';
+import { Logger } from '@nestjs/common';
+import { Job } from 'bull';
+import { WebhookService } from '../services/webhook.service';
+import { QUEUE_NAMES } from '../../queue/queue.constants';
+
+interface WebhookDeliveryJobData {
+  deliveryId: string;
+}
+
+@Processor(QUEUE_NAMES.WEBHOOK_DELIVERIES)
+export class WebhookDeliveryProcessor {
+  private readonly logger = new Logger(WebhookDeliveryProcessor.name);
+
+  constructor(private readonly webhookService: WebhookService) {}
+
+  @Process('deliver-webhook')
+  async handleDelivery(job: Job<WebhookDeliveryJobData>): Promise<void> {
+    const { deliveryId } = job.data;
+    this.logger.log(
+      `Processing webhook delivery ${deliveryId} (attempt ${job.attemptsMade + 1})`,
+    );
+    await this.webhookService.processDelivery(deliveryId);
+  }
+
+  @OnQueueFailed()
+  async onFailed(job: Job<WebhookDeliveryJobData>, err: Error): Promise<void> {
+    const { deliveryId } = job.data;
+    const isLastAttempt = job.attemptsMade >= (job.opts.attempts ?? 1) - 1;
+
+    this.logger.error(
+      `Webhook delivery job failed for ${deliveryId} (attempt ${job.attemptsMade + 1}): ${err.message}`,
+    );
+
+    if (isLastAttempt) {
+      this.logger.error(
+        `All retry attempts exhausted for delivery ${deliveryId}, marking as failed`,
+      );
+      await this.webhookService.handleDeliveryJobFailed(deliveryId);
+    }
+  }
+}

--- a/src/admin/services/webhook.service.spec.ts
+++ b/src/admin/services/webhook.service.spec.ts
@@ -1,0 +1,349 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { getQueueToken } from '@nestjs/bull';
+import { NotFoundException, BadRequestException } from '@nestjs/common';
+import { WebhookService } from './webhook.service';
+import { WebhookSubscription } from '../entities/webhook-subscription.entity';
+import {
+  WebhookDelivery,
+  WebhookDeliveryStatus,
+} from '../entities/webhook-delivery.entity';
+import { User } from '../../user/entities/user.entity';
+import { Notification } from '../../notifications/entities/notification.entity';
+import { AuditLogService } from './audit-log.service';
+import { QUEUE_NAMES } from '../../queue/queue.constants';
+import { UserRole } from '../../roles/entities/user-role.enum';
+import { WebhookEvent } from '../enums/webhook-event.enum';
+
+const ADMIN_ID = 'admin-uuid-123';
+
+const mockSubscription: Partial<WebhookSubscription> = {
+  id: 'sub-uuid-1',
+  url: 'https://example.com/hook',
+  secret: 'abc123secret',
+  events: [WebhookEvent.USER_REGISTERED],
+  isActive: true,
+  consecutiveFailures: 0,
+  createdById: ADMIN_ID,
+};
+
+const mockDelivery: Partial<WebhookDelivery> = {
+  id: 'del-uuid-1',
+  subscriptionId: 'sub-uuid-1',
+  event: WebhookEvent.USER_REGISTERED,
+  payload: { event: WebhookEvent.USER_REGISTERED, timestamp: '2024-01-01T00:00:00Z', data: {} },
+  status: WebhookDeliveryStatus.FAILED,
+  attemptCount: 3,
+  responseStatus: 500,
+  responseBody: 'Internal Server Error',
+};
+
+describe('WebhookService', () => {
+  let service: WebhookService;
+  let subscriptionRepo: any;
+  let deliveryRepo: any;
+  let userRepo: any;
+  let notificationRepo: any;
+  let webhookQueue: any;
+  let auditLogService: any;
+
+  beforeEach(async () => {
+    subscriptionRepo = {
+      find: jest.fn(),
+      findOne: jest.fn(),
+      create: jest.fn(),
+      save: jest.fn(),
+      remove: jest.fn(),
+    };
+    deliveryRepo = {
+      find: jest.fn(),
+      findOne: jest.fn(),
+      findAndCount: jest.fn(),
+      create: jest.fn(),
+      save: jest.fn(),
+    };
+    userRepo = {
+      find: jest.fn(),
+    };
+    notificationRepo = {
+      create: jest.fn(),
+      save: jest.fn(),
+    };
+    webhookQueue = {
+      add: jest.fn().mockResolvedValue({ id: 'job-1' }),
+    };
+    auditLogService = {
+      createAuditLog: jest.fn().mockResolvedValue({}),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        WebhookService,
+        { provide: getRepositoryToken(WebhookSubscription), useValue: subscriptionRepo },
+        { provide: getRepositoryToken(WebhookDelivery), useValue: deliveryRepo },
+        { provide: getRepositoryToken(User), useValue: userRepo },
+        { provide: getRepositoryToken(Notification), useValue: notificationRepo },
+        { provide: getQueueToken(QUEUE_NAMES.WEBHOOK_DELIVERIES), useValue: webhookQueue },
+        { provide: AuditLogService, useValue: auditLogService },
+      ],
+    }).compile();
+
+    service = module.get<WebhookService>(WebhookService);
+  });
+
+  // ─── generateSignature ──────────────────────────────────────────────────────
+
+  describe('generateSignature', () => {
+    it('returns sha256= prefixed HMAC-SHA256 hex digest', () => {
+      const sig = service.generateSignature('{"foo":"bar"}', 'mysecret');
+      expect(sig).toMatch(/^sha256=[0-9a-f]{64}$/);
+    });
+
+    it('produces different signatures for different secrets', () => {
+      const payload = '{"event":"test"}';
+      const sig1 = service.generateSignature(payload, 'secret1');
+      const sig2 = service.generateSignature(payload, 'secret2');
+      expect(sig1).not.toEqual(sig2);
+    });
+
+    it('produces different signatures for different payloads', () => {
+      const secret = 'constant-secret';
+      const sig1 = service.generateSignature('payload-a', secret);
+      const sig2 = service.generateSignature('payload-b', secret);
+      expect(sig1).not.toEqual(sig2);
+    });
+
+    it('is deterministic for the same input', () => {
+      const sig1 = service.generateSignature('data', 'key');
+      const sig2 = service.generateSignature('data', 'key');
+      expect(sig1).toEqual(sig2);
+    });
+  });
+
+  // ─── findAll ─────────────────────────────────────────────────────────────────
+
+  describe('findAll', () => {
+    it('returns all subscriptions ordered by createdAt DESC', async () => {
+      subscriptionRepo.find.mockResolvedValue([mockSubscription]);
+      const result = await service.findAll();
+      expect(result).toEqual([mockSubscription]);
+      expect(subscriptionRepo.find).toHaveBeenCalledWith({
+        order: { createdAt: 'DESC' },
+      });
+    });
+  });
+
+  // ─── create ──────────────────────────────────────────────────────────────────
+
+  describe('create', () => {
+    it('generates a secret and returns it with the subscription', async () => {
+      const saved = { ...mockSubscription, id: 'new-id' };
+      subscriptionRepo.create.mockReturnValue(saved);
+      subscriptionRepo.save.mockResolvedValue(saved);
+
+      const result = await service.create(
+        { url: 'https://example.com/hook', events: [WebhookEvent.USER_REGISTERED] },
+        ADMIN_ID,
+      );
+
+      expect(result.plainSecret).toBeDefined();
+      expect(result.plainSecret).toHaveLength(64); // 32 bytes hex
+      expect(auditLogService.createAuditLog).toHaveBeenCalledTimes(1);
+    });
+
+    it('sets isActive=true and consecutiveFailures=0 on creation', async () => {
+      subscriptionRepo.create.mockImplementation((data) => data);
+      subscriptionRepo.save.mockImplementation((data) => Promise.resolve(data));
+
+      const result = await service.create(
+        { url: 'https://example.com/hook', events: [WebhookEvent.USER_BANNED] },
+        ADMIN_ID,
+      );
+
+      expect(result.isActive).toBe(true);
+      expect(result.consecutiveFailures).toBe(0);
+    });
+  });
+
+  // ─── update ──────────────────────────────────────────────────────────────────
+
+  describe('update', () => {
+    it('throws NotFoundException when subscription not found', async () => {
+      subscriptionRepo.findOne.mockResolvedValue(null);
+      await expect(
+        service.update('bad-id', { isActive: false }, ADMIN_ID),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('updates only provided fields', async () => {
+      const sub = { ...mockSubscription };
+      subscriptionRepo.findOne.mockResolvedValue(sub);
+      subscriptionRepo.save.mockImplementation((s) => Promise.resolve(s));
+
+      const result = await service.update('sub-uuid-1', { isActive: false }, ADMIN_ID);
+      expect(result.isActive).toBe(false);
+      expect(result.url).toBe(mockSubscription.url);
+    });
+  });
+
+  // ─── remove ──────────────────────────────────────────────────────────────────
+
+  describe('remove', () => {
+    it('throws NotFoundException when subscription not found', async () => {
+      subscriptionRepo.findOne.mockResolvedValue(null);
+      await expect(service.remove('bad-id', ADMIN_ID)).rejects.toThrow(NotFoundException);
+    });
+
+    it('removes the subscription and logs audit', async () => {
+      subscriptionRepo.findOne.mockResolvedValue({ ...mockSubscription });
+      subscriptionRepo.remove.mockResolvedValue(undefined);
+
+      await service.remove('sub-uuid-1', ADMIN_ID);
+      expect(subscriptionRepo.remove).toHaveBeenCalledTimes(1);
+      expect(auditLogService.createAuditLog).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // ─── retryDelivery ───────────────────────────────────────────────────────────
+
+  describe('retryDelivery', () => {
+    it('throws NotFoundException when delivery not found', async () => {
+      deliveryRepo.findOne.mockResolvedValue(null);
+      await expect(service.retryDelivery('bad-id', ADMIN_ID)).rejects.toThrow(NotFoundException);
+    });
+
+    it('throws BadRequestException when delivery is not failed', async () => {
+      deliveryRepo.findOne.mockResolvedValue({
+        ...mockDelivery,
+        status: WebhookDeliveryStatus.DELIVERED,
+      });
+      await expect(service.retryDelivery('del-uuid-1', ADMIN_ID)).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+
+    it('resets delivery and enqueues a new job', async () => {
+      const delivery = { ...mockDelivery, status: WebhookDeliveryStatus.FAILED };
+      deliveryRepo.findOne.mockResolvedValue(delivery);
+      deliveryRepo.save.mockImplementation((d) => Promise.resolve(d));
+
+      const result = await service.retryDelivery('del-uuid-1', ADMIN_ID);
+
+      expect(result.status).toBe(WebhookDeliveryStatus.PENDING);
+      expect(result.attemptCount).toBe(0);
+      expect(webhookQueue.add).toHaveBeenCalledWith(
+        'deliver-webhook',
+        { deliveryId: expect.any(String) },
+        expect.objectContaining({ attempts: 3 }),
+      );
+    });
+  });
+
+  // ─── dispatchEvent ──────────────────────────────────────────────────────────
+
+  describe('dispatchEvent', () => {
+    it('creates deliveries only for subscriptions subscribed to the event', async () => {
+      const subs = [
+        { ...mockSubscription, id: 'sub-1', events: [WebhookEvent.USER_REGISTERED] },
+        { ...mockSubscription, id: 'sub-2', events: [WebhookEvent.USER_BANNED] },
+      ];
+      subscriptionRepo.find.mockResolvedValue(subs);
+      const savedDelivery = { id: 'del-new', subscriptionId: 'sub-1' };
+      deliveryRepo.create.mockReturnValue(savedDelivery);
+      deliveryRepo.save.mockResolvedValue(savedDelivery);
+
+      await service.dispatchEvent(WebhookEvent.USER_REGISTERED, { userId: '123' });
+
+      expect(deliveryRepo.create).toHaveBeenCalledTimes(1);
+      expect(webhookQueue.add).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not create deliveries when no subscriptions match the event', async () => {
+      subscriptionRepo.find.mockResolvedValue([
+        { ...mockSubscription, events: [WebhookEvent.ROOM_CREATED] },
+      ]);
+
+      await service.dispatchEvent(WebhookEvent.USER_REGISTERED, {});
+
+      expect(deliveryRepo.create).not.toHaveBeenCalled();
+      expect(webhookQueue.add).not.toHaveBeenCalled();
+    });
+  });
+
+  // ─── handleDeliveryJobFailed ─────────────────────────────────────────────────
+
+  describe('handleDeliveryJobFailed', () => {
+    it('marks delivery as failed', async () => {
+      const delivery = {
+        ...mockDelivery,
+        status: WebhookDeliveryStatus.PENDING,
+        subscription: { ...mockSubscription, consecutiveFailures: 0 },
+      };
+      deliveryRepo.findOne.mockResolvedValue(delivery);
+      deliveryRepo.save.mockImplementation((d) => Promise.resolve(d));
+      subscriptionRepo.save.mockImplementation((s) => Promise.resolve(s));
+
+      await service.handleDeliveryJobFailed('del-uuid-1');
+
+      expect(delivery.status).toBe(WebhookDeliveryStatus.FAILED);
+    });
+
+    it('increments consecutiveFailures on the subscription', async () => {
+      const sub = { ...mockSubscription, consecutiveFailures: 2 };
+      const delivery = {
+        ...mockDelivery,
+        subscription: sub,
+      };
+      deliveryRepo.findOne.mockResolvedValue(delivery);
+      deliveryRepo.save.mockImplementation((d) => Promise.resolve(d));
+      subscriptionRepo.save.mockImplementation((s) => Promise.resolve(s));
+
+      await service.handleDeliveryJobFailed('del-uuid-1');
+
+      expect(sub.consecutiveFailures).toBe(3);
+      expect(sub.isActive).toBe(true);
+    });
+
+    it('deactivates subscription and notifies super admins after 5 consecutive failures', async () => {
+      const sub = { ...mockSubscription, consecutiveFailures: 4 };
+      const delivery = { ...mockDelivery, subscription: sub };
+      deliveryRepo.findOne.mockResolvedValue(delivery);
+      deliveryRepo.save.mockImplementation((d) => Promise.resolve(d));
+      subscriptionRepo.save.mockImplementation((s) => Promise.resolve(s));
+
+      const superAdmin = { id: 'super-1', role: UserRole.SUPER_ADMIN };
+      userRepo.find.mockResolvedValue([superAdmin]);
+      notificationRepo.create.mockImplementation((n) => n);
+      notificationRepo.save.mockResolvedValue([]);
+
+      await service.handleDeliveryJobFailed('del-uuid-1');
+
+      expect(sub.isActive).toBe(false);
+      expect(sub.consecutiveFailures).toBe(5);
+      expect(notificationRepo.create).toHaveBeenCalledTimes(1);
+      expect(notificationRepo.save).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // ─── getDeliveries ───────────────────────────────────────────────────────────
+
+  describe('getDeliveries', () => {
+    it('throws NotFoundException when subscription not found', async () => {
+      subscriptionRepo.findOne.mockResolvedValue(null);
+      await expect(
+        service.getDeliveries('bad-id', {}),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('returns paginated deliveries', async () => {
+      subscriptionRepo.findOne.mockResolvedValue(mockSubscription);
+      deliveryRepo.findAndCount.mockResolvedValue([[mockDelivery], 1]);
+
+      const result = await service.getDeliveries('sub-uuid-1', { page: 1, limit: 10 });
+
+      expect(result.total).toBe(1);
+      expect(result.data).toHaveLength(1);
+      expect(result.page).toBe(1);
+    });
+  });
+});

--- a/src/admin/services/webhook.service.ts
+++ b/src/admin/services/webhook.service.ts
@@ -1,0 +1,434 @@
+import {
+  Injectable,
+  Logger,
+  NotFoundException,
+  BadRequestException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { InjectQueue } from '@nestjs/bull';
+import { Repository, Between, MoreThanOrEqual, LessThanOrEqual } from 'typeorm';
+import { Queue } from 'bull';
+import { createHmac, randomBytes } from 'crypto';
+import type { Request } from 'express';
+
+import {
+  WebhookSubscription,
+} from '../entities/webhook-subscription.entity';
+import {
+  WebhookDelivery,
+  WebhookDeliveryStatus,
+} from '../entities/webhook-delivery.entity';
+import { User } from '../../user/entities/user.entity';
+import { Notification } from '../../notifications/entities/notification.entity';
+import { CreateWebhookDto } from '../dto/webhook/create-webhook.dto';
+import { UpdateWebhookDto } from '../dto/webhook/update-webhook.dto';
+import { GetWebhookDeliveriesDto } from '../dto/webhook/get-webhook-deliveries.dto';
+import { AuditLogService } from './audit-log.service';
+import {
+  AuditAction,
+  AuditEventType,
+  AuditOutcome,
+  AuditSeverity,
+} from '../entities/audit-log.entity';
+import { QUEUE_NAMES } from '../../queue/queue.constants';
+import { UserRole } from '../../roles/entities/user-role.enum';
+import {
+  NotificationType,
+  NotificationPriority,
+} from '../../notifications/enums/notification-type.enum';
+
+const MAX_CONSECUTIVE_FAILURES = 5;
+const WEBHOOK_JOB_NAME = 'deliver-webhook';
+
+@Injectable()
+export class WebhookService {
+  private readonly logger = new Logger(WebhookService.name);
+
+  constructor(
+    @InjectRepository(WebhookSubscription)
+    private readonly subscriptionRepository: Repository<WebhookSubscription>,
+    @InjectRepository(WebhookDelivery)
+    private readonly deliveryRepository: Repository<WebhookDelivery>,
+    @InjectRepository(User)
+    private readonly userRepository: Repository<User>,
+    @InjectRepository(Notification)
+    private readonly notificationRepository: Repository<Notification>,
+    @InjectQueue(QUEUE_NAMES.WEBHOOK_DELIVERIES)
+    private readonly webhookQueue: Queue,
+    private readonly auditLogService: AuditLogService,
+  ) {}
+
+  // ─── Public API ─────────────────────────────────────────────────────────────
+
+  async findAll(): Promise<WebhookSubscription[]> {
+    return this.subscriptionRepository.find({
+      order: { createdAt: 'DESC' },
+    });
+  }
+
+  async create(
+    dto: CreateWebhookDto,
+    adminId: string,
+    req?: Request,
+  ): Promise<WebhookSubscription & { plainSecret: string }> {
+    const plainSecret = randomBytes(32).toString('hex');
+
+    const subscription = this.subscriptionRepository.create({
+      url: dto.url,
+      secret: plainSecret,
+      events: dto.events,
+      description: dto.description ?? null,
+      isActive: true,
+      consecutiveFailures: 0,
+      createdById: adminId,
+    });
+
+    const saved = await this.subscriptionRepository.save(subscription);
+
+    await this.auditLogService.createAuditLog({
+      eventType: AuditEventType.ADMIN,
+      action: AuditAction.WEBHOOK_CREATED,
+      actorUserId: adminId,
+      outcome: AuditOutcome.SUCCESS,
+      severity: AuditSeverity.MEDIUM,
+      resourceType: 'WebhookSubscription',
+      resourceId: saved.id,
+      details: `Created webhook subscription for ${dto.url}`,
+      metadata: { url: dto.url, events: dto.events },
+      req,
+    });
+
+    return { ...saved, plainSecret };
+  }
+
+  async update(
+    id: string,
+    dto: UpdateWebhookDto,
+    adminId: string,
+    req?: Request,
+  ): Promise<WebhookSubscription> {
+    const subscription = await this.findOneOrFail(id);
+
+    if (dto.url !== undefined) subscription.url = dto.url;
+    if (dto.events !== undefined) subscription.events = dto.events;
+    if (dto.description !== undefined) subscription.description = dto.description;
+    if (dto.isActive !== undefined) subscription.isActive = dto.isActive;
+
+    const saved = await this.subscriptionRepository.save(subscription);
+
+    await this.auditLogService.createAuditLog({
+      eventType: AuditEventType.ADMIN,
+      action: AuditAction.WEBHOOK_UPDATED,
+      actorUserId: adminId,
+      outcome: AuditOutcome.SUCCESS,
+      severity: AuditSeverity.MEDIUM,
+      resourceType: 'WebhookSubscription',
+      resourceId: id,
+      details: `Updated webhook subscription ${id}`,
+      metadata: { changes: dto },
+      req,
+    });
+
+    return saved;
+  }
+
+  async remove(id: string, adminId: string, req?: Request): Promise<void> {
+    const subscription = await this.findOneOrFail(id);
+    await this.subscriptionRepository.remove(subscription);
+
+    await this.auditLogService.createAuditLog({
+      eventType: AuditEventType.ADMIN,
+      action: AuditAction.WEBHOOK_DELETED,
+      actorUserId: adminId,
+      outcome: AuditOutcome.SUCCESS,
+      severity: AuditSeverity.HIGH,
+      resourceType: 'WebhookSubscription',
+      resourceId: id,
+      details: `Deleted webhook subscription ${id}`,
+      metadata: { url: subscription.url },
+      req,
+    });
+  }
+
+  async testWebhook(
+    id: string,
+    adminId: string,
+    req?: Request,
+  ): Promise<{ responseStatus: number | null; responseBody: string }> {
+    const subscription = await this.findOneOrFail(id);
+
+    const payload = {
+      event: 'ping',
+      timestamp: new Date().toISOString(),
+      webhookId: id,
+    };
+
+    const result = await this.sendHttpRequest(subscription, payload);
+
+    await this.auditLogService.createAuditLog({
+      eventType: AuditEventType.ADMIN,
+      action: AuditAction.WEBHOOK_TESTED,
+      actorUserId: adminId,
+      outcome: result.success ? AuditOutcome.SUCCESS : AuditOutcome.FAILURE,
+      severity: AuditSeverity.LOW,
+      resourceType: 'WebhookSubscription',
+      resourceId: id,
+      details: `Test ping sent to ${subscription.url} — status ${result.responseStatus}`,
+      metadata: { responseStatus: result.responseStatus },
+      req,
+    });
+
+    return {
+      responseStatus: result.responseStatus,
+      responseBody: result.responseBody,
+    };
+  }
+
+  async getDeliveries(
+    subscriptionId: string,
+    query: GetWebhookDeliveriesDto,
+  ): Promise<{ data: WebhookDelivery[]; total: number; page: number; limit: number }> {
+    await this.findOneOrFail(subscriptionId);
+
+    const { page = 1, limit = 20, status, event, startDate, endDate } = query;
+    const skip = (page - 1) * limit;
+
+    const where: any = { subscriptionId };
+    if (status) where.status = status;
+    if (event) where.event = event;
+    if (startDate && endDate) {
+      where.createdAt = Between(new Date(startDate), new Date(endDate));
+    } else if (startDate) {
+      where.createdAt = MoreThanOrEqual(new Date(startDate));
+    } else if (endDate) {
+      where.createdAt = LessThanOrEqual(new Date(endDate));
+    }
+
+    const [data, total] = await this.deliveryRepository.findAndCount({
+      where,
+      order: { createdAt: 'DESC' },
+      skip,
+      take: limit,
+    });
+
+    return { data, total, page, limit };
+  }
+
+  async retryDelivery(deliveryId: string, adminId: string): Promise<WebhookDelivery> {
+    const delivery = await this.deliveryRepository.findOne({
+      where: { id: deliveryId },
+    });
+
+    if (!delivery) {
+      throw new NotFoundException(`Delivery ${deliveryId} not found`);
+    }
+
+    if (delivery.status !== WebhookDeliveryStatus.FAILED) {
+      throw new BadRequestException('Only failed deliveries can be retried');
+    }
+
+    delivery.status = WebhookDeliveryStatus.PENDING;
+    delivery.attemptCount = 0;
+    delivery.responseStatus = null;
+    delivery.responseBody = null;
+    delivery.lastAttemptAt = null;
+
+    const saved = await this.deliveryRepository.save(delivery);
+
+    await this.webhookQueue.add(
+      WEBHOOK_JOB_NAME,
+      { deliveryId: saved.id },
+      { attempts: 3, backoff: { type: 'exponential', delay: 5000 } },
+    );
+
+    this.logger.log(`Manual retry queued for delivery ${deliveryId} by admin ${adminId}`);
+    return saved;
+  }
+
+  // ─── Event Dispatch ─────────────────────────────────────────────────────────
+
+  async dispatchEvent(event: string, payload: Record<string, any>): Promise<void> {
+    const subscriptions = await this.subscriptionRepository.find({
+      where: { isActive: true },
+    });
+
+    const relevant = subscriptions.filter((s) => s.events.includes(event));
+
+    for (const subscription of relevant) {
+      const fullPayload = {
+        event,
+        timestamp: new Date().toISOString(),
+        data: payload,
+      };
+
+      const delivery = this.deliveryRepository.create({
+        subscriptionId: subscription.id,
+        event,
+        payload: fullPayload,
+        status: WebhookDeliveryStatus.PENDING,
+        attemptCount: 0,
+      });
+
+      const saved = await this.deliveryRepository.save(delivery);
+
+      await this.webhookQueue.add(
+        WEBHOOK_JOB_NAME,
+        { deliveryId: saved.id },
+        { attempts: 3, backoff: { type: 'exponential', delay: 5000 } },
+      );
+    }
+  }
+
+  // ─── Delivery Processing (called by processor) ───────────────────────────────
+
+  async processDelivery(deliveryId: string): Promise<void> {
+    const delivery = await this.deliveryRepository.findOne({
+      where: { id: deliveryId },
+      relations: ['subscription'],
+    });
+
+    if (!delivery) {
+      throw new Error(`Delivery ${deliveryId} not found`);
+    }
+
+    const { subscription } = delivery;
+
+    if (!subscription || !subscription.isActive) {
+      delivery.status = WebhookDeliveryStatus.FAILED;
+      delivery.responseBody = 'Subscription inactive or deleted';
+      await this.deliveryRepository.save(delivery);
+      return;
+    }
+
+    delivery.attemptCount += 1;
+    delivery.lastAttemptAt = new Date();
+    await this.deliveryRepository.save(delivery);
+
+    const result = await this.sendHttpRequest(subscription, delivery.payload);
+
+    delivery.responseStatus = result.responseStatus;
+    delivery.responseBody = result.responseBody;
+
+    if (result.success) {
+      delivery.status = WebhookDeliveryStatus.DELIVERED;
+      await this.deliveryRepository.save(delivery);
+
+      // Reset consecutive failures on success
+      subscription.consecutiveFailures = 0;
+      await this.subscriptionRepository.save(subscription);
+    } else {
+      // Throw so Bull can retry
+      await this.deliveryRepository.save(delivery);
+      throw new Error(
+        `Webhook delivery failed: HTTP ${result.responseStatus ?? 'no-response'}`,
+      );
+    }
+  }
+
+  async handleDeliveryJobFailed(deliveryId: string): Promise<void> {
+    const delivery = await this.deliveryRepository.findOne({
+      where: { id: deliveryId },
+      relations: ['subscription'],
+    });
+
+    if (!delivery) return;
+
+    delivery.status = WebhookDeliveryStatus.FAILED;
+    await this.deliveryRepository.save(delivery);
+
+    const subscription = delivery.subscription;
+    if (!subscription) return;
+
+    subscription.consecutiveFailures += 1;
+    this.logger.warn(
+      `Webhook ${subscription.id} consecutive failures: ${subscription.consecutiveFailures}`,
+    );
+
+    if (subscription.consecutiveFailures >= MAX_CONSECUTIVE_FAILURES) {
+      subscription.isActive = false;
+      this.logger.error(
+        `Webhook subscription ${subscription.id} deactivated after ${MAX_CONSECUTIVE_FAILURES} consecutive failures`,
+      );
+      await this.subscriptionRepository.save(subscription);
+      await this.notifySuperAdminsOfDeactivation(subscription);
+    } else {
+      await this.subscriptionRepository.save(subscription);
+    }
+  }
+
+  // ─── Signature ───────────────────────────────────────────────────────────────
+
+  generateSignature(payloadString: string, secret: string): string {
+    const hmac = createHmac('sha256', secret);
+    hmac.update(payloadString);
+    return `sha256=${hmac.digest('hex')}`;
+  }
+
+  // ─── Private Helpers ─────────────────────────────────────────────────────────
+
+  private async findOneOrFail(id: string): Promise<WebhookSubscription> {
+    const subscription = await this.subscriptionRepository.findOne({ where: { id } });
+    if (!subscription) {
+      throw new NotFoundException(`Webhook subscription ${id} not found`);
+    }
+    return subscription;
+  }
+
+  private async sendHttpRequest(
+    subscription: WebhookSubscription,
+    payload: Record<string, any>,
+  ): Promise<{ success: boolean; responseStatus: number | null; responseBody: string }> {
+    const payloadString = JSON.stringify(payload);
+    const signature = this.generateSignature(payloadString, subscription.secret);
+
+    try {
+      const response = await fetch(subscription.url, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-GG-Signature': signature,
+          'User-Agent': 'GaslessGossip-Webhooks/1.0',
+        },
+        body: payloadString,
+        signal: AbortSignal.timeout(10_000),
+      });
+
+      const responseBody = await response.text().catch(() => '');
+      const success = response.status >= 200 && response.status < 300;
+
+      return { success, responseStatus: response.status, responseBody };
+    } catch (err) {
+      this.logger.error(`HTTP request to ${subscription.url} failed: ${err.message}`);
+      return { success: false, responseStatus: null, responseBody: err.message };
+    }
+  }
+
+  private async notifySuperAdminsOfDeactivation(
+    subscription: WebhookSubscription,
+  ): Promise<void> {
+    try {
+      const superAdmins = await this.userRepository.find({
+        where: { role: UserRole.SUPER_ADMIN },
+      });
+
+      if (superAdmins.length === 0) return;
+
+      const notifications = superAdmins.map((admin) =>
+        this.notificationRepository.create({
+          recipientId: admin.id,
+          senderId: null,
+          type: NotificationType.SYSTEM,
+          title: 'Webhook subscription deactivated',
+          message: `Webhook subscription for ${subscription.url} was automatically deactivated after ${MAX_CONSECUTIVE_FAILURES} consecutive delivery failures.`,
+          priority: NotificationPriority.HIGH,
+          data: { webhookId: subscription.id, url: subscription.url },
+          isRead: false,
+        }),
+      );
+
+      await this.notificationRepository.save(notifications);
+    } catch (err) {
+      this.logger.error(`Failed to notify super admins: ${err.message}`);
+    }
+  }
+}

--- a/src/database/migrations/1771800000000-CreateWebhookSubscriptionsTable.ts
+++ b/src/database/migrations/1771800000000-CreateWebhookSubscriptionsTable.ts
@@ -1,0 +1,111 @@
+import {
+  MigrationInterface,
+  QueryRunner,
+  Table,
+  TableForeignKey,
+  TableIndex,
+} from 'typeorm';
+
+export class CreateWebhookSubscriptionsTable1771800000000 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // Add new webhook audit actions to the existing audit_logs action enum
+    await queryRunner.query(`
+      ALTER TYPE "audit_logs_action_enum"
+        ADD VALUE IF NOT EXISTS 'webhook.created'
+    `);
+    await queryRunner.query(`
+      ALTER TYPE "audit_logs_action_enum"
+        ADD VALUE IF NOT EXISTS 'webhook.updated'
+    `);
+    await queryRunner.query(`
+      ALTER TYPE "audit_logs_action_enum"
+        ADD VALUE IF NOT EXISTS 'webhook.deleted'
+    `);
+    await queryRunner.query(`
+      ALTER TYPE "audit_logs_action_enum"
+        ADD VALUE IF NOT EXISTS 'webhook.tested'
+    `);
+
+    await queryRunner.createTable(
+      new Table({
+        name: 'webhook_subscriptions',
+        columns: [
+          {
+            name: 'id',
+            type: 'uuid',
+            isPrimary: true,
+            isGenerated: true,
+            generationStrategy: 'uuid',
+          },
+          {
+            name: 'url',
+            type: 'varchar',
+            isNullable: false,
+          },
+          {
+            name: 'secret',
+            type: 'varchar',
+            isNullable: false,
+          },
+          {
+            name: 'events',
+            type: 'simple-array',
+            isNullable: false,
+          },
+          {
+            name: 'isActive',
+            type: 'boolean',
+            default: true,
+            isNullable: false,
+          },
+          {
+            name: 'description',
+            type: 'text',
+            isNullable: true,
+          },
+          {
+            name: 'consecutiveFailures',
+            type: 'int',
+            default: 0,
+            isNullable: false,
+          },
+          {
+            name: 'createdById',
+            type: 'uuid',
+            isNullable: false,
+          },
+          {
+            name: 'createdAt',
+            type: 'timestamp',
+            default: 'CURRENT_TIMESTAMP',
+            isNullable: false,
+          },
+          {
+            name: 'updatedAt',
+            type: 'timestamp',
+            default: 'CURRENT_TIMESTAMP',
+            onUpdate: 'CURRENT_TIMESTAMP',
+            isNullable: false,
+          },
+        ],
+        foreignKeys: [
+          new TableForeignKey({
+            columnNames: ['createdById'],
+            referencedTableName: 'users',
+            referencedColumnNames: ['id'],
+            onDelete: 'RESTRICT',
+          }),
+        ],
+        indices: [
+          new TableIndex({ columnNames: ['isActive', 'createdAt'] }),
+          new TableIndex({ columnNames: ['createdById'] }),
+        ],
+      }),
+      true,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropTable('webhook_subscriptions');
+  }
+}

--- a/src/database/migrations/1771800000001-CreateWebhookDeliveriesTable.ts
+++ b/src/database/migrations/1771800000001-CreateWebhookDeliveriesTable.ts
@@ -1,0 +1,100 @@
+import {
+  MigrationInterface,
+  QueryRunner,
+  Table,
+  TableForeignKey,
+  TableIndex,
+} from 'typeorm';
+
+export class CreateWebhookDeliveriesTable1771800000001 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.createTable(
+      new Table({
+        name: 'webhook_deliveries',
+        columns: [
+          {
+            name: 'id',
+            type: 'uuid',
+            isPrimary: true,
+            isGenerated: true,
+            generationStrategy: 'uuid',
+          },
+          {
+            name: 'subscriptionId',
+            type: 'uuid',
+            isNullable: false,
+          },
+          {
+            name: 'event',
+            type: 'varchar',
+            isNullable: false,
+          },
+          {
+            name: 'payload',
+            type: 'jsonb',
+            isNullable: false,
+          },
+          {
+            name: 'status',
+            type: 'enum',
+            enum: ['pending', 'delivered', 'failed'],
+            default: "'pending'",
+            isNullable: false,
+          },
+          {
+            name: 'responseStatus',
+            type: 'int',
+            isNullable: true,
+          },
+          {
+            name: 'responseBody',
+            type: 'text',
+            isNullable: true,
+          },
+          {
+            name: 'attemptCount',
+            type: 'int',
+            default: 0,
+            isNullable: false,
+          },
+          {
+            name: 'lastAttemptAt',
+            type: 'timestamp',
+            isNullable: true,
+          },
+          {
+            name: 'createdAt',
+            type: 'timestamp',
+            default: 'CURRENT_TIMESTAMP',
+            isNullable: false,
+          },
+          {
+            name: 'updatedAt',
+            type: 'timestamp',
+            default: 'CURRENT_TIMESTAMP',
+            onUpdate: 'CURRENT_TIMESTAMP',
+            isNullable: false,
+          },
+        ],
+        foreignKeys: [
+          new TableForeignKey({
+            columnNames: ['subscriptionId'],
+            referencedTableName: 'webhook_subscriptions',
+            referencedColumnNames: ['id'],
+            onDelete: 'CASCADE',
+          }),
+        ],
+        indices: [
+          new TableIndex({ columnNames: ['subscriptionId', 'createdAt'] }),
+          new TableIndex({ columnNames: ['status', 'createdAt'] }),
+          new TableIndex({ columnNames: ['event', 'createdAt'] }),
+        ],
+      }),
+      true,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropTable('webhook_deliveries');
+  }
+}

--- a/src/queue/queue.constants.ts
+++ b/src/queue/queue.constants.ts
@@ -2,4 +2,5 @@ export const QUEUE_NAMES = {
   WALLET_CREATION: 'wallet-creation',
   NOTIFICATIONS: 'notifications',
   BLOCKCHAIN_TASKS: 'blockchain-tasks',
+  WEBHOOK_DELIVERIES: 'webhook-deliveries',
 };

--- a/src/queue/queue.module.ts
+++ b/src/queue/queue.module.ts
@@ -38,6 +38,7 @@ import { QUEUE_NAMES } from './queue.constants';
       { name: QUEUE_NAMES.WALLET_CREATION },
       { name: QUEUE_NAMES.NOTIFICATIONS },
       { name: QUEUE_NAMES.BLOCKCHAIN_TASKS },
+      { name: QUEUE_NAMES.WEBHOOK_DELIVERIES },
     ),
   ],
   providers: [

--- a/test/admin-webhooks.e2e-spec.ts
+++ b/test/admin-webhooks.e2e-spec.ts
@@ -1,0 +1,295 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import * as request from 'supertest';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { getQueueToken } from '@nestjs/bull';
+import { WebhookController } from '../src/admin/controllers/webhook.controller';
+import { WebhookService } from '../src/admin/services/webhook.service';
+import { WebhookSubscription } from '../src/admin/entities/webhook-subscription.entity';
+import {
+  WebhookDelivery,
+  WebhookDeliveryStatus,
+} from '../src/admin/entities/webhook-delivery.entity';
+import { User } from '../src/user/entities/user.entity';
+import { Notification } from '../src/notifications/entities/notification.entity';
+import { AuditLogService } from '../src/admin/services/audit-log.service';
+import { QUEUE_NAMES } from '../src/queue/queue.constants';
+import { RoleGuard } from '../src/roles/guards/role.guard';
+import { WebhookEvent } from '../src/admin/enums/webhook-event.enum';
+
+const SUPER_ADMIN_ID = 'super-admin-uuid';
+
+const mockUser = {
+  id: SUPER_ADMIN_ID,
+  role: 'super_admin',
+  roles: [{ name: 'super_admin' }],
+};
+
+const mockSubscription = {
+  id: 'sub-uuid-1',
+  url: 'https://example.com/hook',
+  secret: 'stored-secret-never-exposed',
+  events: [WebhookEvent.USER_REGISTERED],
+  isActive: true,
+  consecutiveFailures: 0,
+  createdById: SUPER_ADMIN_ID,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+
+describe('Webhook Subscriptions (e2e)', () => {
+  let app: INestApplication;
+  let webhookService: WebhookService;
+  let subscriptionRepo: any;
+  let deliveryRepo: any;
+  let webhookQueue: any;
+
+  beforeAll(async () => {
+    subscriptionRepo = {
+      find: jest.fn().mockResolvedValue([mockSubscription]),
+      findOne: jest.fn().mockResolvedValue(mockSubscription),
+      create: jest.fn().mockImplementation((d) => d),
+      save: jest.fn().mockImplementation((d) => Promise.resolve({ ...d, id: d.id ?? 'new-id' })),
+      remove: jest.fn().mockResolvedValue(undefined),
+    };
+    deliveryRepo = {
+      find: jest.fn().mockResolvedValue([]),
+      findOne: jest.fn().mockResolvedValue(null),
+      findAndCount: jest.fn().mockResolvedValue([[], 0]),
+      create: jest.fn().mockImplementation((d) => d),
+      save: jest.fn().mockImplementation((d) => Promise.resolve({ ...d, id: d.id ?? 'del-id' })),
+    };
+    webhookQueue = {
+      add: jest.fn().mockResolvedValue({ id: 'job-1' }),
+    };
+
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      controllers: [WebhookController],
+      providers: [
+        WebhookService,
+        { provide: getRepositoryToken(WebhookSubscription), useValue: subscriptionRepo },
+        { provide: getRepositoryToken(WebhookDelivery), useValue: deliveryRepo },
+        { provide: getRepositoryToken(User), useValue: { find: jest.fn().mockResolvedValue([]) } },
+        { provide: getRepositoryToken(Notification), useValue: { create: jest.fn(), save: jest.fn() } },
+        { provide: getQueueToken(QUEUE_NAMES.WEBHOOK_DELIVERIES), useValue: webhookQueue },
+        { provide: AuditLogService, useValue: { createAuditLog: jest.fn().mockResolvedValue({}) } },
+      ],
+    })
+      .overrideGuard(RoleGuard)
+      .useValue({ canActivate: () => true })
+      .compile();
+
+    app = moduleFixture.createNestApplication();
+    app.useGlobalPipes(
+      new ValidationPipe({ whitelist: true, transform: true, forbidNonWhitelisted: true }),
+    );
+
+    // Inject mock user into every request
+    app.use((req: any, _res: any, next: any) => {
+      req.user = mockUser;
+      next();
+    });
+
+    webhookService = moduleFixture.get<WebhookService>(WebhookService);
+
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  // ─── GET /admin/webhooks ─────────────────────────────────────────────────────
+
+  describe('GET /admin/webhooks', () => {
+    it('returns list of subscriptions', async () => {
+      const res = await request(app.getHttpServer())
+        .get('/admin/webhooks')
+        .expect(200);
+
+      expect(Array.isArray(res.body)).toBe(true);
+    });
+  });
+
+  // ─── POST /admin/webhooks ────────────────────────────────────────────────────
+
+  describe('POST /admin/webhooks', () => {
+    it('creates a subscription and returns the plainSecret once', async () => {
+      subscriptionRepo.create.mockImplementation((d) => ({ ...d, id: 'new-sub-id' }));
+      subscriptionRepo.save.mockResolvedValue({ ...mockSubscription, id: 'new-sub-id' });
+
+      const res = await request(app.getHttpServer())
+        .post('/admin/webhooks')
+        .send({ url: 'https://example.com/hook', events: [WebhookEvent.USER_REGISTERED] })
+        .expect(201);
+
+      expect(res.body.plainSecret).toBeDefined();
+      expect(res.body.plainSecret).toHaveLength(64);
+    });
+
+    it('rejects non-HTTPS URLs', async () => {
+      await request(app.getHttpServer())
+        .post('/admin/webhooks')
+        .send({ url: 'http://example.com/hook', events: [WebhookEvent.USER_REGISTERED] })
+        .expect(400);
+    });
+
+    it('rejects empty events array', async () => {
+      await request(app.getHttpServer())
+        .post('/admin/webhooks')
+        .send({ url: 'https://example.com/hook', events: [] })
+        .expect(400);
+    });
+
+    it('rejects invalid event names', async () => {
+      await request(app.getHttpServer())
+        .post('/admin/webhooks')
+        .send({ url: 'https://example.com/hook', events: ['not.a.real.event'] })
+        .expect(400);
+    });
+  });
+
+  // ─── PATCH /admin/webhooks/:id ───────────────────────────────────────────────
+
+  describe('PATCH /admin/webhooks/:id', () => {
+    it('updates a subscription', async () => {
+      subscriptionRepo.findOne.mockResolvedValue({ ...mockSubscription });
+      subscriptionRepo.save.mockImplementation((s) => Promise.resolve(s));
+
+      const res = await request(app.getHttpServer())
+        .patch('/admin/webhooks/sub-uuid-1')
+        .send({ isActive: false })
+        .expect(200);
+
+      expect(res.body.isActive).toBe(false);
+    });
+
+    it('returns 404 for unknown subscription', async () => {
+      subscriptionRepo.findOne.mockResolvedValue(null);
+
+      await request(app.getHttpServer())
+        .patch('/admin/webhooks/nonexistent-id')
+        .send({ isActive: false })
+        .expect(404);
+    });
+  });
+
+  // ─── DELETE /admin/webhooks/:id ──────────────────────────────────────────────
+
+  describe('DELETE /admin/webhooks/:id', () => {
+    it('deletes a subscription and returns 204', async () => {
+      subscriptionRepo.findOne.mockResolvedValue({ ...mockSubscription });
+      subscriptionRepo.remove.mockResolvedValue(undefined);
+
+      await request(app.getHttpServer())
+        .delete('/admin/webhooks/sub-uuid-1')
+        .expect(204);
+    });
+  });
+
+  // ─── POST /admin/webhooks/:id/test ───────────────────────────────────────────
+
+  describe('POST /admin/webhooks/:id/test', () => {
+    it('returns response status and body from test ping', async () => {
+      subscriptionRepo.findOne.mockResolvedValue({ ...mockSubscription });
+
+      // Mock the HTTP fetch call
+      const mockFetch = jest.fn().mockResolvedValue({
+        status: 200,
+        text: async () => 'OK',
+      });
+      global.fetch = mockFetch as any;
+
+      const res = await request(app.getHttpServer())
+        .post('/admin/webhooks/sub-uuid-1/test')
+        .expect(201);
+
+      expect(res.body).toHaveProperty('responseStatus');
+      expect(res.body).toHaveProperty('responseBody');
+    });
+  });
+
+  // ─── GET /admin/webhooks/:id/deliveries ──────────────────────────────────────
+
+  describe('GET /admin/webhooks/:id/deliveries', () => {
+    it('returns paginated delivery history', async () => {
+      subscriptionRepo.findOne.mockResolvedValue({ ...mockSubscription });
+      deliveryRepo.findAndCount.mockResolvedValue([[{ id: 'del-1' }], 1]);
+
+      const res = await request(app.getHttpServer())
+        .get('/admin/webhooks/sub-uuid-1/deliveries')
+        .expect(200);
+
+      expect(res.body).toMatchObject({
+        data: expect.any(Array),
+        total: 1,
+        page: 1,
+        limit: 20,
+      });
+    });
+
+    it('accepts status filter', async () => {
+      subscriptionRepo.findOne.mockResolvedValue({ ...mockSubscription });
+      deliveryRepo.findAndCount.mockResolvedValue([[], 0]);
+
+      await request(app.getHttpServer())
+        .get('/admin/webhooks/sub-uuid-1/deliveries?status=failed')
+        .expect(200);
+    });
+  });
+
+  // ─── POST /admin/webhooks/deliveries/:id/retry ───────────────────────────────
+
+  describe('POST /admin/webhooks/deliveries/:deliveryId/retry', () => {
+    it('returns 400 when delivery is not failed', async () => {
+      deliveryRepo.findOne.mockResolvedValue({
+        ...mockSubscription,
+        id: 'del-1',
+        status: WebhookDeliveryStatus.DELIVERED,
+      });
+
+      await request(app.getHttpServer())
+        .post('/admin/webhooks/deliveries/del-1/retry')
+        .expect(400);
+    });
+
+    it('enqueues a retry job for a failed delivery', async () => {
+      const failedDelivery = {
+        id: 'del-1',
+        subscriptionId: 'sub-uuid-1',
+        event: WebhookEvent.USER_REGISTERED,
+        payload: {},
+        status: WebhookDeliveryStatus.FAILED,
+        attemptCount: 3,
+        responseStatus: 500,
+        responseBody: 'error',
+      };
+      deliveryRepo.findOne.mockResolvedValue(failedDelivery);
+      deliveryRepo.save.mockImplementation((d) => Promise.resolve(d));
+
+      const res = await request(app.getHttpServer())
+        .post('/admin/webhooks/deliveries/del-1/retry')
+        .expect(201);
+
+      expect(res.body.status).toBe(WebhookDeliveryStatus.PENDING);
+      expect(webhookQueue.add).toHaveBeenCalled();
+    });
+  });
+
+  // ─── Signature verification ──────────────────────────────────────────────────
+
+  describe('Signature generation', () => {
+    it('signs payload with HMAC-SHA256 and prefixes with sha256=', () => {
+      const service = app.get(WebhookService);
+      const sig = service.generateSignature('{"event":"test"}', 'secret-key');
+      expect(sig).toMatch(/^sha256=[0-9a-f]{64}$/);
+    });
+
+    it('different payloads produce different signatures', () => {
+      const service = app.get(WebhookService);
+      const s1 = service.generateSignature('payload-one', 'same-secret');
+      const s2 = service.generateSignature('payload-two', 'same-secret');
+      expect(s1).not.toEqual(s2);
+    });
+  });
+});


### PR DESCRIPTION
Closes #248

---

This PR closes issue #248 
Adds a full webhook delivery system allowing external services to subscribe to platform events via HTTPS endpoints.

- WebhookSubscription entity: url, secret (HMAC), events[], isActive, description, consecutiveFailures, createdBy, timestamps
- WebhookDelivery entity: subscriptionId, event, payload (JSONB), status (pending|delivered|failed), responseStatus/Body, attemptCount, lastAttemptAt
- Migrations for both tables + ALTER TYPE to add webhook audit actions
- WebhookEvent enum: 9 supported events (user.registered, user.banned, user.level_up, room.created/closed, transaction.confirmed/failed, platform.maintenance_start/end)
- GET/POST/PATCH/DELETE /admin/webhooks — CRUD (SUPER_ADMIN only)
- POST /admin/webhooks/:id/test — live ping with response echoed back
- GET /admin/webhooks/:id/deliveries — paginated history with filters
- POST /admin/webhooks/deliveries/:id/retry — reset + re-queue failed delivery
- HMAC-SHA256 signing via X-GG-Signature header (sha256=<hex>)
- Auto-retry: Bull exponential backoff, 3 attempts per delivery
- Auto-deactivation after 5 consecutive delivery failures + in-app notification to all SUPER_ADMIN users
- Full audit log for create, update, delete, test actions
- Unit tests covering signature generation, CRUD, dispatch, retry logic
- E2E tests covering all endpoints and validation