### PR TITLE
feat(admin): implement support ticket system

### DIFF
--- a/src/admin/admin.module.ts
+++ b/src/admin/admin.module.ts
@@ -57,6 +57,10 @@ import { WebhookDelivery } from './entities/webhook-delivery.entity';
 import { WebhookService } from './services/webhook.service';
 import { WebhookDeliveryProcessor } from './jobs/webhook-delivery.processor';
 import { WebhookController } from './controllers/webhook.controller';
+import { SupportTicket } from './entities/support-ticket.entity';
+import { TicketMessage } from './entities/ticket-message.entity';
+import { SupportTicketService } from './services/support-ticket.service';
+import { SupportTicketController } from './controllers/support-ticket.controller';
 
 @Module({
   imports: [
@@ -95,9 +99,11 @@ import { WebhookController } from './controllers/webhook.controller';
       NotificationDelivery,
       WebhookSubscription,
       WebhookDelivery,
+      SupportTicket,
+      TicketMessage,
     ]),
   ],
-  controllers: [AdminController, IpWhitelistController, WebhookController],
+  controllers: [AdminController, IpWhitelistController, WebhookController, SupportTicketController],
   providers: [
     AdminConfigService,
     AdminService,
@@ -114,6 +120,7 @@ import { WebhookController } from './controllers/webhook.controller';
     BroadcastDeliveryStatsService,
     WebhookService,
     WebhookDeliveryProcessor,
+    SupportTicketService,
   ],
   exports: [
     AdminConfigService,
@@ -123,6 +130,7 @@ import { WebhookController } from './controllers/webhook.controller';
     AdminBroadcastService,
     BroadcastDeliveryStatsService,
     WebhookService,
+    SupportTicketService,
   ],
 })
 export class AdminModule {

--- a/src/admin/controllers/support-ticket.controller.ts
+++ b/src/admin/controllers/support-ticket.controller.ts
@@ -1,0 +1,127 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Patch,
+  Body,
+  Param,
+  Query,
+  UseGuards,
+  Req,
+  HttpCode,
+  HttpStatus,
+} from '@nestjs/common';
+import {
+  ApiTags,
+  ApiBearerAuth,
+  ApiOperation,
+  ApiResponse,
+  ApiParam,
+} from '@nestjs/swagger';
+import { Request } from 'express';
+import { RoleGuard } from '../../roles/guards/role.guard';
+import { Roles } from '../../roles/decorators/roles.decorator';
+import { UserRole } from '../../roles/entities/role.entity';
+import { CurrentUser } from '../../auth/decorators/current-user.decorator';
+import { SupportTicketService } from '../services/support-ticket.service';
+import { ListTicketsDto } from '../dto/support-ticket/list-tickets.dto';
+import { UpdateTicketDto } from '../dto/support-ticket/update-ticket.dto';
+import { ReplyTicketDto } from '../dto/support-ticket/reply-ticket.dto';
+import { AssignTicketDto } from '../dto/support-ticket/assign-ticket.dto';
+import { ResolveTicketDto } from '../dto/support-ticket/resolve-ticket.dto';
+
+@ApiTags('admin-support')
+@ApiBearerAuth()
+@UseGuards(RoleGuard)
+@Controller('admin/support/tickets')
+export class SupportTicketController {
+  constructor(private readonly supportTicketService: SupportTicketService) {}
+
+  // ─── Read + Reply (MODERATOR or above) ───────────────────────────────────
+
+  @Get()
+  @Roles(UserRole.MODERATOR, UserRole.ADMIN, UserRole.SUPER_ADMIN)
+  @ApiOperation({ summary: 'List support tickets with filters and pagination' })
+  @ApiResponse({ status: 200, description: 'Paginated list of tickets' })
+  async list(@Query() dto: ListTicketsDto) {
+    return this.supportTicketService.listTickets(dto);
+  }
+
+  @Get(':ticketId')
+  @Roles(UserRole.MODERATOR, UserRole.ADMIN, UserRole.SUPER_ADMIN)
+  @ApiOperation({ summary: 'Get a single ticket with all messages (oldest-first)' })
+  @ApiParam({ name: 'ticketId', description: 'Ticket UUID' })
+  @ApiResponse({ status: 200, description: 'Full ticket detail' })
+  async getOne(@Param('ticketId') ticketId: string) {
+    return this.supportTicketService.getTicket(ticketId);
+  }
+
+  @Post(':ticketId/messages')
+  @Roles(UserRole.MODERATOR, UserRole.ADMIN, UserRole.SUPER_ADMIN)
+  @ApiOperation({ summary: 'Admin reply to a support ticket (notifies user)' })
+  @ApiParam({ name: 'ticketId', description: 'Ticket UUID' })
+  @ApiResponse({ status: 201, description: 'Message created' })
+  async reply(
+    @Param('ticketId') ticketId: string,
+    @Body() dto: ReplyTicketDto,
+    @CurrentUser() user: any,
+  ) {
+    const adminId = (user?.user ?? user)?.id;
+    return this.supportTicketService.replyToTicket(ticketId, adminId, dto);
+  }
+
+  // ─── Status / priority changes (ADMIN or above) ──────────────────────────
+
+  @Patch(':ticketId')
+  @Roles(UserRole.ADMIN, UserRole.SUPER_ADMIN)
+  @ApiOperation({ summary: 'Update ticket status, priority, category, or assignee' })
+  @ApiParam({ name: 'ticketId', description: 'Ticket UUID' })
+  async update(
+    @Param('ticketId') ticketId: string,
+    @Body() dto: UpdateTicketDto,
+    @CurrentUser() user: any,
+    @Req() req: Request,
+  ) {
+    const adminId = (user?.user ?? user)?.id;
+    return this.supportTicketService.updateTicket(ticketId, adminId, dto, req);
+  }
+
+  @Post(':ticketId/assign')
+  @Roles(UserRole.ADMIN, UserRole.SUPER_ADMIN)
+  @ApiOperation({ summary: 'Assign ticket to an admin (notifies assignee)' })
+  @ApiParam({ name: 'ticketId', description: 'Ticket UUID' })
+  async assign(
+    @Param('ticketId') ticketId: string,
+    @Body() dto: AssignTicketDto,
+    @CurrentUser() user: any,
+    @Req() req: Request,
+  ) {
+    const adminId = (user?.user ?? user)?.id;
+    return this.supportTicketService.assignTicket(ticketId, adminId, dto, req);
+  }
+
+  @Post(':ticketId/resolve')
+  @Roles(UserRole.ADMIN, UserRole.SUPER_ADMIN)
+  @ApiOperation({ summary: 'Mark ticket as resolved with a resolution note' })
+  @ApiParam({ name: 'ticketId', description: 'Ticket UUID' })
+  async resolve(
+    @Param('ticketId') ticketId: string,
+    @Body() dto: ResolveTicketDto,
+    @CurrentUser() user: any,
+    @Req() req: Request,
+  ) {
+    const adminId = (user?.user ?? user)?.id;
+    return this.supportTicketService.resolveTicket(ticketId, adminId, dto, req);
+  }
+
+  @Post(':ticketId/close')
+  @HttpCode(HttpStatus.OK)
+  @Roles(UserRole.ADMIN, UserRole.SUPER_ADMIN)
+  @ApiOperation({
+    summary: 'Close a resolved ticket. Auto-close also runs after 72 h.',
+  })
+  @ApiParam({ name: 'ticketId', description: 'Ticket UUID' })
+  async close(@Param('ticketId') ticketId: string) {
+    return this.supportTicketService.closeTicket(ticketId);
+  }
+}

--- a/src/admin/dto/support-ticket/assign-ticket.dto.ts
+++ b/src/admin/dto/support-ticket/assign-ticket.dto.ts
@@ -1,0 +1,8 @@
+import { IsUUID } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class AssignTicketDto {
+  @ApiProperty({ description: 'Admin user ID to assign the ticket to' })
+  @IsUUID()
+  adminId: string;
+}

