### PR TITLE
feat(rooms): implement search, filtering, trending, and discovery

### DIFF
--- a/src/database/migrations/1771900000000-AddRoomSearchFeatures.ts
+++ b/src/database/migrations/1771900000000-AddRoomSearchFeatures.ts
@@ -1,0 +1,95 @@
+import { MigrationInterface, QueryRunner, Table, TableIndex } from 'typeorm';
+
+export class AddRoomSearchFeatures1771900000000 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // 1. Add category and tags columns to rooms table
+    await queryRunner.query(`
+      ALTER TABLE rooms
+        ADD COLUMN IF NOT EXISTS "category" varchar NULL,
+        ADD COLUMN IF NOT EXISTS "tags" text NULL
+    `);
+
+    // 2. Add GIN index on to_tsvector for full-text search on name + description
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS idx_rooms_fts
+        ON rooms
+        USING GIN (to_tsvector('english', name || ' ' || COALESCE(description, '')))
+    `);
+
+    // 3. Add index on category for fast filtering
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS idx_rooms_category
+        ON rooms ("category")
+        WHERE "isDeleted" = false AND "isActive" = true
+    `);
+
+    // 4. Add index on memberCount for popular/trending sort
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS idx_rooms_member_count
+        ON rooms ("memberCount" DESC)
+        WHERE "isDeleted" = false AND "isActive" = true AND "isPrivate" = false
+    `);
+
+    // 5. Create room_search_analytics table
+    await queryRunner.createTable(
+      new Table({
+        name: 'room_search_analytics',
+        columns: [
+          {
+            name: 'id',
+            type: 'uuid',
+            isPrimary: true,
+            isGenerated: true,
+            generationStrategy: 'uuid',
+          },
+          {
+            name: 'query',
+            type: 'text',
+            isNullable: true,
+          },
+          {
+            name: 'userId',
+            type: 'uuid',
+            isNullable: true,
+          },
+          {
+            name: 'resultCount',
+            type: 'int',
+            default: 0,
+            isNullable: false,
+          },
+          {
+            name: 'filters',
+            type: 'jsonb',
+            isNullable: true,
+          },
+          {
+            name: 'createdAt',
+            type: 'timestamp',
+            default: 'CURRENT_TIMESTAMP',
+            isNullable: false,
+          },
+        ],
+        indices: [
+          new TableIndex({ columnNames: ['userId', 'createdAt'] }),
+          new TableIndex({ columnNames: ['createdAt'] }),
+        ],
+      }),
+      true,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropTable('room_search_analytics');
+
+    await queryRunner.query(`DROP INDEX IF EXISTS idx_rooms_fts`);
+    await queryRunner.query(`DROP INDEX IF EXISTS idx_rooms_category`);
+    await queryRunner.query(`DROP INDEX IF EXISTS idx_rooms_member_count`);
+
+    await queryRunner.query(`
+      ALTER TABLE rooms
+        DROP COLUMN IF EXISTS "category",
+        DROP COLUMN IF EXISTS "tags"
+    `);
+  }
+}

--- a/src/room/controllers/room-search.controller.ts
+++ b/src/room/controllers/room-search.controller.ts
@@ -1,0 +1,66 @@
+import {
+  Controller,
+  Get,
+  Query,
+  UseGuards,
+} from '@nestjs/common';
+import {
+  ApiTags,
+  ApiBearerAuth,
+  ApiOperation,
+  ApiResponse,
+} from '@nestjs/swagger';
+import { JwtAuthGuard } from '../../auth/guards/jwt-auth.guard';
+import { CurrentUser } from '../../auth/decorators/current-user.decorator';
+import { RoomSearchService } from '../services/room-search.service';
+import { RoomSearchDto, TrendingRoomsDto } from '../dto/room-search.dto';
+
+@ApiTags('rooms')
+@ApiBearerAuth()
+@UseGuards(JwtAuthGuard)
+@Controller('rooms')
+export class RoomSearchController {
+  constructor(private readonly roomSearchService: RoomSearchService) {}
+
+  @Get('search')
+  @ApiOperation({
+    summary: 'Search and filter public rooms',
+    description:
+      'Full-text search on room name/description with filters for type, category, tags, member count, and entry fee. Results are cached for 60 seconds.',
+  })
+  @ApiResponse({ status: 200, description: 'Paginated search results' })
+  async search(
+    @Query() dto: RoomSearchDto,
+    @CurrentUser() user: any,
+  ) {
+    const userId = (user?.user ?? user)?.id;
+    return this.roomSearchService.search(dto, userId);
+  }
+
+  @Get('trending')
+  @ApiOperation({
+    summary: 'Get trending rooms',
+    description:
+      'Returns rooms ranked by a trending score combining member count, growth rate, and recency. Cached for 5 minutes.',
+  })
+  @ApiResponse({ status: 200, description: 'List of trending rooms' })
+  async trending(@Query() dto: TrendingRoomsDto) {
+    return this.roomSearchService.getTrending(dto);
+  }
+
+  @Get('recommended')
+  @ApiOperation({
+    summary: 'Get recommended rooms for the current user',
+    description:
+      'Returns rooms based on the categories and tags of rooms the user has joined. Falls back to trending rooms if no preference data is available. Cached per user for 10 minutes.',
+  })
+  @ApiResponse({ status: 200, description: 'List of recommended rooms' })
+  async recommended(
+    @CurrentUser() user: any,
+    @Query('limit') limit?: number,
+  ) {
+    const userId = (user?.user ?? user)?.id;
+    const safeLimit = Math.min(Math.max(Number(limit) || 10, 1), 50);
+    return this.roomSearchService.getRecommended(userId, safeLimit);
+  }
+}

--- a/src/room/dto/create-room.dto.ts
+++ b/src/room/dto/create-room.dto.ts
@@ -5,14 +5,17 @@ import {
   IsNumber,
   IsEnum,
   IsInt,
+  IsArray,
   Min,
   Max,
   MinLength,
   MaxLength,
   IsDateString,
+  ArrayMaxSize,
 } from 'class-validator';
 import { RoomType } from '../entities/room.entity';
 import { ROOM_MEMBER_CONSTANTS } from '../constants/room-member.constants';
+import { RoomCategory } from '../enums/room-category.enum';
 
 export class CreateRoomDto {
   @IsString()
@@ -84,4 +87,15 @@ export class CreateRoomDto {
   @IsDateString()
   @IsOptional()
   expiresAt?: string;
+
+  @IsEnum(RoomCategory)
+  @IsOptional()
+  category?: RoomCategory;
+
+  @IsArray()
+  @IsString({ each: true })
+  @MaxLength(30, { each: true })
+  @ArrayMaxSize(10)
+  @IsOptional()
+  tags?: string[];
 }

--- a/src/room/dto/room-search.dto.ts
+++ b/src/room/dto/room-search.dto.ts
@@ -1,0 +1,105 @@
+import {
+  IsString,
+  IsOptional,
+  IsEnum,
+  IsBoolean,
+  IsInt,
+  IsArray,
+  Min,
+  Max,
+  MaxLength,
+} from 'class-validator';
+import { Type, Transform } from 'class-transformer';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { RoomType } from '../entities/room.entity';
+import { RoomCategory } from '../enums/room-category.enum';
+
+export enum RoomSortBy {
+  NEWEST = 'newest',
+  POPULAR = 'popular',
+  ACTIVE = 'active',
+}
+
+export class RoomSearchDto {
+  @ApiPropertyOptional({ description: 'Full-text search across room name and description' })
+  @IsOptional()
+  @IsString()
+  @MaxLength(100)
+  q?: string;
+
+  @ApiPropertyOptional({ enum: RoomType })
+  @IsOptional()
+  @IsEnum(RoomType)
+  roomType?: RoomType;
+
+  @ApiPropertyOptional({ enum: RoomCategory })
+  @IsOptional()
+  @IsEnum(RoomCategory)
+  category?: RoomCategory;
+
+  @ApiPropertyOptional({
+    description: 'Comma-separated list of tags to filter by',
+    example: 'defi,nft',
+  })
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  @Transform(({ value }) =>
+    typeof value === 'string' ? value.split(',').map((t: string) => t.trim()).filter(Boolean) : value,
+  )
+  tags?: string[];
+
+  @ApiPropertyOptional({ minimum: 0, description: 'Minimum member count' })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(0)
+  minMembers?: number;
+
+  @ApiPropertyOptional({ minimum: 0, description: 'Maximum member count' })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(0)
+  maxMembers?: number;
+
+  @ApiPropertyOptional({ description: 'Filter rooms that require an entry fee' })
+  @IsOptional()
+  @Transform(({ value }) => {
+    if (value === 'true') return true;
+    if (value === 'false') return false;
+    return value;
+  })
+  @IsBoolean()
+  hasEntryFee?: boolean;
+
+  @ApiPropertyOptional({ enum: RoomSortBy, default: RoomSortBy.NEWEST })
+  @IsOptional()
+  @IsEnum(RoomSortBy)
+  sortBy?: RoomSortBy = RoomSortBy.NEWEST;
+
+  @ApiPropertyOptional({ default: 1, minimum: 1 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  page?: number = 1;
+
+  @ApiPropertyOptional({ default: 20, minimum: 1, maximum: 50 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(50)
+  limit?: number = 20;
+}
+
+export class TrendingRoomsDto {
+  @ApiPropertyOptional({ default: 10, minimum: 1, maximum: 50 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(50)
+  limit?: number = 10;
+}

--- a/src/room/entities/room-search-analytics.entity.ts
+++ b/src/room/entities/room-search-analytics.entity.ts
@@ -1,0 +1,30 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  Index,
+} from 'typeorm';
+
+@Entity('room_search_analytics')
+@Index(['userId', 'createdAt'])
+@Index(['createdAt'])
+export class RoomSearchAnalytics {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ type: 'text', nullable: true })
+  query: string | null;
+
+  @Column({ type: 'uuid', nullable: true })
+  userId: string | null;
+
+  @Column({ type: 'int', default: 0 })
+  resultCount: number;
+
+  @Column('jsonb', { nullable: true })
+  filters: Record<string, any> | null;
+
+  @CreateDateColumn()
+  createdAt: Date;
+}

--- a/src/room/entities/room.entity.ts
+++ b/src/room/entities/room.entity.ts
@@ -122,6 +122,12 @@ export class Room {
   @Column({ type: 'text', nullable: true })
   closeReason?: string;
 
+  @Column({ type: 'varchar', nullable: true })
+  category?: string;
+
+  @Column('simple-array', { nullable: true })
+  tags?: string[];
+
   @OneToMany(() => RoomPayment, (payment) => payment.room)
   payments!: RoomPayment[];
 

--- a/src/room/enums/room-category.enum.ts
+++ b/src/room/enums/room-category.enum.ts
@@ -1,0 +1,12 @@
+export enum RoomCategory {
+  GAMING = 'gaming',
+  CRYPTO = 'crypto',
+  SOCIAL = 'social',
+  EDUCATION = 'education',
+  ENTERTAINMENT = 'entertainment',
+  SPORTS = 'sports',
+  TECHNOLOGY = 'technology',
+  MUSIC = 'music',
+  ART = 'art',
+  OTHER = 'other',
+}

--- a/src/room/repositories/room.repository.ts
+++ b/src/room/repositories/room.repository.ts
@@ -1,6 +1,20 @@
 import { Injectable } from '@nestjs/common';
-import { DataSource, Repository } from 'typeorm';
-import { Room } from '../entities/room.entity';
+import { DataSource, Repository, SelectQueryBuilder } from 'typeorm';
+import { Room, RoomType } from '../entities/room.entity';
+import { RoomSortBy } from '../dto/room-search.dto';
+
+export interface RoomSearchFilters {
+  q?: string;
+  roomType?: RoomType;
+  category?: string;
+  tags?: string[];
+  minMembers?: number;
+  maxMembers?: number;
+  hasEntryFee?: boolean;
+  sortBy?: RoomSortBy;
+  page?: number;
+  limit?: number;
+}
 
 @Injectable()
 export class RoomRepository extends Repository<Room> {
@@ -30,5 +44,181 @@ export class RoomRepository extends Repository<Room> {
       deletedAt: new Date(),
       isActive: false,
     });
+  }
+
+  // ─── Search & Discovery ────────────────────────────────────────────────────
+
+  async searchRooms(
+    filters: RoomSearchFilters,
+  ): Promise<[Room[], number]> {
+    const {
+      q,
+      roomType,
+      category,
+      tags,
+      minMembers,
+      maxMembers,
+      hasEntryFee,
+      sortBy = RoomSortBy.NEWEST,
+      page = 1,
+      limit = 20,
+    } = filters;
+
+    const qb = this.createBaseDiscoveryQuery();
+
+    // Full-text search on name and description
+    if (q && q.trim()) {
+      const trimmed = q.trim();
+      qb.andWhere(
+        `(
+          to_tsvector('english', r.name || ' ' || COALESCE(r.description, ''))
+            @@ plainto_tsquery('english', :tsquery)
+          OR r.name ILIKE :ilike
+          OR r.description ILIKE :ilike
+        )`,
+        { tsquery: trimmed, ilike: `%${trimmed}%` },
+      );
+    }
+
+    if (roomType) {
+      qb.andWhere('r.roomType = :roomType', { roomType });
+    }
+
+    if (category) {
+      qb.andWhere('r.category = :category', { category });
+    }
+
+    // Tag filtering: any room that contains all specified tags
+    if (tags && tags.length > 0) {
+      tags.forEach((tag, idx) => {
+        qb.andWhere(`r.tags LIKE :tag${idx}`, { [`tag${idx}`]: `%${tag}%` });
+      });
+    }
+
+    if (minMembers !== undefined) {
+      qb.andWhere('r.memberCount >= :minMembers', { minMembers });
+    }
+
+    if (maxMembers !== undefined) {
+      qb.andWhere('r.memberCount <= :maxMembers', { maxMembers });
+    }
+
+    if (hasEntryFee === true) {
+      qb.andWhere('r.paymentRequired = true AND CAST(r.entry_fee AS DECIMAL) > 0');
+    } else if (hasEntryFee === false) {
+      qb.andWhere('(r.paymentRequired = false OR CAST(r.entry_fee AS DECIMAL) = 0)');
+    }
+
+    // Sorting
+    this.applySortOrder(qb, sortBy);
+
+    const skip = (page - 1) * limit;
+    qb.skip(skip).take(limit);
+
+    return qb.getManyAndCount();
+  }
+
+  async findTrendingRooms(limit: number): Promise<Room[]> {
+    // Trending = public/active rooms scored by member count + recency
+    // We pull a broader candidate set and score in memory
+    const candidateLimit = Math.min(limit * 10, 200);
+
+    const rooms = await this.createBaseDiscoveryQuery()
+      .andWhere('r.createdAt >= :since', {
+        since: new Date(Date.now() - 30 * 24 * 60 * 60 * 1000), // last 30 days
+      })
+      .orderBy('r.memberCount', 'DESC')
+      .take(candidateLimit)
+      .getMany();
+
+    return this.scoreTrending(rooms, limit);
+  }
+
+  async findRecommendedForUser(
+    userId: string,
+    joinedRoomIds: string[],
+    preferredCategories: string[],
+    preferredTags: string[],
+    limit: number,
+  ): Promise<Room[]> {
+    const qb = this.createBaseDiscoveryQuery();
+
+    // Exclude rooms the user already joined
+    if (joinedRoomIds.length > 0) {
+      qb.andWhere('r.id NOT IN (:...joinedRoomIds)', { joinedRoomIds });
+    }
+
+    // Prefer rooms with matching category or tags
+    if (preferredCategories.length > 0 || preferredTags.length > 0) {
+      const conditions: string[] = [];
+      if (preferredCategories.length > 0) {
+        conditions.push('r.category IN (:...preferredCategories)');
+        qb.setParameter('preferredCategories', preferredCategories);
+      }
+      if (preferredTags.length > 0) {
+        preferredTags.forEach((tag, idx) => {
+          conditions.push(`r.tags LIKE :recTag${idx}`);
+          qb.setParameter(`recTag${idx}`, `%${tag}%`);
+        });
+      }
+      qb.andWhere(`(${conditions.join(' OR ')})`);
+    }
+
+    return qb
+      .orderBy('r.memberCount', 'DESC')
+      .addOrderBy('r.createdAt', 'DESC')
+      .take(limit)
+      .getMany();
+  }
+
+  // ─── Private Helpers ───────────────────────────────────────────────────────
+
+  private createBaseDiscoveryQuery(): SelectQueryBuilder<Room> {
+    return this.createQueryBuilder('r')
+      .where('r.isDeleted = false')
+      .andWhere('r.isActive = true')
+      .andWhere('r.isClosed = false')
+      .andWhere('r.isPrivate = false')
+      .andWhere('r.roomType != :tokenGated', { tokenGated: RoomType.TOKEN_GATED });
+  }
+
+  private applySortOrder(qb: SelectQueryBuilder<Room>, sortBy: RoomSortBy): void {
+    switch (sortBy) {
+      case RoomSortBy.POPULAR:
+        qb.orderBy('r.memberCount', 'DESC').addOrderBy('r.createdAt', 'DESC');
+        break;
+      case RoomSortBy.ACTIVE:
+        qb.orderBy('r.memberCount', 'DESC').addOrderBy('r.updatedAt', 'DESC');
+        break;
+      case RoomSortBy.NEWEST:
+      default:
+        qb.orderBy('r.createdAt', 'DESC');
+        break;
+    }
+  }
+
+  private scoreTrending(rooms: Room[], limit: number): Room[] {
+    if (rooms.length === 0) return [];
+
+    const now = Date.now();
+    const maxMembers = Math.max(...rooms.map((r) => r.memberCount), 1);
+
+    const scored = rooms.map((room) => {
+      const memberScore = room.memberCount / maxMembers; // 0-1
+
+      const ageMs = now - new Date(room.createdAt).getTime();
+      const ageDays = Math.max(ageMs / (1000 * 60 * 60 * 24), 0.1);
+      // Recency: rooms created within 7 days get a boost; decays over time
+      const recencyScore = 1 / Math.sqrt(ageDays);
+
+      // Growth proxy: memberCount per day of existence
+      const growthScore = Math.min(room.memberCount / ageDays / 10, 1);
+
+      const score = memberScore * 0.5 + recencyScore * 0.3 + growthScore * 0.2;
+      return { room, score };
+    });
+
+    scored.sort((a, b) => b.score - a.score);
+    return scored.slice(0, limit).map((s) => s.room);
   }
 }

--- a/src/room/room.module.ts
+++ b/src/room/room.module.ts
@@ -17,6 +17,7 @@ import { UserRoomAccess } from './entities/user-room-access.entity';
 import { RoomBan } from './entities/room-ban.entity';
 import { RoomWhitelist } from './entities/room-whitelist.entity';
 import { RoomEmergencyPause } from './entities/room-emergency-pause.entity';
+import { RoomSearchAnalytics } from './entities/room-search-analytics.entity';
 
 // Controllers
 import {
@@ -24,12 +25,14 @@ import {
   RoomPaymentController,
   RoomSettingsController,
 } from './room.controller';
+import { RoomSearchController } from './controllers/room-search.controller';
 import { RoomMemberController } from './room-member.controller';
 import { RoomInvitationController } from './room-invitation.controller';
 import { RoomRoleController } from './room-role.controller';
 
 // Services
 import { RoomService, RoomSettingsService } from './room.service';
+import { RoomSearchService } from './services/room-search.service';
 import { RoomMemberService } from './services/room-member.service';
 import { RoomInvitationService } from './services/room-invitation.service';
 import { MemberPermissionsService } from './services/member-permissions.service';
@@ -69,6 +72,7 @@ import { PaymentExpirationJob } from './jobs/payment-expiration.job';
       RoomBan,
       RoomWhitelist,
       RoomEmergencyPause,
+      RoomSearchAnalytics,
     ]),
     ChainModule,
     CacheModule,
@@ -79,6 +83,7 @@ import { PaymentExpirationJob } from './jobs/payment-expiration.job';
     AdminModule,
   ],
   controllers: [
+    RoomSearchController,  // must be registered before RoomController to avoid :id swallowing /search
     RoomController,
     RoomSettingsController,
     RoomPaymentController,
@@ -89,6 +94,7 @@ import { PaymentExpirationJob } from './jobs/payment-expiration.job';
   providers: [
     RoomService,
     RoomSettingsService,
+    RoomSearchService,
     RoomMemberService,
     RoomInvitationService,
     MemberPermissionsService,

--- a/src/room/room.service.ts
+++ b/src/room/room.service.ts
@@ -177,6 +177,8 @@ export class RoomService {
       extensionCount: 0,
       isDeleted: false,
       deletedAt: undefined,
+      category: dto.category,
+      tags: dto.tags,
     });
 
     const saved = await this.roomRepository.save(room);
@@ -260,6 +262,12 @@ export class RoomService {
     }
     if (dto.accessDurationDays !== undefined) {
       room.accessDurationDays = dto.accessDurationDays;
+    }
+    if (dto.category !== undefined) {
+      room.category = dto.category;
+    }
+    if (dto.tags !== undefined) {
+      room.tags = dto.tags;
     }
 
     const timing = this.resolveTiming(

--- a/src/room/services/room-search.service.spec.ts
+++ b/src/room/services/room-search.service.spec.ts
@@ -1,0 +1,264 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { RoomSearchService } from './room-search.service';
+import { RoomRepository } from '../repositories/room.repository';
+import { RoomMember, MemberStatus } from '../entities/room-member.entity';
+import { RoomSearchAnalytics } from '../entities/room-search-analytics.entity';
+import { CacheService } from '../../cache/cache.service';
+import { RoomSearchDto, RoomSortBy, TrendingRoomsDto } from '../dto/room-search.dto';
+import { RoomType } from '../entities/room.entity';
+import { RoomCategory } from '../enums/room-category.enum';
+
+const mockRoom = (overrides = {}) => ({
+  id: 'room-uuid-1',
+  name: 'Test Room',
+  description: 'A test room',
+  roomType: RoomType.PUBLIC,
+  isPrivate: false,
+  isActive: true,
+  isDeleted: false,
+  isClosed: false,
+  memberCount: 10,
+  category: RoomCategory.CRYPTO,
+  tags: ['defi', 'nft'],
+  createdAt: new Date('2024-06-01'),
+  updatedAt: new Date(),
+  ...overrides,
+});
+
+describe('RoomSearchService', () => {
+  let service: RoomSearchService;
+  let roomRepository: any;
+  let memberRepository: any;
+  let analyticsRepository: any;
+  let cacheService: any;
+
+  beforeEach(async () => {
+    roomRepository = {
+      searchRooms: jest.fn(),
+      findTrendingRooms: jest.fn(),
+      findRecommendedForUser: jest.fn(),
+    };
+    memberRepository = {
+      find: jest.fn(),
+    };
+    analyticsRepository = {
+      createQueryBuilder: jest.fn().mockReturnValue({
+        where: jest.fn().mockReturnThis(),
+        getCount: jest.fn().mockResolvedValue(0),
+        select: jest.fn().mockReturnThis(),
+        addSelect: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        groupBy: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+        limit: jest.fn().mockReturnThis(),
+        getRawMany: jest.fn().mockResolvedValue([]),
+      }),
+      create: jest.fn().mockImplementation((d) => d),
+      save: jest.fn().mockResolvedValue({}),
+    };
+    cacheService = {
+      get: jest.fn().mockResolvedValue(null),
+      set: jest.fn().mockResolvedValue(undefined),
+      wrap: jest.fn().mockImplementation((_key: string, fn: () => Promise<any>) => fn()),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        RoomSearchService,
+        { provide: RoomRepository, useValue: roomRepository },
+        { provide: getRepositoryToken(RoomMember), useValue: memberRepository },
+        { provide: getRepositoryToken(RoomSearchAnalytics), useValue: analyticsRepository },
+        { provide: CacheService, useValue: cacheService },
+      ],
+    }).compile();
+
+    service = module.get<RoomSearchService>(RoomSearchService);
+  });
+
+  // ─── search ───────────────────────────────────────────────────────────────
+
+  describe('search', () => {
+    it('returns rooms from repository when cache misses', async () => {
+      const rooms = [mockRoom()];
+      roomRepository.searchRooms.mockResolvedValue([rooms, 1]);
+
+      const dto: RoomSearchDto = { q: 'test', page: 1, limit: 20 };
+      const result = await service.search(dto, 'user-id');
+
+      expect(result.data).toEqual(rooms);
+      expect(result.total).toBe(1);
+      expect(result.page).toBe(1);
+      expect(roomRepository.searchRooms).toHaveBeenCalledWith(
+        expect.objectContaining({ q: 'test', page: 1, limit: 20 }),
+      );
+    });
+
+    it('returns cached result when cache hits', async () => {
+      const cached = { data: [mockRoom()], total: 1, page: 1, limit: 20 };
+      cacheService.get.mockResolvedValue(cached);
+
+      const dto: RoomSearchDto = { q: 'cached' };
+      const result = await service.search(dto, 'user-id');
+
+      expect(result).toEqual(cached);
+      expect(roomRepository.searchRooms).not.toHaveBeenCalled();
+    });
+
+    it('caches results after a fresh search', async () => {
+      const rooms = [mockRoom()];
+      roomRepository.searchRooms.mockResolvedValue([rooms, 1]);
+
+      await service.search({ q: 'nft' }, 'user-id');
+
+      expect(cacheService.set).toHaveBeenCalledWith(
+        expect.stringContaining('rooms:search:'),
+        expect.objectContaining({ total: 1 }),
+        60,
+      );
+    });
+
+    it('passes all filters to the repository', async () => {
+      roomRepository.searchRooms.mockResolvedValue([[], 0]);
+
+      const dto: RoomSearchDto = {
+        q: 'defi',
+        roomType: RoomType.PUBLIC,
+        category: RoomCategory.CRYPTO,
+        tags: ['nft'],
+        minMembers: 5,
+        maxMembers: 100,
+        hasEntryFee: false,
+        sortBy: RoomSortBy.POPULAR,
+        page: 2,
+        limit: 10,
+      };
+
+      await service.search(dto, 'user-id');
+
+      expect(roomRepository.searchRooms).toHaveBeenCalledWith(
+        expect.objectContaining({
+          q: 'defi',
+          roomType: RoomType.PUBLIC,
+          category: RoomCategory.CRYPTO,
+          tags: ['nft'],
+          minMembers: 5,
+          maxMembers: 100,
+          hasEntryFee: false,
+          sortBy: RoomSortBy.POPULAR,
+          page: 2,
+          limit: 10,
+        }),
+      );
+    });
+
+    it('produces the same cache key for identical query params (deterministic)', async () => {
+      roomRepository.searchRooms.mockResolvedValue([[], 0]);
+
+      await service.search({ q: 'abc', page: 1 }, 'user-id');
+      await service.search({ page: 1, q: 'abc' }, 'user-id');
+
+      const keys = (cacheService.set.mock.calls as [string, any, any][]).map(([k]) => k);
+      expect(keys[0]).toEqual(keys[1]);
+    });
+  });
+
+  // ─── getTrending ─────────────────────────────────────────────────────────
+
+  describe('getTrending', () => {
+    it('returns trending rooms via cache wrap', async () => {
+      const trending = [mockRoom({ memberCount: 50 }), mockRoom({ memberCount: 30 })];
+      cacheService.wrap.mockResolvedValue(trending);
+
+      const dto: TrendingRoomsDto = { limit: 5 };
+      const result = await service.getTrending(dto);
+
+      expect(result).toEqual(trending);
+      expect(cacheService.wrap).toHaveBeenCalledWith(
+        'rooms:trending:5',
+        expect.any(Function),
+        300,
+      );
+    });
+
+    it('uses default limit of 10', async () => {
+      cacheService.wrap.mockResolvedValue([]);
+      await service.getTrending({});
+      expect(cacheService.wrap).toHaveBeenCalledWith('rooms:trending:10', expect.any(Function), 300);
+    });
+  });
+
+  // ─── getRecommended ───────────────────────────────────────────────────────
+
+  describe('getRecommended', () => {
+    it('calls findRecommendedForUser with user preferences from joined rooms', async () => {
+      const joinedRoom = mockRoom({ category: RoomCategory.GAMING, tags: ['fps'] });
+      memberRepository.find.mockResolvedValue([
+        { userId: 'user-1', roomId: 'room-1', status: MemberStatus.ACTIVE, room: joinedRoom },
+      ]);
+      roomRepository.findRecommendedForUser.mockResolvedValue([mockRoom()]);
+
+      await service.getRecommended('user-1', 5);
+
+      expect(roomRepository.findRecommendedForUser).toHaveBeenCalledWith(
+        'user-1',
+        ['room-1'],
+        [RoomCategory.GAMING],
+        ['fps'],
+        5,
+      );
+    });
+
+    it('falls back to trending rooms when user has no memberships', async () => {
+      memberRepository.find.mockResolvedValue([]);
+      roomRepository.findRecommendedForUser.mockResolvedValue([]);
+      const trending = [mockRoom({ memberCount: 99 })];
+      roomRepository.findTrendingRooms.mockResolvedValue(trending);
+
+      const result = await service.getRecommended('new-user', 5);
+
+      expect(result).toEqual(trending);
+    });
+
+    it('caches recommendations per user', async () => {
+      memberRepository.find.mockResolvedValue([]);
+      roomRepository.findRecommendedForUser.mockResolvedValue([]);
+      roomRepository.findTrendingRooms.mockResolvedValue([]);
+
+      await service.getRecommended('user-abc', 10);
+
+      expect(cacheService.wrap).toHaveBeenCalledWith(
+        'rooms:recommended:user-abc:10',
+        expect.any(Function),
+        600,
+      );
+    });
+  });
+
+  // ─── search analytics ─────────────────────────────────────────────────────
+
+  describe('analytics tracking', () => {
+    it('saves a search analytics record after a fresh search', async () => {
+      roomRepository.searchRooms.mockResolvedValue([[mockRoom()], 1]);
+
+      await service.search({ q: 'tracked-query' }, 'user-tracked');
+
+      // Allow micro-task to flush (trackSearch is fire-and-forget)
+      await new Promise((r) => setImmediate(r));
+
+      expect(analyticsRepository.create).toHaveBeenCalledWith(
+        expect.objectContaining({ query: 'tracked-query', userId: 'user-tracked' }),
+      );
+      expect(analyticsRepository.save).toHaveBeenCalledTimes(1);
+    });
+
+    it('stores null query when no search term is provided', async () => {
+      roomRepository.searchRooms.mockResolvedValue([[], 0]);
+      await service.search({ roomType: RoomType.PUBLIC }, 'user-id');
+      await new Promise((r) => setImmediate(r));
+      expect(analyticsRepository.create).toHaveBeenCalledWith(
+        expect.objectContaining({ query: null }),
+      );
+    });
+  });
+});

--- a/src/room/services/room-search.service.ts
+++ b/src/room/services/room-search.service.ts
@@ -1,0 +1,195 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Room } from '../entities/room.entity';
+import { RoomMember, MemberStatus } from '../entities/room-member.entity';
+import { RoomSearchAnalytics } from '../entities/room-search-analytics.entity';
+import { RoomRepository } from '../repositories/room.repository';
+import { RoomSearchDto, TrendingRoomsDto } from '../dto/room-search.dto';
+import { CacheService } from '../../cache/cache.service';
+
+const CACHE_TTL = {
+  SEARCH: 60,          // 60 seconds
+  TRENDING: 300,       // 5 minutes
+  RECOMMENDED: 600,    // 10 minutes
+};
+
+@Injectable()
+export class RoomSearchService {
+  private readonly logger = new Logger(RoomSearchService.name);
+
+  constructor(
+    private readonly roomRepository: RoomRepository,
+    @InjectRepository(RoomMember)
+    private readonly memberRepository: Repository<RoomMember>,
+    @InjectRepository(RoomSearchAnalytics)
+    private readonly analyticsRepository: Repository<RoomSearchAnalytics>,
+    private readonly cacheService: CacheService,
+  ) {}
+
+  // ─── Search ───────────────────────────────────────────────────────────────
+
+  async search(
+    dto: RoomSearchDto,
+    userId: string,
+  ): Promise<{ data: Room[]; total: number; page: number; limit: number }> {
+    const { page = 1, limit = 20, ...filters } = dto;
+    const cacheKey = this.buildSearchCacheKey(dto);
+
+    const cached = await this.cacheService.get<{
+      data: Room[];
+      total: number;
+      page: number;
+      limit: number;
+    }>(cacheKey);
+
+    if (cached) {
+      // Track analytics even on cache hit (don't await to avoid latency)
+      this.trackSearch(dto.q ?? null, userId, cached.total, filters).catch(
+        (err) => this.logger.error('Search analytics tracking failed', err),
+      );
+      return cached;
+    }
+
+    const [data, total] = await this.roomRepository.searchRooms({
+      ...filters,
+      page,
+      limit,
+    });
+
+    const result = { data, total, page, limit };
+
+    await this.cacheService.set(cacheKey, result, CACHE_TTL.SEARCH);
+
+    // Track search analytics asynchronously
+    this.trackSearch(dto.q ?? null, userId, total, filters).catch((err) =>
+      this.logger.error('Search analytics tracking failed', err),
+    );
+
+    return result;
+  }
+
+  // ─── Trending ────────────────────────────────────────────────────────────
+
+  async getTrending(dto: TrendingRoomsDto): Promise<Room[]> {
+    const limit = dto.limit ?? 10;
+    const cacheKey = `rooms:trending:${limit}`;
+
+    return this.cacheService.wrap(
+      cacheKey,
+      () => this.roomRepository.findTrendingRooms(limit),
+      CACHE_TTL.TRENDING,
+    );
+  }
+
+  // ─── Recommended ─────────────────────────────────────────────────────────
+
+  async getRecommended(userId: string, limit = 10): Promise<Room[]> {
+    const cacheKey = `rooms:recommended:${userId}:${limit}`;
+
+    return this.cacheService.wrap(
+      cacheKey,
+      () => this.computeRecommended(userId, limit),
+      CACHE_TTL.RECOMMENDED,
+    );
+  }
+
+  // ─── Analytics ───────────────────────────────────────────────────────────
+
+  async getSearchAnalyticsSummary(
+    since?: Date,
+  ): Promise<{ totalSearches: number; topQueries: { query: string; count: number }[] }> {
+    const qb = this.analyticsRepository.createQueryBuilder('sa');
+
+    if (since) {
+      qb.where('sa.createdAt >= :since', { since });
+    }
+
+    const totalSearches = await qb.getCount();
+
+    const topQueries: { query: string; count: number }[] = await this.analyticsRepository
+      .createQueryBuilder('sa')
+      .select('sa.query', 'query')
+      .addSelect('COUNT(*)', 'count')
+      .where('sa.query IS NOT NULL')
+      .andWhere('sa.query != :empty', { empty: '' })
+      .groupBy('sa.query')
+      .orderBy('count', 'DESC')
+      .limit(20)
+      .getRawMany();
+
+    return { totalSearches, topQueries };
+  }
+
+  // ─── Private ─────────────────────────────────────────────────────────────
+
+  private async computeRecommended(userId: string, limit: number): Promise<Room[]> {
+    // Get rooms the user is already a member of
+    const memberships = await this.memberRepository.find({
+      where: { userId, status: MemberStatus.ACTIVE },
+      relations: ['room'],
+    });
+
+    const joinedRoomIds = memberships.map((m) => m.roomId).filter(Boolean);
+    const joinedRooms = memberships.map((m) => m.room).filter(Boolean);
+
+    // Extract preferred categories and tags from joined rooms
+    const preferredCategories = [
+      ...new Set(
+        joinedRooms
+          .map((r) => r?.category)
+          .filter((c): c is string => Boolean(c)),
+      ),
+    ];
+
+    const preferredTags = [
+      ...new Set(
+        joinedRooms.flatMap((r) => r?.tags ?? []),
+      ),
+    ];
+
+    const rooms = await this.roomRepository.findRecommendedForUser(
+      userId,
+      joinedRoomIds,
+      preferredCategories,
+      preferredTags.slice(0, 10), // cap to avoid too-wide queries
+      limit,
+    );
+
+    // If no results from preferences, fall back to popular rooms
+    if (rooms.length === 0) {
+      return this.roomRepository.findTrendingRooms(limit);
+    }
+
+    return rooms;
+  }
+
+  private async trackSearch(
+    query: string | null,
+    userId: string,
+    resultCount: number,
+    filters: Partial<RoomSearchDto>,
+  ): Promise<void> {
+    try {
+      const record = this.analyticsRepository.create({
+        query: query ?? null,
+        userId,
+        resultCount,
+        filters: Object.keys(filters).length > 0 ? (filters as Record<string, any>) : null,
+      });
+      await this.analyticsRepository.save(record);
+    } catch (err) {
+      this.logger.error('Failed to persist search analytics', err);
+    }
+  }
+
+  private buildSearchCacheKey(dto: RoomSearchDto): string {
+    // Sort keys deterministically so same params always produce same key
+    const sortedParams = Object.entries(dto)
+      .filter(([, v]) => v !== undefined && v !== null)
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([k, v]) => `${k}=${Array.isArray(v) ? v.sort().join(',') : v}`)
+      .join('&');
+    return `rooms:search:${Buffer.from(sortedParams).toString('base64')}`;
+  }
+}


### PR DESCRIPTION
Pr closes #22 
- Add RoomCategory enum (10 categories) and tags support on Room entity
- Add RoomSearchAnalytics entity for query tracking
- Add RoomSearchDto with full-text search, type/category/tag/member/fee filters and sort options
- Add RoomRepository methods: searchRooms (FTS + ILIKE), findTrendingRooms (scored algorithm), findRecommendedForUser
- Add RoomSearchService with 60/300/600s caching via CacheService and fire-and-forget analytics
- Add RoomSearchController (GET /rooms/search, /trending, /recommended) registered before :id route
- Add migration for category/tags columns, GIN full-text index, and room_search_analytics table
- Add unit tests covering cache hit/miss, filter passthrough, trending, recommendations, analytics