--- a/src/admin/dto/support-ticket/list-tickets.dto.ts
+++ b/src/admin/dto/support-ticket/list-tickets.dto.ts
@@ -1,0 +1,74 @@
+import {
+  IsOptional,
+  IsEnum,
+  IsUUID,
+  IsDateString,
+  IsString,
+  MaxLength,
+  IsInt,
+  Min,
+  Max,
+} from 'class-validator';
+import { Type } from 'class-transformer';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { TicketStatus } from '../../enums/ticket-status.enum';
+import { TicketCategory } from '../../enums/ticket-category.enum';
+import { TicketPriority } from '../../enums/ticket-priority.enum';
+
+export class ListTicketsDto {
+  @ApiPropertyOptional({ enum: TicketStatus })
+  @IsOptional()
+  @IsEnum(TicketStatus)
+  status?: TicketStatus;
+
+  @ApiPropertyOptional({ enum: TicketPriority })
+  @IsOptional()
+  @IsEnum(TicketPriority)
+  priority?: TicketPriority;
+
+  @ApiPropertyOptional({ enum: TicketCategory })
+  @IsOptional()
+  @IsEnum(TicketCategory)
+  category?: TicketCategory;
+
+  @ApiPropertyOptional({ description: 'Filter by assigned admin ID' })
+  @IsOptional()
+  @IsUUID()
+  assignedTo?: string;
+
+  @ApiPropertyOptional({ description: 'Filter by user ID' })
+  @IsOptional()
+  @IsUUID()
+  userId?: string;
+
+  @ApiPropertyOptional({ description: 'ISO date — tickets created on or after this date' })
+  @IsOptional()
+  @IsDateString()
+  startDate?: string;
+
+  @ApiPropertyOptional({ description: 'ISO date — tickets created on or before this date' })
+  @IsOptional()
+  @IsDateString()
+  endDate?: string;
+
+  @ApiPropertyOptional({ description: 'Partial subject search' })
+  @IsOptional()
+  @IsString()
+  @MaxLength(200)
+  search?: string;
+
+  @ApiPropertyOptional({ default: 1 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  page?: number = 1;
+
+  @ApiPropertyOptional({ default: 20, maximum: 100 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  limit?: number = 20;
+}

--- a/src/admin/dto/support-ticket/reply-ticket.dto.ts
+++ b/src/admin/dto/support-ticket/reply-ticket.dto.ts
@@ -1,0 +1,10 @@
+import { IsString, MinLength, MaxLength } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class ReplyTicketDto {
+  @ApiProperty({ description: 'Message body', minLength: 1, maxLength: 5000 })
+  @IsString()
+  @MinLength(1)
+  @MaxLength(5000)
+  body: string;
+}

--- a/src/admin/dto/support-ticket/resolve-ticket.dto.ts
+++ b/src/admin/dto/support-ticket/resolve-ticket.dto.ts
@@ -1,0 +1,10 @@
+import { IsString, MinLength, MaxLength } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class ResolveTicketDto {
+  @ApiProperty({ description: 'Resolution note describing how the issue was resolved' })
+  @IsString()
+  @MinLength(1)
+  @MaxLength(2000)
+  resolutionNote: string;
+}

--- a/src/admin/dto/support-ticket/update-ticket.dto.ts
+++ b/src/admin/dto/support-ticket/update-ticket.dto.ts
@@ -1,0 +1,27 @@
+import { IsOptional, IsEnum, IsUUID } from 'class-validator';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { TicketStatus } from '../../enums/ticket-status.enum';
+import { TicketCategory } from '../../enums/ticket-category.enum';
+import { TicketPriority } from '../../enums/ticket-priority.enum';
+
+export class UpdateTicketDto {
+  @ApiPropertyOptional({ enum: TicketStatus })
+  @IsOptional()
+  @IsEnum(TicketStatus)
+  status?: TicketStatus;
+
+  @ApiPropertyOptional({ enum: TicketPriority })
+  @IsOptional()
+  @IsEnum(TicketPriority)
+  priority?: TicketPriority;
+
+  @ApiPropertyOptional({ enum: TicketCategory })
+  @IsOptional()
+  @IsEnum(TicketCategory)
+  category?: TicketCategory;
+
+  @ApiPropertyOptional({ description: 'Admin ID to assign' })
+  @IsOptional()
+  @IsUUID()
+  assignedTo?: string;
+}

--- a/src/admin/entities/audit-log.entity.ts
+++ b/src/admin/entities/audit-log.entity.ts
@@ -64,6 +64,9 @@ export enum AuditAction {
   WEBHOOK_UPDATED = 'webhook.updated',
   WEBHOOK_DELETED = 'webhook.deleted',
   WEBHOOK_TESTED = 'webhook.tested',
+  TICKET_ASSIGNED = 'ticket.assigned',
+  TICKET_STATUS_CHANGED = 'ticket.status.changed',
+  TICKET_RESOLVED = 'ticket.resolved',
 }
 
 export enum AuditEventType {

--- a/src/admin/entities/support-ticket.entity.ts
+++ b/src/admin/entities/support-ticket.entity.ts
@@ -1,0 +1,66 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+  ManyToOne,
+  JoinColumn,
+  Index,
+  OneToMany,
+} from 'typeorm';
+import { User } from '../../user/entities/user.entity';
+import { TicketStatus } from '../enums/ticket-status.enum';
+import { TicketCategory } from '../enums/ticket-category.enum';
+import { TicketPriority } from '../enums/ticket-priority.enum';
+import { TicketMessage } from './ticket-message.entity';
+
+@Entity('support_tickets')
+@Index(['status', 'createdAt'])
+@Index(['userId', 'createdAt'])
+@Index(['assignedToId', 'status'])
+export class SupportTicket {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ type: 'uuid' })
+  userId: string;
+
+  @ManyToOne(() => User, { onDelete: 'RESTRICT' })
+  @JoinColumn({ name: 'userId' })
+  user: User;
+
+  @Column({ type: 'varchar', length: 255 })
+  subject: string;
+
+  @Column({ type: 'text' })
+  description: string;
+
+  @Column({ type: 'enum', enum: TicketCategory })
+  category: TicketCategory;
+
+  @Column({ type: 'enum', enum: TicketStatus, default: TicketStatus.OPEN })
+  status: TicketStatus;
+
+  @Column({ type: 'enum', enum: TicketPriority, default: TicketPriority.MEDIUM })
+  priority: TicketPriority;
+
+  @Column({ type: 'uuid', nullable: true })
+  assignedToId: string | null;
+
+  @ManyToOne(() => User, { nullable: true, onDelete: 'SET NULL' })
+  @JoinColumn({ name: 'assignedToId' })
+  assignedTo: User | null;
+
+  @Column({ type: 'timestamp', nullable: true })
+  resolvedAt: Date | null;
+
+  @OneToMany(() => TicketMessage, (msg) => msg.ticket)
+  messages: TicketMessage[];
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/src/admin/entities/ticket-message.entity.ts
+++ b/src/admin/entities/ticket-message.entity.ts
@@ -1,0 +1,43 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  ManyToOne,
+  JoinColumn,
+  Index,
+} from 'typeorm';
+import { SupportTicket } from './support-ticket.entity';
+
+export enum TicketAuthorType {
+  USER = 'user',
+  ADMIN = 'admin',
+}
+
+@Entity('ticket_messages')
+@Index(['ticketId', 'createdAt'])
+export class TicketMessage {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ type: 'uuid' })
+  ticketId: string;
+
+  @ManyToOne(() => SupportTicket, (ticket) => ticket.messages, {
+    onDelete: 'CASCADE',
+  })
+  @JoinColumn({ name: 'ticketId' })
+  ticket: SupportTicket;
+
+  @Column({ type: 'uuid' })
+  authorId: string;
+
+  @Column({ type: 'enum', enum: TicketAuthorType })
+  authorType: TicketAuthorType;
+
+  @Column({ type: 'text' })
+  body: string;
+
+  @CreateDateColumn()
+  createdAt: Date;
+}

--- a/src/admin/enums/ticket-category.enum.ts
+++ b/src/admin/enums/ticket-category.enum.ts
@@ -1,0 +1,7 @@
+export enum TicketCategory {
+  ACCOUNT = 'account',
+  TRANSACTION = 'transaction',
+  TECHNICAL = 'technical',
+  ABUSE = 'abuse',
+  OTHER = 'other',
+}

--- a/src/admin/enums/ticket-priority.enum.ts
+++ b/src/admin/enums/ticket-priority.enum.ts
@@ -1,0 +1,6 @@
+export enum TicketPriority {
+  LOW = 'low',
+  MEDIUM = 'medium',
+  HIGH = 'high',
+  URGENT = 'urgent',
+}

--- a/src/admin/enums/ticket-status.enum.ts
+++ b/src/admin/enums/ticket-status.enum.ts
@@ -1,0 +1,7 @@
+export enum TicketStatus {
+  OPEN = 'open',
+  IN_PROGRESS = 'in_progress',
+  PENDING_USER = 'pending_user',
+  RESOLVED = 'resolved',
+  CLOSED = 'closed',
+}

--- a/src/admin/services/support-ticket.service.spec.ts
+++ b/src/admin/services/support-ticket.service.spec.ts
@@ -1,0 +1,367 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { NotFoundException, BadRequestException } from '@nestjs/common';
+import { SupportTicketService } from './support-ticket.service';
+import { SupportTicket } from '../entities/support-ticket.entity';
+import { TicketMessage, TicketAuthorType } from '../entities/ticket-message.entity';
+import { User } from '../../user/entities/user.entity';
+import { Notification } from '../../notifications/entities/notification.entity';
+import { AuditLogService } from './audit-log.service';
+import { TicketStatus } from '../enums/ticket-status.enum';
+import { TicketCategory } from '../enums/ticket-category.enum';
+import { TicketPriority } from '../enums/ticket-priority.enum';
+
+const ADMIN_ID = 'admin-uuid-001';
+const USER_ID = 'user-uuid-001';
+const TICKET_ID = 'ticket-uuid-001';
+
+const mockTicket = (overrides: Partial<SupportTicket> = {}): SupportTicket =>
+  ({
+    id: TICKET_ID,
+    userId: USER_ID,
+    subject: 'Cannot log in',
+    description: 'I get an error when I try to log in',
+    category: TicketCategory.ACCOUNT,
+    status: TicketStatus.OPEN,
+    priority: TicketPriority.MEDIUM,
+    assignedToId: null,
+    assignedTo: null,
+    resolvedAt: null,
+    messages: [],
+    createdAt: new Date('2024-01-01'),
+    updatedAt: new Date('2024-01-01'),
+    ...overrides,
+  } as SupportTicket);
+
+describe('SupportTicketService', () => {
+  let service: SupportTicketService;
+  let ticketRepo: any;
+  let messageRepo: any;
+  let userRepo: any;
+  let notificationRepo: any;
+  let auditLogService: any;
+
+  beforeEach(async () => {
+    const qbMock = {
+      leftJoinAndSelect: jest.fn().mockReturnThis(),
+      orderBy: jest.fn().mockReturnThis(),
+      skip: jest.fn().mockReturnThis(),
+      take: jest.fn().mockReturnThis(),
+      andWhere: jest.fn().mockReturnThis(),
+      getManyAndCount: jest.fn().mockResolvedValue([[], 0]),
+      update: jest.fn().mockReturnThis(),
+      set: jest.fn().mockReturnThis(),
+      where: jest.fn().mockReturnThis(),
+      execute: jest.fn().mockResolvedValue({ affected: 0 }),
+    };
+
+    ticketRepo = {
+      findOne: jest.fn(),
+      update: jest.fn().mockResolvedValue({ affected: 1 }),
+      createQueryBuilder: jest.fn().mockReturnValue(qbMock),
+    };
+    messageRepo = {
+      create: jest.fn().mockImplementation((d) => d),
+      save: jest.fn().mockImplementation((d) => Promise.resolve({ id: 'msg-uuid-1', ...d })),
+    };
+    userRepo = {
+      findOne: jest.fn(),
+    };
+    notificationRepo = {
+      create: jest.fn().mockImplementation((d) => d),
+      save: jest.fn().mockResolvedValue({}),
+    };
+    auditLogService = {
+      createAuditLog: jest.fn().mockResolvedValue({}),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        SupportTicketService,
+        { provide: getRepositoryToken(SupportTicket), useValue: ticketRepo },
+        { provide: getRepositoryToken(TicketMessage), useValue: messageRepo },
+        { provide: getRepositoryToken(User), useValue: userRepo },
+        { provide: getRepositoryToken(Notification), useValue: notificationRepo },
+        { provide: AuditLogService, useValue: auditLogService },
+      ],
+    }).compile();
+
+    service = module.get<SupportTicketService>(SupportTicketService);
+  });
+
+  // ─── listTickets ──────────────────────────────────────────────────────────
+
+  describe('listTickets', () => {
+    it('returns paginated tickets with defaults', async () => {
+      const tickets = [mockTicket()];
+      const qb = ticketRepo.createQueryBuilder();
+      qb.getManyAndCount.mockResolvedValue([tickets, 1]);
+
+      const result = await service.listTickets({});
+
+      expect(result.data).toEqual(tickets);
+      expect(result.total).toBe(1);
+      expect(result.page).toBe(1);
+      expect(result.limit).toBe(20);
+    });
+
+    it('applies status filter', async () => {
+      const qb = ticketRepo.createQueryBuilder();
+      qb.getManyAndCount.mockResolvedValue([[], 0]);
+
+      await service.listTickets({ status: TicketStatus.OPEN });
+
+      expect(qb.andWhere).toHaveBeenCalledWith('t.status = :status', { status: TicketStatus.OPEN });
+    });
+
+    it('applies date range filter when both dates provided', async () => {
+      const qb = ticketRepo.createQueryBuilder();
+      qb.getManyAndCount.mockResolvedValue([[], 0]);
+
+      await service.listTickets({ startDate: '2024-01-01', endDate: '2024-12-31' });
+
+      expect(qb.andWhere).toHaveBeenCalledWith(
+        't.createdAt BETWEEN :start AND :end',
+        expect.objectContaining({ start: expect.any(Date), end: expect.any(Date) }),
+      );
+    });
+
+    it('applies subject ILIKE search', async () => {
+      const qb = ticketRepo.createQueryBuilder();
+      qb.getManyAndCount.mockResolvedValue([[], 0]);
+
+      await service.listTickets({ search: 'login' });
+
+      expect(qb.andWhere).toHaveBeenCalledWith('t.subject ILIKE :search', {
+        search: '%login%',
+      });
+    });
+  });
+
+  // ─── getTicket ────────────────────────────────────────────────────────────
+
+  describe('getTicket', () => {
+    it('returns ticket with messages sorted oldest-first', async () => {
+      const msg1 = { id: 'm1', createdAt: new Date('2024-01-02') } as TicketMessage;
+      const msg2 = { id: 'm2', createdAt: new Date('2024-01-01') } as TicketMessage;
+      ticketRepo.findOne.mockResolvedValue(mockTicket({ messages: [msg1, msg2] }));
+
+      const result = await service.getTicket(TICKET_ID);
+
+      expect(result.messages[0].id).toBe('m2');
+      expect(result.messages[1].id).toBe('m1');
+    });
+
+    it('throws NotFoundException for unknown ticket', async () => {
+      ticketRepo.findOne.mockResolvedValue(null);
+
+      await expect(service.getTicket('bad-id')).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  // ─── replyToTicket ────────────────────────────────────────────────────────
+
+  describe('replyToTicket', () => {
+    it('creates a message with ADMIN authorType', async () => {
+      ticketRepo.findOne.mockResolvedValue(mockTicket());
+
+      const result = await service.replyToTicket(TICKET_ID, ADMIN_ID, { body: 'Hello user' });
+
+      expect(messageRepo.create).toHaveBeenCalledWith(
+        expect.objectContaining({ authorType: TicketAuthorType.ADMIN, body: 'Hello user' }),
+      );
+      expect(result.id).toBeDefined();
+    });
+
+    it('moves OPEN ticket to IN_PROGRESS after admin reply', async () => {
+      ticketRepo.findOne.mockResolvedValue(mockTicket({ status: TicketStatus.OPEN }));
+
+      await service.replyToTicket(TICKET_ID, ADMIN_ID, { body: 'Working on it' });
+
+      expect(ticketRepo.update).toHaveBeenCalledWith(TICKET_ID, {
+        status: TicketStatus.IN_PROGRESS,
+      });
+    });
+
+    it('does not change status when ticket is already IN_PROGRESS', async () => {
+      ticketRepo.findOne.mockResolvedValue(mockTicket({ status: TicketStatus.IN_PROGRESS }));
+
+      await service.replyToTicket(TICKET_ID, ADMIN_ID, { body: 'Still looking' });
+
+      expect(ticketRepo.update).not.toHaveBeenCalled();
+    });
+
+    it('throws BadRequestException when ticket is CLOSED', async () => {
+      ticketRepo.findOne.mockResolvedValue(mockTicket({ status: TicketStatus.CLOSED }));
+
+      await expect(
+        service.replyToTicket(TICKET_ID, ADMIN_ID, { body: 'Too late' }),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('sends an in-app notification to the user', async () => {
+      ticketRepo.findOne.mockResolvedValue(mockTicket());
+
+      await service.replyToTicket(TICKET_ID, ADMIN_ID, { body: 'Hi' });
+
+      expect(notificationRepo.create).toHaveBeenCalledWith(
+        expect.objectContaining({ recipientId: USER_ID }),
+      );
+      expect(notificationRepo.save).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // ─── updateTicket ─────────────────────────────────────────────────────────
+
+  describe('updateTicket', () => {
+    it('updates priority without creating audit log if status unchanged', async () => {
+      ticketRepo.findOne
+        .mockResolvedValueOnce(mockTicket())
+        .mockResolvedValueOnce(mockTicket({ priority: TicketPriority.HIGH }));
+
+      await service.updateTicket(TICKET_ID, ADMIN_ID, { priority: TicketPriority.HIGH });
+
+      expect(auditLogService.createAuditLog).not.toHaveBeenCalled();
+    });
+
+    it('creates audit log when status changes', async () => {
+      ticketRepo.findOne
+        .mockResolvedValueOnce(mockTicket({ status: TicketStatus.OPEN }))
+        .mockResolvedValueOnce(mockTicket({ status: TicketStatus.IN_PROGRESS }));
+
+      await service.updateTicket(TICKET_ID, ADMIN_ID, { status: TicketStatus.IN_PROGRESS });
+
+      expect(auditLogService.createAuditLog).toHaveBeenCalledWith(
+        expect.objectContaining({ resourceId: TICKET_ID }),
+      );
+    });
+  });
+
+  // ─── assignTicket ─────────────────────────────────────────────────────────
+
+  describe('assignTicket', () => {
+    it('assigns ticket, sets IN_PROGRESS, notifies assignee', async () => {
+      const assigneeId = 'admin-assignee-uuid';
+      ticketRepo.findOne
+        .mockResolvedValueOnce(mockTicket({ status: TicketStatus.OPEN }))
+        .mockResolvedValueOnce(mockTicket({ assignedToId: assigneeId }));
+      userRepo.findOne.mockResolvedValue({ id: assigneeId });
+
+      await service.assignTicket(TICKET_ID, ADMIN_ID, { adminId: assigneeId });
+
+      expect(ticketRepo.update).toHaveBeenCalledWith(TICKET_ID, {
+        assignedToId: assigneeId,
+        status: TicketStatus.IN_PROGRESS,
+      });
+      expect(auditLogService.createAuditLog).toHaveBeenCalledTimes(1);
+      expect(notificationRepo.create).toHaveBeenCalledWith(
+        expect.objectContaining({ recipientId: assigneeId }),
+      );
+    });
+
+    it('throws NotFoundException when assignee user does not exist', async () => {
+      ticketRepo.findOne.mockResolvedValue(mockTicket());
+      userRepo.findOne.mockResolvedValue(null);
+
+      await expect(
+        service.assignTicket(TICKET_ID, ADMIN_ID, { adminId: 'bad-admin-id' }),
+      ).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  // ─── resolveTicket ────────────────────────────────────────────────────────
+
+  describe('resolveTicket', () => {
+    it('sets status to RESOLVED and records resolvedAt', async () => {
+      ticketRepo.findOne
+        .mockResolvedValueOnce(mockTicket({ status: TicketStatus.IN_PROGRESS }))
+        .mockResolvedValueOnce(mockTicket({ status: TicketStatus.RESOLVED, resolvedAt: new Date() }));
+
+      const result = await service.resolveTicket(TICKET_ID, ADMIN_ID, {
+        resolutionNote: 'Reset password fixed it',
+      });
+
+      expect(ticketRepo.update).toHaveBeenCalledWith(
+        TICKET_ID,
+        expect.objectContaining({ status: TicketStatus.RESOLVED, resolvedAt: expect.any(Date) }),
+      );
+      expect(auditLogService.createAuditLog).toHaveBeenCalledTimes(1);
+      expect(notificationRepo.save).toHaveBeenCalledTimes(1);
+    });
+
+    it('records resolution note as an admin message with [Resolution] prefix', async () => {
+      ticketRepo.findOne
+        .mockResolvedValueOnce(mockTicket({ status: TicketStatus.IN_PROGRESS }))
+        .mockResolvedValueOnce(mockTicket({ status: TicketStatus.RESOLVED }));
+
+      await service.resolveTicket(TICKET_ID, ADMIN_ID, { resolutionNote: 'Fixed' });
+
+      expect(messageRepo.create).toHaveBeenCalledWith(
+        expect.objectContaining({ body: '[Resolution] Fixed', authorType: TicketAuthorType.ADMIN }),
+      );
+    });
+
+    it('throws BadRequestException when ticket is already RESOLVED', async () => {
+      ticketRepo.findOne.mockResolvedValue(mockTicket({ status: TicketStatus.RESOLVED }));
+
+      await expect(
+        service.resolveTicket(TICKET_ID, ADMIN_ID, { resolutionNote: 'Again?' }),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('throws BadRequestException when ticket is CLOSED', async () => {
+      ticketRepo.findOne.mockResolvedValue(mockTicket({ status: TicketStatus.CLOSED }));
+
+      await expect(
+        service.resolveTicket(TICKET_ID, ADMIN_ID, { resolutionNote: 'Nope' }),
+      ).rejects.toThrow(BadRequestException);
+    });
+  });
+
+  // ─── closeTicket ──────────────────────────────────────────────────────────
+
+  describe('closeTicket', () => {
+    it('closes a resolved ticket', async () => {
+      ticketRepo.findOne
+        .mockResolvedValueOnce(mockTicket({ status: TicketStatus.RESOLVED }))
+        .mockResolvedValueOnce(mockTicket({ status: TicketStatus.CLOSED }));
+
+      const result = await service.closeTicket(TICKET_ID);
+
+      expect(ticketRepo.update).toHaveBeenCalledWith(TICKET_ID, { status: TicketStatus.CLOSED });
+    });
+
+    it('throws BadRequestException when ticket is not RESOLVED', async () => {
+      ticketRepo.findOne.mockResolvedValue(mockTicket({ status: TicketStatus.IN_PROGRESS }));
+
+      await expect(service.closeTicket(TICKET_ID)).rejects.toThrow(BadRequestException);
+    });
+
+    it('throws BadRequestException when ticket is already CLOSED', async () => {
+      ticketRepo.findOne.mockResolvedValue(mockTicket({ status: TicketStatus.CLOSED }));
+
+      await expect(service.closeTicket(TICKET_ID)).rejects.toThrow(BadRequestException);
+    });
+  });
+
+  // ─── autoCloseResolvedTickets ─────────────────────────────────────────────
+
+  describe('autoCloseResolvedTickets', () => {
+    it('bulk-updates resolved tickets older than 72h to CLOSED', async () => {
+      const qb = ticketRepo.createQueryBuilder();
+      qb.execute.mockResolvedValue({ affected: 3 });
+
+      await service.autoCloseResolvedTickets();
+
+      expect(qb.update).toHaveBeenCalledWith(SupportTicket);
+      expect(qb.set).toHaveBeenCalledWith({ status: TicketStatus.CLOSED });
+      expect(qb.where).toHaveBeenCalledWith('status = :status', {
+        status: TicketStatus.RESOLVED,
+      });
+      expect(qb.andWhere).toHaveBeenCalledWith(
+        'resolvedAt <= :cutoff',
+        expect.objectContaining({ cutoff: expect.any(Date) }),
+      );
+    });
+  });
+});

--- a/src/admin/services/support-ticket.service.ts
+++ b/src/admin/services/support-ticket.service.ts
@@ -1,0 +1,388 @@
+import {
+  Injectable,
+  Logger,
+  NotFoundException,
+  BadRequestException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository, Between, MoreThanOrEqual, LessThanOrEqual } from 'typeorm';
+import { Cron, CronExpression } from '@nestjs/schedule';
+import type { Request } from 'express';
+
+import { SupportTicket } from '../entities/support-ticket.entity';
+import {
+  TicketMessage,
+  TicketAuthorType,
+} from '../entities/ticket-message.entity';
+import { User } from '../../user/entities/user.entity';
+import { Notification } from '../../notifications/entities/notification.entity';
+import { AuditLogService } from './audit-log.service';
+import {
+  AuditAction,
+  AuditEventType,
+  AuditOutcome,
+  AuditSeverity,
+} from '../entities/audit-log.entity';
+import { TicketStatus } from '../enums/ticket-status.enum';
+import { TicketPriority } from '../enums/ticket-priority.enum';
+import { ListTicketsDto } from '../dto/support-ticket/list-tickets.dto';
+import { UpdateTicketDto } from '../dto/support-ticket/update-ticket.dto';
+import { ReplyTicketDto } from '../dto/support-ticket/reply-ticket.dto';
+import { AssignTicketDto } from '../dto/support-ticket/assign-ticket.dto';
+import { ResolveTicketDto } from '../dto/support-ticket/resolve-ticket.dto';
+import {
+  NotificationType,
+  NotificationPriority,
+} from '../../notifications/enums/notification-type.enum';
+
+const AUTO_CLOSE_HOURS = 72;
+
+@Injectable()
+export class SupportTicketService {
+  private readonly logger = new Logger(SupportTicketService.name);
+
+  constructor(
+    @InjectRepository(SupportTicket)
+    private readonly ticketRepository: Repository<SupportTicket>,
+    @InjectRepository(TicketMessage)
+    private readonly messageRepository: Repository<TicketMessage>,
+    @InjectRepository(User)
+    private readonly userRepository: Repository<User>,
+    @InjectRepository(Notification)
+    private readonly notificationRepository: Repository<Notification>,
+    private readonly auditLogService: AuditLogService,
+  ) {}
+
+  // ─── List ────────────────────────────────────────────────────────────────
+
+  async listTickets(dto: ListTicketsDto): Promise<{
+    data: SupportTicket[];
+    total: number;
+    page: number;
+    limit: number;
+  }> {
+    const page = dto.page ?? 1;
+    const limit = dto.limit ?? 20;
+    const skip = (page - 1) * limit;
+
+    const qb = this.ticketRepository
+      .createQueryBuilder('t')
+      .leftJoinAndSelect('t.user', 'user')
+      .leftJoinAndSelect('t.assignedTo', 'assignedTo')
+      .orderBy('t.createdAt', 'DESC')
+      .skip(skip)
+      .take(limit);
+
+    if (dto.status) {
+      qb.andWhere('t.status = :status', { status: dto.status });
+    }
+    if (dto.priority) {
+      qb.andWhere('t.priority = :priority', { priority: dto.priority });
+    }
+    if (dto.category) {
+      qb.andWhere('t.category = :category', { category: dto.category });
+    }
+    if (dto.assignedTo) {
+      qb.andWhere('t.assignedToId = :assignedTo', { assignedTo: dto.assignedTo });
+    }
+    if (dto.userId) {
+      qb.andWhere('t.userId = :userId', { userId: dto.userId });
+    }
+    if (dto.search) {
+      qb.andWhere('t.subject ILIKE :search', { search: `%${dto.search}%` });
+    }
+    if (dto.startDate && dto.endDate) {
+      qb.andWhere('t.createdAt BETWEEN :start AND :end', {
+        start: new Date(dto.startDate),
+        end: new Date(dto.endDate),
+      });
+    } else if (dto.startDate) {
+      qb.andWhere('t.createdAt >= :start', { start: new Date(dto.startDate) });
+    } else if (dto.endDate) {
+      qb.andWhere('t.createdAt <= :end', { end: new Date(dto.endDate) });
+    }
+
+    const [data, total] = await qb.getManyAndCount();
+    return { data, total, page, limit };
+  }
+
+  // ─── Get single ──────────────────────────────────────────────────────────
+
+  async getTicket(ticketId: string): Promise<SupportTicket> {
+    const ticket = await this.ticketRepository.findOne({
+      where: { id: ticketId },
+      relations: ['user', 'assignedTo', 'messages'],
+    });
+
+    if (!ticket) {
+      throw new NotFoundException(`Ticket ${ticketId} not found`);
+    }
+
+    // Sort messages oldest-first
+    ticket.messages?.sort(
+      (a, b) => a.createdAt.getTime() - b.createdAt.getTime(),
+    );
+
+    return ticket;
+  }
+
+  // ─── Reply ───────────────────────────────────────────────────────────────
+
+  async replyToTicket(
+    ticketId: string,
+    adminId: string,
+    dto: ReplyTicketDto,
+  ): Promise<TicketMessage> {
+    const ticket = await this.findTicketOrFail(ticketId);
+
+    if (ticket.status === TicketStatus.CLOSED) {
+      throw new BadRequestException('Cannot reply to a closed ticket');
+    }
+
+    const message = this.messageRepository.create({
+      ticketId,
+      authorId: adminId,
+      authorType: TicketAuthorType.ADMIN,
+      body: dto.body,
+    });
+
+    const saved = await this.messageRepository.save(message);
+
+    // Move ticket to in_progress if still open
+    if (ticket.status === TicketStatus.OPEN) {
+      await this.ticketRepository.update(ticketId, {
+        status: TicketStatus.IN_PROGRESS,
+      });
+    }
+
+    // Notify the user
+    await this.sendNotification(
+      ticket.userId,
+      'Support ticket update',
+      `An admin has replied to your support ticket: "${ticket.subject}"`,
+      { ticketId },
+      NotificationPriority.NORMAL,
+    );
+
+    return saved;
+  }
+
+  // ─── Update metadata ────────────────────────────────────────────────────
+
+  async updateTicket(
+    ticketId: string,
+    adminId: string,
+    dto: UpdateTicketDto,
+    req?: Request,
+  ): Promise<SupportTicket> {
+    const ticket = await this.findTicketOrFail(ticketId);
+    const previousStatus = ticket.status;
+
+    const updates: Partial<SupportTicket> = {};
+    if (dto.status !== undefined) updates.status = dto.status;
+    if (dto.priority !== undefined) updates.priority = dto.priority;
+    if (dto.category !== undefined) updates.category = dto.category;
+    if (dto.assignedTo !== undefined) updates.assignedToId = dto.assignedTo ?? null;
+
+    await this.ticketRepository.update(ticketId, updates);
+
+    if (dto.status && dto.status !== previousStatus) {
+      await this.auditLogService.createAuditLog({
+        actorUserId: adminId,
+        targetUserId: ticket.userId,
+        action: AuditAction.TICKET_STATUS_CHANGED,
+        eventType: AuditEventType.ADMIN,
+        outcome: AuditOutcome.SUCCESS,
+        severity: AuditSeverity.LOW,
+        resourceType: 'support_ticket',
+        resourceId: ticketId,
+        details: `Status changed from ${previousStatus} to ${dto.status}`,
+        req,
+      });
+    }
+
+    return this.getTicket(ticketId);
+  }
+
+  // ─── Assign ──────────────────────────────────────────────────────────────
+
+  async assignTicket(
+    ticketId: string,
+    actorAdminId: string,
+    dto: AssignTicketDto,
+    req?: Request,
+  ): Promise<SupportTicket> {
+    const ticket = await this.findTicketOrFail(ticketId);
+
+    const assignee = await this.userRepository.findOne({
+      where: { id: dto.adminId },
+    });
+    if (!assignee) {
+      throw new NotFoundException(`Admin user ${dto.adminId} not found`);
+    }
+
+    await this.ticketRepository.update(ticketId, {
+      assignedToId: dto.adminId,
+      status:
+        ticket.status === TicketStatus.OPEN
+          ? TicketStatus.IN_PROGRESS
+          : ticket.status,
+    });
+
+    await this.auditLogService.createAuditLog({
+      actorUserId: actorAdminId,
+      targetUserId: ticket.userId,
+      action: AuditAction.TICKET_ASSIGNED,
+      eventType: AuditEventType.ADMIN,
+      outcome: AuditOutcome.SUCCESS,
+      severity: AuditSeverity.LOW,
+      resourceType: 'support_ticket',
+      resourceId: ticketId,
+      details: `Ticket assigned to admin ${dto.adminId}`,
+      req,
+    });
+
+    // Notify the assignee
+    await this.sendNotification(
+      dto.adminId,
+      'Support ticket assigned to you',
+      `You have been assigned ticket: "${ticket.subject}"`,
+      { ticketId },
+      NotificationPriority.HIGH,
+    );
+
+    return this.getTicket(ticketId);
+  }
+
+  // ─── Resolve ─────────────────────────────────────────────────────────────
+
+  async resolveTicket(
+    ticketId: string,
+    adminId: string,
+    dto: ResolveTicketDto,
+    req?: Request,
+  ): Promise<SupportTicket> {
+    const ticket = await this.findTicketOrFail(ticketId);
+
+    if (ticket.status === TicketStatus.CLOSED) {
+      throw new BadRequestException('Ticket is already closed');
+    }
+    if (ticket.status === TicketStatus.RESOLVED) {
+      throw new BadRequestException('Ticket is already resolved');
+    }
+
+    const now = new Date();
+    await this.ticketRepository.update(ticketId, {
+      status: TicketStatus.RESOLVED,
+      resolvedAt: now,
+    });
+
+    // Record resolution note as an admin message
+    const message = this.messageRepository.create({
+      ticketId,
+      authorId: adminId,
+      authorType: TicketAuthorType.ADMIN,
+      body: `[Resolution] ${dto.resolutionNote}`,
+    });
+    await this.messageRepository.save(message);
+
+    await this.auditLogService.createAuditLog({
+      actorUserId: adminId,
+      targetUserId: ticket.userId,
+      action: AuditAction.TICKET_RESOLVED,
+      eventType: AuditEventType.ADMIN,
+      outcome: AuditOutcome.SUCCESS,
+      severity: AuditSeverity.LOW,
+      resourceType: 'support_ticket',
+      resourceId: ticketId,
+      details: dto.resolutionNote,
+      req,
+    });
+
+    // Notify the user
+    await this.sendNotification(
+      ticket.userId,
+      'Your support ticket has been resolved',
+      `Your ticket "${ticket.subject}" has been resolved. If the issue persists you can reopen it within 72 hours.`,
+      { ticketId },
+      NotificationPriority.NORMAL,
+    );
+
+    return this.getTicket(ticketId);
+  }
+
+  // ─── Close ───────────────────────────────────────────────────────────────
+
+  async closeTicket(ticketId: string): Promise<SupportTicket> {
+    const ticket = await this.findTicketOrFail(ticketId);
+
+    if (ticket.status === TicketStatus.CLOSED) {
+      throw new BadRequestException('Ticket is already closed');
+    }
+    if (ticket.status !== TicketStatus.RESOLVED) {
+      throw new BadRequestException(
+        'Only resolved tickets can be closed. Resolve the ticket first.',
+      );
+    }
+
+    await this.ticketRepository.update(ticketId, {
+      status: TicketStatus.CLOSED,
+    });
+
+    return this.getTicket(ticketId);
+  }
+
+  // ─── Auto-close job ──────────────────────────────────────────────────────
+
+  @Cron(CronExpression.EVERY_HOUR)
+  async autoCloseResolvedTickets(): Promise<void> {
+    const cutoff = new Date(Date.now() - AUTO_CLOSE_HOURS * 60 * 60 * 1000);
+
+    const result = await this.ticketRepository
+      .createQueryBuilder()
+      .update(SupportTicket)
+      .set({ status: TicketStatus.CLOSED })
+      .where('status = :status', { status: TicketStatus.RESOLVED })
+      .andWhere('resolvedAt <= :cutoff', { cutoff })
+      .execute();
+
+    if (result.affected && result.affected > 0) {
+      this.logger.log(`Auto-closed ${result.affected} ticket(s) after ${AUTO_CLOSE_HOURS}h`);
+    }
+  }
+
+  // ─── Private helpers ─────────────────────────────────────────────────────
+
+  private async findTicketOrFail(ticketId: string): Promise<SupportTicket> {
+    const ticket = await this.ticketRepository.findOne({
+      where: { id: ticketId },
+    });
+    if (!ticket) {
+      throw new NotFoundException(`Ticket ${ticketId} not found`);
+    }
+    return ticket;
+  }
+
+  private async sendNotification(
+    recipientId: string,
+    title: string,
+    message: string,
+    data: Record<string, any>,
+    priority: NotificationPriority,
+  ): Promise<void> {
+    try {
+      const notification = this.notificationRepository.create({
+        recipientId,
+        senderId: null,
+        type: NotificationType.SYSTEM,
+        title,
+        message,
+        data,
+        priority,
+      });
+      await this.notificationRepository.save(notification);
+    } catch (err) {
+      this.logger.error('Failed to send support ticket notification', err);
+    }
+  }
+}

--- a/src/database/migrations/1772000000000-CreateSupportTicketsTable.ts
+++ b/src/database/migrations/1772000000000-CreateSupportTicketsTable.ts
@@ -1,0 +1,110 @@
+import { MigrationInterface, QueryRunner, Table, TableIndex } from 'typeorm';
+
+export class CreateSupportTicketsTable1772000000000 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // Extend the audit_logs action enum
+    for (const value of ['ticket.assigned', 'ticket.status.changed', 'ticket.resolved']) {
+      await queryRunner.query(
+        `ALTER TYPE "audit_logs_action_enum" ADD VALUE IF NOT EXISTS '${value}'`,
+      );
+    }
+
+    await queryRunner.createTable(
+      new Table({
+        name: 'support_tickets',
+        columns: [
+          {
+            name: 'id',
+            type: 'uuid',
+            isPrimary: true,
+            isGenerated: true,
+            generationStrategy: 'uuid',
+          },
+          {
+            name: 'userId',
+            type: 'uuid',
+            isNullable: false,
+          },
+          {
+            name: 'subject',
+            type: 'varchar',
+            length: '255',
+            isNullable: false,
+          },
+          {
+            name: 'description',
+            type: 'text',
+            isNullable: false,
+          },
+          {
+            name: 'category',
+            type: 'enum',
+            enum: ['account', 'transaction', 'technical', 'abuse', 'other'],
+            isNullable: false,
+          },
+          {
+            name: 'status',
+            type: 'enum',
+            enum: ['open', 'in_progress', 'pending_user', 'resolved', 'closed'],
+            default: "'open'",
+            isNullable: false,
+          },
+          {
+            name: 'priority',
+            type: 'enum',
+            enum: ['low', 'medium', 'high', 'urgent'],
+            default: "'medium'",
+            isNullable: false,
+          },
+          {
+            name: 'assignedToId',
+            type: 'uuid',
+            isNullable: true,
+          },
+          {
+            name: 'resolvedAt',
+            type: 'timestamp',
+            isNullable: true,
+          },
+          {
+            name: 'createdAt',
+            type: 'timestamp',
+            default: 'CURRENT_TIMESTAMP',
+            isNullable: false,
+          },
+          {
+            name: 'updatedAt',
+            type: 'timestamp',
+            default: 'CURRENT_TIMESTAMP',
+            onUpdate: 'CURRENT_TIMESTAMP',
+            isNullable: false,
+          },
+        ],
+        foreignKeys: [
+          {
+            columnNames: ['userId'],
+            referencedTableName: 'users',
+            referencedColumnNames: ['id'],
+            onDelete: 'RESTRICT',
+          },
+          {
+            columnNames: ['assignedToId'],
+            referencedTableName: 'users',
+            referencedColumnNames: ['id'],
+            onDelete: 'SET NULL',
+          },
+        ],
+        indices: [
+          new TableIndex({ columnNames: ['status', 'createdAt'] }),
+          new TableIndex({ columnNames: ['userId', 'createdAt'] }),
+          new TableIndex({ columnNames: ['assignedToId', 'status'] }),
+        ],
+      }),
+      true,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropTable('support_tickets');
+  }
+}

--- a/src/database/migrations/1772000000001-CreateTicketMessagesTable.ts
+++ b/src/database/migrations/1772000000001-CreateTicketMessagesTable.ts
@@ -1,0 +1,63 @@
+import { MigrationInterface, QueryRunner, Table, TableIndex } from 'typeorm';
+
+export class CreateTicketMessagesTable1772000000001 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.createTable(
+      new Table({
+        name: 'ticket_messages',
+        columns: [
+          {
+            name: 'id',
+            type: 'uuid',
+            isPrimary: true,
+            isGenerated: true,
+            generationStrategy: 'uuid',
+          },
+          {
+            name: 'ticketId',
+            type: 'uuid',
+            isNullable: false,
+          },
+          {
+            name: 'authorId',
+            type: 'uuid',
+            isNullable: false,
+          },
+          {
+            name: 'authorType',
+            type: 'enum',
+            enum: ['user', 'admin'],
+            isNullable: false,
+          },
+          {
+            name: 'body',
+            type: 'text',
+            isNullable: false,
+          },
+          {
+            name: 'createdAt',
+            type: 'timestamp',
+            default: 'CURRENT_TIMESTAMP',
+            isNullable: false,
+          },
+        ],
+        foreignKeys: [
+          {
+            columnNames: ['ticketId'],
+            referencedTableName: 'support_tickets',
+            referencedColumnNames: ['id'],
+            onDelete: 'CASCADE',
+          },
+        ],
+        indices: [
+          new TableIndex({ columnNames: ['ticketId', 'createdAt'] }),
+        ],
+      }),
+      true,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropTable('ticket_messages');
+  }
+}

--- a/test/admin-support-tickets.e2e-spec.ts
+++ b/test/admin-support-tickets.e2e-spec.ts
@@ -1,0 +1,323 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import * as request from 'supertest';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { SupportTicketController } from '../src/admin/controllers/support-ticket.controller';
+import { SupportTicketService } from '../src/admin/services/support-ticket.service';
+import { SupportTicket } from '../src/admin/entities/support-ticket.entity';
+import { TicketMessage, TicketAuthorType } from '../src/admin/entities/ticket-message.entity';
+import { User } from '../src/user/entities/user.entity';
+import { Notification } from '../src/notifications/entities/notification.entity';
+import { AuditLogService } from '../src/admin/services/audit-log.service';
+import { RoleGuard } from '../src/roles/guards/role.guard';
+import { TicketStatus } from '../src/admin/enums/ticket-status.enum';
+import { TicketCategory } from '../src/admin/enums/ticket-category.enum';
+import { TicketPriority } from '../src/admin/enums/ticket-priority.enum';
+
+const ADMIN_ID = 'admin-uuid-e2e';
+const USER_ID = 'user-uuid-e2e';
+const TICKET_ID = 'ticket-uuid-e2e';
+
+const mockUser = {
+  id: ADMIN_ID,
+  role: 'admin',
+  roles: [{ name: 'admin' }],
+};
+
+const baseTicket: Partial<SupportTicket> = {
+  id: TICKET_ID,
+  userId: USER_ID,
+  subject: 'I cannot withdraw funds',
+  description: 'Getting 500 error when I click withdraw',
+  category: TicketCategory.TRANSACTION,
+  status: TicketStatus.OPEN,
+  priority: TicketPriority.HIGH,
+  assignedToId: null,
+  resolvedAt: null,
+  messages: [],
+  createdAt: new Date('2024-06-01T12:00:00Z'),
+  updatedAt: new Date('2024-06-01T12:00:00Z'),
+};
+
+describe('Support Tickets (e2e)', () => {
+  let app: INestApplication;
+  let ticketRepo: any;
+  let messageRepo: any;
+  let userRepo: any;
+  let notificationRepo: any;
+  let qbMock: any;
+
+  beforeAll(async () => {
+    qbMock = {
+      leftJoinAndSelect: jest.fn().mockReturnThis(),
+      orderBy: jest.fn().mockReturnThis(),
+      skip: jest.fn().mockReturnThis(),
+      take: jest.fn().mockReturnThis(),
+      andWhere: jest.fn().mockReturnThis(),
+      getManyAndCount: jest.fn().mockResolvedValue([[baseTicket], 1]),
+      update: jest.fn().mockReturnThis(),
+      set: jest.fn().mockReturnThis(),
+      where: jest.fn().mockReturnThis(),
+      execute: jest.fn().mockResolvedValue({ affected: 0 }),
+    };
+
+    ticketRepo = {
+      findOne: jest.fn().mockResolvedValue(baseTicket),
+      update: jest.fn().mockResolvedValue({ affected: 1 }),
+      createQueryBuilder: jest.fn().mockReturnValue(qbMock),
+    };
+    messageRepo = {
+      create: jest.fn().mockImplementation((d) => d),
+      save: jest
+        .fn()
+        .mockImplementation((d) => Promise.resolve({ id: 'msg-uuid', ...d })),
+    };
+    userRepo = {
+      findOne: jest.fn().mockResolvedValue({ id: ADMIN_ID }),
+    };
+    notificationRepo = {
+      create: jest.fn().mockImplementation((d) => d),
+      save: jest.fn().mockResolvedValue({}),
+    };
+
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      controllers: [SupportTicketController],
+      providers: [
+        SupportTicketService,
+        { provide: getRepositoryToken(SupportTicket), useValue: ticketRepo },
+        { provide: getRepositoryToken(TicketMessage), useValue: messageRepo },
+        { provide: getRepositoryToken(User), useValue: userRepo },
+        { provide: getRepositoryToken(Notification), useValue: notificationRepo },
+        {
+          provide: AuditLogService,
+          useValue: { createAuditLog: jest.fn().mockResolvedValue({}) },
+        },
+      ],
+    })
+      .overrideGuard(RoleGuard)
+      .useValue({ canActivate: () => true })
+      .compile();
+
+    app = moduleFixture.createNestApplication();
+    app.useGlobalPipes(
+      new ValidationPipe({ whitelist: true, transform: true, forbidNonWhitelisted: true }),
+    );
+
+    // Inject mock admin user into every request
+    app.use((req: any, _res: any, next: any) => {
+      req.user = mockUser;
+      next();
+    });
+
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  // ─── GET /admin/support/tickets ───────────────────────────────────────────
+
+  describe('GET /admin/support/tickets', () => {
+    it('returns paginated ticket list', async () => {
+      const res = await request(app.getHttpServer())
+        .get('/admin/support/tickets')
+        .expect(200);
+
+      expect(res.body.data).toBeDefined();
+      expect(res.body.total).toBe(1);
+      expect(res.body.page).toBe(1);
+    });
+
+    it('accepts status filter in query string', async () => {
+      await request(app.getHttpServer())
+        .get('/admin/support/tickets?status=open')
+        .expect(200);
+    });
+
+    it('rejects invalid status value', async () => {
+      await request(app.getHttpServer())
+        .get('/admin/support/tickets?status=invalid_status')
+        .expect(400);
+    });
+
+    it('rejects invalid priority value', async () => {
+      await request(app.getHttpServer())
+        .get('/admin/support/tickets?priority=extreme')
+        .expect(400);
+    });
+  });
+
+  // ─── GET /admin/support/tickets/:ticketId ─────────────────────────────────
+
+  describe('GET /admin/support/tickets/:ticketId', () => {
+    it('returns ticket detail with messages array', async () => {
+      const msg1 = {
+        id: 'm1',
+        body: 'First',
+        authorType: TicketAuthorType.USER,
+        createdAt: new Date('2024-06-01T13:00:00Z'),
+      } as TicketMessage;
+      ticketRepo.findOne.mockResolvedValueOnce({ ...baseTicket, messages: [msg1] });
+
+      const res = await request(app.getHttpServer())
+        .get(`/admin/support/tickets/${TICKET_ID}`)
+        .expect(200);
+
+      expect(res.body.id).toBe(TICKET_ID);
+      expect(Array.isArray(res.body.messages)).toBe(true);
+    });
+
+    it('returns 404 for unknown ticket', async () => {
+      ticketRepo.findOne.mockResolvedValueOnce(null);
+
+      await request(app.getHttpServer())
+        .get('/admin/support/tickets/nonexistent-id')
+        .expect(404);
+    });
+  });
+
+  // ─── POST /admin/support/tickets/:ticketId/messages ───────────────────────
+
+  describe('POST /admin/support/tickets/:ticketId/messages', () => {
+    beforeEach(() => {
+      ticketRepo.findOne.mockResolvedValue(baseTicket);
+    });
+
+    it('creates a reply message', async () => {
+      const res = await request(app.getHttpServer())
+        .post(`/admin/support/tickets/${TICKET_ID}/messages`)
+        .send({ body: 'We are looking into this for you.' })
+        .expect(201);
+
+      expect(res.body.body).toBe('We are looking into this for you.');
+      expect(res.body.authorType).toBe(TicketAuthorType.ADMIN);
+    });
+
+    it('rejects empty body', async () => {
+      await request(app.getHttpServer())
+        .post(`/admin/support/tickets/${TICKET_ID}/messages`)
+        .send({ body: '' })
+        .expect(400);
+    });
+
+    it('rejects missing body field', async () => {
+      await request(app.getHttpServer())
+        .post(`/admin/support/tickets/${TICKET_ID}/messages`)
+        .send({})
+        .expect(400);
+    });
+  });
+
+  // ─── PATCH /admin/support/tickets/:ticketId ───────────────────────────────
+
+  describe('PATCH /admin/support/tickets/:ticketId', () => {
+    it('updates priority', async () => {
+      ticketRepo.findOne
+        .mockResolvedValueOnce(baseTicket)
+        .mockResolvedValueOnce({ ...baseTicket, priority: TicketPriority.URGENT });
+
+      const res = await request(app.getHttpServer())
+        .patch(`/admin/support/tickets/${TICKET_ID}`)
+        .send({ priority: TicketPriority.URGENT })
+        .expect(200);
+
+      expect(res.body.priority).toBe(TicketPriority.URGENT);
+    });
+
+    it('rejects unknown fields (whitelist)', async () => {
+      await request(app.getHttpServer())
+        .patch(`/admin/support/tickets/${TICKET_ID}`)
+        .send({ unknownField: 'hack' })
+        .expect(400);
+    });
+  });
+
+  // ─── POST /admin/support/tickets/:ticketId/assign ─────────────────────────
+
+  describe('POST /admin/support/tickets/:ticketId/assign', () => {
+    it('assigns ticket to an admin', async () => {
+      const assigneeId = 'assignee-admin-uuid';
+      ticketRepo.findOne
+        .mockResolvedValueOnce(baseTicket)
+        .mockResolvedValueOnce({ ...baseTicket, assignedToId: assigneeId });
+      userRepo.findOne.mockResolvedValueOnce({ id: assigneeId });
+
+      const res = await request(app.getHttpServer())
+        .post(`/admin/support/tickets/${TICKET_ID}/assign`)
+        .send({ adminId: assigneeId })
+        .expect(201);
+
+      expect(res.body.assignedToId).toBe(assigneeId);
+    });
+
+    it('rejects non-UUID adminId', async () => {
+      await request(app.getHttpServer())
+        .post(`/admin/support/tickets/${TICKET_ID}/assign`)
+        .send({ adminId: 'not-a-uuid' })
+        .expect(400);
+    });
+  });
+
+  // ─── POST /admin/support/tickets/:ticketId/resolve ────────────────────────
+
+  describe('POST /admin/support/tickets/:ticketId/resolve', () => {
+    it('resolves ticket with a resolution note', async () => {
+      ticketRepo.findOne
+        .mockResolvedValueOnce({ ...baseTicket, status: TicketStatus.IN_PROGRESS })
+        .mockResolvedValueOnce({
+          ...baseTicket,
+          status: TicketStatus.RESOLVED,
+          resolvedAt: new Date(),
+        });
+
+      const res = await request(app.getHttpServer())
+        .post(`/admin/support/tickets/${TICKET_ID}/resolve`)
+        .send({ resolutionNote: 'Issue was a known bug, patched in v2.3.' })
+        .expect(201);
+
+      expect(res.body.status).toBe(TicketStatus.RESOLVED);
+    });
+
+    it('rejects empty resolutionNote', async () => {
+      await request(app.getHttpServer())
+        .post(`/admin/support/tickets/${TICKET_ID}/resolve`)
+        .send({ resolutionNote: '' })
+        .expect(400);
+    });
+
+    it('rejects missing resolutionNote', async () => {
+      await request(app.getHttpServer())
+        .post(`/admin/support/tickets/${TICKET_ID}/resolve`)
+        .send({})
+        .expect(400);
+    });
+  });
+
+  // ─── POST /admin/support/tickets/:ticketId/close ──────────────────────────
+
+  describe('POST /admin/support/tickets/:ticketId/close', () => {
+    it('closes a resolved ticket', async () => {
+      ticketRepo.findOne
+        .mockResolvedValueOnce({ ...baseTicket, status: TicketStatus.RESOLVED })
+        .mockResolvedValueOnce({ ...baseTicket, status: TicketStatus.CLOSED });
+
+      const res = await request(app.getHttpServer())
+        .post(`/admin/support/tickets/${TICKET_ID}/close`)
+        .expect(200);
+
+      expect(res.body.status).toBe(TicketStatus.CLOSED);
+    });
+
+    it('returns 400 when ticket is not yet resolved', async () => {
+      ticketRepo.findOne.mockResolvedValueOnce({
+        ...baseTicket,
+        status: TicketStatus.IN_PROGRESS,
+      });
+
+      await request(app.getHttpServer())
+        .post(`/admin/support/tickets/${TICKET_ID}/close`)
+        .expect(400);
+    });
+  });
+});


### PR DESCRIPTION
PR closes #244 
- Add SupportTicket entity (status, priority, category, assignedTo, resolvedAt)
- Add TicketMessage entity (authorType user|admin, body, ticketId FK cascade)
- Add TicketStatus, TicketCategory, TicketPriority enums
- Add GET /admin/support/tickets (paginated, filterable by status/priority/category/userId/assignedTo/date/search)
- Add GET /admin/support/tickets/:id (full ticket + messages sorted oldest-first)
- Add POST /admin/support/tickets/:id/messages (admin reply, notifies user in-app)
- Add PATCH /admin/support/tickets/:id (status/priority/category/assignedTo — ADMIN+)
- Add POST /admin/support/tickets/:id/assign (notifies assignee in-app — ADMIN+)
- Add POST /admin/support/tickets/:id/resolve (records resolvedAt + resolution note — ADMIN+)
- Add POST /admin/support/tickets/:id/close (only from RESOLVED state — ADMIN+)
- Add hourly cron to auto-close tickets 72h after resolution
- Add MODERATOR role access for read + reply endpoints
- Add audit logging for assign, status change, and resolve actions
- Add migrations for support_tickets and ticket_messages tables
- Add unit tests covering all service methods and edge cases
- Add e2e tests for all 8 endpoints including validation