### PR TITLE
feat(admin): implement EVM chain health monitoring

### DIFF
--- a/src/admin/admin.module.ts
+++ b/src/admin/admin.module.ts
@@ -57,6 +57,10 @@ import { WebhookDelivery } from './entities/webhook-delivery.entity';
 import { WebhookService } from './services/webhook.service';
 import { WebhookDeliveryProcessor } from './jobs/webhook-delivery.processor';
 import { WebhookController } from './controllers/webhook.controller';
+import { ChainHealthRecord } from './entities/chain-health-record.entity';
+import { ChainHealthService } from './services/chain-health.service';
+import { ChainHealthController } from './controllers/chain-health.controller';
+import { ChainModule } from '../chain/chain.module';
 
 @Module({
   imports: [
@@ -70,6 +74,7 @@ import { WebhookController } from './controllers/webhook.controller';
     UsersModule,
     NotificationsModule,
     QueueModule,
+    ChainModule,
     TypeOrmModule.forFeature([
       User,
       AuditLog,
@@ -95,9 +100,10 @@ import { WebhookController } from './controllers/webhook.controller';
       NotificationDelivery,
       WebhookSubscription,
       WebhookDelivery,
+      ChainHealthRecord,
     ]),
   ],
-  controllers: [AdminController, IpWhitelistController, WebhookController],
+  controllers: [AdminController, IpWhitelistController, WebhookController, ChainHealthController],
   providers: [
     AdminConfigService,
     AdminService,
@@ -114,6 +120,7 @@ import { WebhookController } from './controllers/webhook.controller';
     BroadcastDeliveryStatsService,
     WebhookService,
     WebhookDeliveryProcessor,
+    ChainHealthService,
   ],
   exports: [
     AdminConfigService,
@@ -123,6 +130,7 @@ import { WebhookController } from './controllers/webhook.controller';
     AdminBroadcastService,
     BroadcastDeliveryStatsService,
     WebhookService,
+    ChainHealthService,
   ],
 })
 export class AdminModule {

--- a/src/admin/controllers/chain-health.controller.ts
+++ b/src/admin/controllers/chain-health.controller.ts
@@ -1,0 +1,50 @@
+import { Controller, Get, Query, UseGuards } from '@nestjs/common';
+import {
+  ApiTags,
+  ApiBearerAuth,
+  ApiOperation,
+  ApiResponse,
+  ApiQuery,
+} from '@nestjs/swagger';
+import { RoleGuard } from '../../roles/guards/role.guard';
+import { Roles } from '../../roles/decorators/roles.decorator';
+import { UserRole } from '../../roles/entities/role.entity';
+import { ChainHealthService } from '../services/chain-health.service';
+import { SupportedChain } from '../../chain/enums/supported-chain.enum';
+
+@ApiTags('admin-chains')
+@ApiBearerAuth()
+@UseGuards(RoleGuard)
+@Roles(UserRole.ADMIN, UserRole.SUPER_ADMIN)
+@Controller('admin/chains')
+export class ChainHealthController {
+  constructor(private readonly chainHealthService: ChainHealthService) {}
+
+  @Get('health')
+  @ApiOperation({
+    summary: 'Current EVM chain health (read from Redis — instant, no live RPC call)',
+    description:
+      'Returns cached health for all configured chains. Data is refreshed every 30 seconds by the background cron job.',
+  })
+  @ApiResponse({ status: 200, description: 'Health map keyed by chain name' })
+  async getCurrentHealth() {
+    return this.chainHealthService.getCurrentHealth();
+  }
+
+  @Get('health/history')
+  @ApiOperation({
+    summary: 'Last 24 h of chain health check results per chain',
+    description:
+      'Useful for identifying recurring degradation windows. Ordered newest-first.',
+  })
+  @ApiQuery({
+    name: 'chain',
+    required: false,
+    enum: SupportedChain,
+    description: 'Filter results to a specific chain',
+  })
+  @ApiResponse({ status: 200, description: 'Array of historical health records' })
+  async getHistory(@Query('chain') chain?: SupportedChain) {
+    return this.chainHealthService.getHealthHistory(chain);
+  }
+}

--- a/src/admin/entities/chain-health-record.entity.ts
+++ b/src/admin/entities/chain-health-record.entity.ts
@@ -1,0 +1,40 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  Index,
+} from 'typeorm';
+import { ChainHealthStatus } from '../enums/chain-health-status.enum';
+
+@Entity('chain_health_records')
+@Index(['chain', 'checkedAt'])
+@Index(['checkedAt'])
+export class ChainHealthRecord {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ type: 'varchar', length: 20 })
+  chain: string;
+
+  @Column({ type: 'enum', enum: ChainHealthStatus })
+  status: ChainHealthStatus;
+
+  @Column({ type: 'int', nullable: true })
+  latencyMs: number | null;
+
+  @Column({ type: 'bigint', nullable: true })
+  blockNumber: number | null;
+
+  @Column({ type: 'int', nullable: true })
+  blockAge: number | null;
+
+  @Column({ type: 'varchar', length: 40, nullable: true })
+  paymasterBalance: string | null;
+
+  @Column({ type: 'boolean', default: false })
+  paymasterBalanceWarning: boolean;
+
+  @CreateDateColumn({ name: 'checkedAt' })
+  checkedAt: Date;
+}

--- a/src/admin/enums/chain-health-status.enum.ts
+++ b/src/admin/enums/chain-health-status.enum.ts
@@ -1,0 +1,5 @@
+export enum ChainHealthStatus {
+  HEALTHY = 'healthy',
+  DEGRADED = 'degraded',
+  DOWN = 'down',
+}

--- a/src/admin/events/admin-stream.events.ts
+++ b/src/admin/events/admin-stream.events.ts
@@ -7,7 +7,8 @@ export type AdminStreamEventType =
   | 'user.registered'
   | 'transaction.large'
   | 'room.flagged'
-  | 'platform.error';
+  | 'platform.error'
+  | 'security.alert';
 
 export interface AdminStreamEventPayload {
   type: AdminStreamEventType;
@@ -47,4 +48,12 @@ export interface PlatformErrorEntity {
   message: string;
   code?: string;
   context?: string;
+}
+
+export interface SecurityAlertEntity {
+  alertType: string;
+  chain: string;
+  details: string;
+  paymasterBalance?: string;
+  threshold?: string;
 }

--- a/src/admin/gateways/admin-event-stream.gateway.ts
+++ b/src/admin/gateways/admin-event-stream.gateway.ts
@@ -22,6 +22,7 @@ export const ADMIN_STREAM_EVENTS = {
   TRANSACTION_LARGE: 'admin.stream.transaction.large',
   ROOM_FLAGGED: 'admin.stream.room.flagged',
   PLATFORM_ERROR: 'admin.stream.platform.error',
+  SECURITY_ALERT: 'admin.stream.security.alert',
 } as const;
 
 @WebSocketGateway({
@@ -139,6 +140,11 @@ export class AdminEventStreamGateway
 
   @OnEvent(ADMIN_STREAM_EVENTS.PLATFORM_ERROR)
   onPlatformError(payload: AdminStreamEventPayload): void {
+    this.broadcast(payload);
+  }
+
+  @OnEvent(ADMIN_STREAM_EVENTS.SECURITY_ALERT)
+  onSecurityAlert(payload: AdminStreamEventPayload): void {
     this.broadcast(payload);
   }
 }

--- a/src/admin/services/chain-health.service.spec.ts
+++ b/src/admin/services/chain-health.service.spec.ts
@@ -1,0 +1,279 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import { ConfigService } from '@nestjs/config';
+import { ChainHealthService, ChainHealthResult } from './chain-health.service';
+import { ChainHealthRecord } from '../entities/chain-health-record.entity';
+import { ChainHealthStatus } from '../enums/chain-health-status.enum';
+import { ChainService } from '../../chain/chain.service';
+import { RedisService } from '../../redis/redis.service';
+import { SupportedChain } from '../../chain/enums/supported-chain.enum';
+import { ADMIN_STREAM_EVENTS } from '../gateways/admin-event-stream.gateway';
+
+const mockProvider = {
+  getBlock: jest.fn(),
+  getBalance: jest.fn(),
+};
+
+const mockChainService = {
+  getAllChains: jest.fn().mockReturnValue([
+    { chain: SupportedChain.BNB },
+    { chain: SupportedChain.BASE },
+  ]),
+  getChainConfig: jest.fn().mockReturnValue({
+    rpcUrl: 'https://rpc.example.com',
+    name: 'Test Chain',
+  }),
+  getProvider: jest.fn().mockReturnValue(mockProvider),
+};
+
+const mockRedisService = {
+  get: jest.fn(),
+  set: jest.fn().mockResolvedValue(undefined),
+};
+
+const mockEventEmitter = {
+  emit: jest.fn(),
+};
+
+const mockConfigService = {
+  get: jest.fn((key: string) => {
+    if (key === 'PAYMASTER_ADDRESS') return '0xDeadBeef00000000000000000000000000000001';
+    if (key === 'PAYMASTER_BALANCE_WARN_THRESHOLD') return '0.5';
+    return undefined;
+  }),
+};
+
+const mockHealthRepo = {
+  find: jest.fn().mockResolvedValue([]),
+  save: jest.fn().mockResolvedValue({}),
+  create: jest.fn().mockImplementation((d) => d),
+  createQueryBuilder: jest.fn().mockReturnValue({
+    delete: jest.fn().mockReturnThis(),
+    from: jest.fn().mockReturnThis(),
+    where: jest.fn().mockReturnThis(),
+    execute: jest.fn().mockResolvedValue({ affected: 0 }),
+  }),
+};
+
+describe('ChainHealthService', () => {
+  let service: ChainHealthService;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ChainHealthService,
+        { provide: getRepositoryToken(ChainHealthRecord), useValue: mockHealthRepo },
+        { provide: ChainService, useValue: mockChainService },
+        { provide: RedisService, useValue: mockRedisService },
+        { provide: EventEmitter2, useValue: mockEventEmitter },
+        { provide: ConfigService, useValue: mockConfigService },
+      ],
+    }).compile();
+
+    service = module.get<ChainHealthService>(ChainHealthService);
+  });
+
+  // ─── classifyHealth ───────────────────────────────────────────────────────
+
+  describe('classifyHealth', () => {
+    it('returns HEALTHY when latency < 500ms and blockAge < 30s', () => {
+      expect(service.classifyHealth(100, 10)).toBe(ChainHealthStatus.HEALTHY);
+    });
+
+    it('returns HEALTHY with exactly 0ms latency and 0s blockAge', () => {
+      expect(service.classifyHealth(0, 0)).toBe(ChainHealthStatus.HEALTHY);
+    });
+
+    it('returns HEALTHY at boundary: latency = 499ms and blockAge = 29s', () => {
+      expect(service.classifyHealth(499, 29)).toBe(ChainHealthStatus.HEALTHY);
+    });
+
+    it('returns DEGRADED when latency > 500ms (block is fine)', () => {
+      expect(service.classifyHealth(501, 5)).toBe(ChainHealthStatus.DEGRADED);
+    });
+
+    it('returns DEGRADED when blockAge = 30s (at warn threshold)', () => {
+      expect(service.classifyHealth(100, 30)).toBe(ChainHealthStatus.DEGRADED);
+    });
+
+    it('returns DEGRADED when blockAge = 120s (at down boundary, exclusive)', () => {
+      // blockAge == 120 is still DEGRADED (> 120 → DOWN)
+      expect(service.classifyHealth(100, 120)).toBe(ChainHealthStatus.DEGRADED);
+    });
+
+    it('returns DEGRADED when both latency and blockAge are in degraded range', () => {
+      expect(service.classifyHealth(800, 60)).toBe(ChainHealthStatus.DEGRADED);
+    });
+
+    it('returns DOWN when RPC does not respond (latencyMs is null)', () => {
+      expect(service.classifyHealth(null, null)).toBe(ChainHealthStatus.DOWN);
+    });
+
+    it('returns DOWN when blockAge > 120s', () => {
+      expect(service.classifyHealth(50, 121)).toBe(ChainHealthStatus.DOWN);
+    });
+
+    it('returns DOWN when blockAge is very stale (no RPC issue)', () => {
+      expect(service.classifyHealth(200, 3600)).toBe(ChainHealthStatus.DOWN);
+    });
+
+    it('returns DOWN over DEGRADED when blockAge > 120 even if latency is fine', () => {
+      expect(service.classifyHealth(100, 200)).toBe(ChainHealthStatus.DOWN);
+    });
+
+    it('handles null blockAge with healthy latency → HEALTHY', () => {
+      // If block age is unknown but latency is fast, default to healthy
+      expect(service.classifyHealth(100, null)).toBe(ChainHealthStatus.HEALTHY);
+    });
+
+    it('handles null blockAge with slow latency → DEGRADED', () => {
+      expect(service.classifyHealth(700, null)).toBe(ChainHealthStatus.DEGRADED);
+    });
+  });
+
+  // ─── getCurrentHealth ────────────────────────────────────────────────────
+
+  describe('getCurrentHealth', () => {
+    it('returns parsed health results from Redis for each chain', async () => {
+      const bnbHealth: ChainHealthResult = {
+        chain: SupportedChain.BNB,
+        rpcUrl: 'https://bsc.example.com',
+        status: ChainHealthStatus.HEALTHY,
+        latencyMs: 120,
+        blockNumber: 1234,
+        blockAge: 5,
+        paymasterBalance: '1.200000',
+        paymasterBalanceWarning: false,
+        lastCheckedAt: new Date().toISOString(),
+      };
+
+      mockRedisService.get.mockImplementation((key: string) => {
+        if (key.includes(SupportedChain.BNB)) return Promise.resolve(JSON.stringify(bnbHealth));
+        return Promise.resolve(null);
+      });
+
+      const result = await service.getCurrentHealth();
+
+      expect(result[SupportedChain.BNB]).toEqual(bnbHealth);
+      expect(result[SupportedChain.BASE]).toBeNull();
+    });
+
+    it('returns null for chains with no Redis entry', async () => {
+      mockRedisService.get.mockResolvedValue(null);
+
+      const result = await service.getCurrentHealth();
+
+      expect(Object.values(result).every((v) => v === null)).toBe(true);
+    });
+  });
+
+  // ─── getHealthHistory ────────────────────────────────────────────────────
+
+  describe('getHealthHistory', () => {
+    it('queries last 24h records without chain filter', async () => {
+      const record = {
+        id: 'r1',
+        chain: SupportedChain.BNB,
+        status: ChainHealthStatus.HEALTHY,
+        checkedAt: new Date(),
+      } as ChainHealthRecord;
+      mockHealthRepo.find.mockResolvedValue([record]);
+
+      const result = await service.getHealthHistory();
+
+      expect(result).toEqual([record]);
+      expect(mockHealthRepo.find).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            checkedAt: expect.anything(),
+          }),
+          order: { checkedAt: 'DESC' },
+        }),
+      );
+    });
+
+    it('applies chain filter when provided', async () => {
+      mockHealthRepo.find.mockResolvedValue([]);
+
+      await service.getHealthHistory(SupportedChain.BASE);
+
+      expect(mockHealthRepo.find).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ chain: SupportedChain.BASE }),
+        }),
+      );
+    });
+  });
+
+  // ─── checkAllChains (integration via private checkAndPersist) ────────────
+
+  describe('checkAllChains', () => {
+    it('persists health records to Redis and DB for each chain', async () => {
+      const nowSec = Math.floor(Date.now() / 1000);
+      mockProvider.getBlock.mockResolvedValue({
+        number: 99999,
+        timestamp: nowSec - 5, // 5s old block → healthy
+      });
+      // Balance above threshold (0.5 ETH)
+      mockProvider.getBalance.mockResolvedValue(BigInt('1000000000000000000')); // 1 ETH
+
+      await service.checkAllChains();
+
+      // Two chains → two Redis writes
+      expect(mockRedisService.set).toHaveBeenCalledTimes(2);
+      expect(mockHealthRepo.save).toHaveBeenCalledTimes(2);
+      // No security alert because balance > threshold
+      expect(mockEventEmitter.emit).not.toHaveBeenCalled();
+    });
+
+    it('marks chain as DOWN when provider throws', async () => {
+      mockProvider.getBlock.mockRejectedValue(new Error('Connection refused'));
+
+      await service.checkAllChains();
+
+      // Should still save records (DOWN status)
+      const saveCalls = mockHealthRepo.save.mock.calls;
+      expect(saveCalls.length).toBeGreaterThan(0);
+      expect(saveCalls[0][0]).toEqual(
+        expect.objectContaining({ status: ChainHealthStatus.DOWN, latencyMs: null }),
+      );
+    });
+
+    it('emits SECURITY_ALERT when paymaster balance falls below threshold', async () => {
+      const nowSec = Math.floor(Date.now() / 1000);
+      mockProvider.getBlock.mockResolvedValue({
+        number: 12345,
+        timestamp: nowSec - 3,
+      });
+      // Balance below 0.5 ETH threshold → 0.1 ETH
+      mockProvider.getBalance.mockResolvedValue(BigInt('100000000000000000'));
+
+      await service.checkAllChains();
+
+      expect(mockEventEmitter.emit).toHaveBeenCalledWith(
+        ADMIN_STREAM_EVENTS.SECURITY_ALERT,
+        expect.objectContaining({
+          type: 'security.alert',
+          entity: expect.objectContaining({
+            alertType: 'low_paymaster_balance',
+          }),
+        }),
+      );
+    });
+
+    it('sets paymasterBalanceWarning: true on DB record when balance is low', async () => {
+      const nowSec = Math.floor(Date.now() / 1000);
+      mockProvider.getBlock.mockResolvedValue({ number: 1, timestamp: nowSec - 2 });
+      mockProvider.getBalance.mockResolvedValue(BigInt('50000000000000000')); // 0.05 ETH < 0.5
+
+      await service.checkAllChains();
+
+      expect(mockHealthRepo.save).toHaveBeenCalledWith(
+        expect.objectContaining({ paymasterBalanceWarning: true }),
+      );
+    });
+  });
+});

--- a/src/admin/services/chain-health.service.ts
+++ b/src/admin/services/chain-health.service.ts
@@ -1,0 +1,267 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository, MoreThanOrEqual } from 'typeorm';
+import { Cron } from '@nestjs/schedule';
+import { ConfigService } from '@nestjs/config';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import { ethers } from 'ethers';
+
+import { ChainService } from '../../chain/chain.service';
+import { SupportedChain } from '../../chain/enums/supported-chain.enum';
+import { RedisService } from '../../redis/redis.service';
+import { ChainHealthRecord } from '../entities/chain-health-record.entity';
+import { ChainHealthStatus } from '../enums/chain-health-status.enum';
+import { ADMIN_STREAM_EVENTS } from '../gateways/admin-event-stream.gateway';
+
+const LATENCY_WARN_MS = 500;
+const BLOCK_AGE_WARN_S = 30;
+const BLOCK_AGE_DOWN_S = 120;
+const REDIS_KEY_PREFIX = 'admin:chain:health:';
+const REDIS_TTL_S = 120;
+const HISTORY_HOURS = 24;
+const CLEANUP_OLDER_THAN_HOURS = 25; // keep a 1h buffer
+
+export interface ChainHealthResult {
+  chain: string;
+  rpcUrl: string;
+  status: ChainHealthStatus;
+  latencyMs: number | null;
+  blockNumber: number | null;
+  blockAge: number | null;
+  paymasterBalance: string | null;
+  paymasterBalanceWarning: boolean;
+  lastCheckedAt: string;
+}
+
+@Injectable()
+export class ChainHealthService {
+  private readonly logger = new Logger(ChainHealthService.name);
+  private readonly paymasterAddress: string | null;
+  private readonly balanceWarnThreshold: number;
+
+  constructor(
+    @InjectRepository(ChainHealthRecord)
+    private readonly healthRecordRepository: Repository<ChainHealthRecord>,
+    private readonly chainService: ChainService,
+    private readonly redisService: RedisService,
+    private readonly eventEmitter: EventEmitter2,
+    private readonly configService: ConfigService,
+  ) {
+    // Resolve paymaster address (explicit env var OR derived from EVM_PRIVATE_KEY)
+    const explicit = this.configService.get<string>('PAYMASTER_ADDRESS');
+    if (explicit) {
+      this.paymasterAddress = explicit;
+    } else {
+      const pk = this.configService.get<string>('EVM_PRIVATE_KEY');
+      if (pk) {
+        try {
+          this.paymasterAddress = new ethers.Wallet(pk).address;
+        } catch {
+          this.paymasterAddress = null;
+        }
+      } else {
+        this.paymasterAddress = null;
+      }
+    }
+
+    const rawThreshold = this.configService.get<string>(
+      'PAYMASTER_BALANCE_WARN_THRESHOLD',
+    );
+    this.balanceWarnThreshold = rawThreshold ? parseFloat(rawThreshold) : 0.1;
+  }
+
+  // ─── Cron: every 30 seconds ──────────────────────────────────────────────
+
+  @Cron('*/30 * * * * *')
+  async checkAllChains(): Promise<void> {
+    const chains = this.chainService.getAllChains();
+    await Promise.allSettled(
+      chains.map(({ chain }) => this.checkAndPersist(chain)),
+    );
+    // Prune history older than retention window
+    await this.pruneOldRecords();
+  }
+
+  // ─── Public API ──────────────────────────────────────────────────────────
+
+  /**
+   * Read current health for all chains from Redis.
+   * Returns stale data if Redis is populated; returns null per chain if no data yet.
+   */
+  async getCurrentHealth(): Promise<Record<string, ChainHealthResult | null>> {
+    const chains = this.chainService.getAllChains();
+    const result: Record<string, ChainHealthResult | null> = {};
+
+    await Promise.all(
+      chains.map(async ({ chain }) => {
+        const raw = await this.redisService.get(`${REDIS_KEY_PREFIX}${chain}`);
+        result[chain] = raw ? (JSON.parse(raw) as ChainHealthResult) : null;
+      }),
+    );
+
+    return result;
+  }
+
+  /**
+   * Return last 24h of health check records, optionally filtered to one chain.
+   */
+  async getHealthHistory(
+    chain?: SupportedChain,
+  ): Promise<ChainHealthRecord[]> {
+    const since = new Date(
+      Date.now() - HISTORY_HOURS * 60 * 60 * 1000,
+    );
+
+    const where: Record<string, any> = { checkedAt: MoreThanOrEqual(since) };
+    if (chain) {
+      where.chain = chain;
+    }
+
+    return this.healthRecordRepository.find({
+      where,
+      order: { checkedAt: 'DESC' },
+    });
+  }
+
+  // ─── Health classification (pure / testable) ─────────────────────────────
+
+  classifyHealth(
+    latencyMs: number | null,
+    blockAge: number | null,
+  ): ChainHealthStatus {
+    // No RPC response at all
+    if (latencyMs === null) {
+      return ChainHealthStatus.DOWN;
+    }
+    // Block is too old → down regardless of latency
+    if (blockAge !== null && blockAge > BLOCK_AGE_DOWN_S) {
+      return ChainHealthStatus.DOWN;
+    }
+    // Slow RPC or block starting to age → degraded
+    if (
+      latencyMs > LATENCY_WARN_MS ||
+      (blockAge !== null && blockAge >= BLOCK_AGE_WARN_S)
+    ) {
+      return ChainHealthStatus.DEGRADED;
+    }
+    return ChainHealthStatus.HEALTHY;
+  }
+
+  // ─── Internal ────────────────────────────────────────────────────────────
+
+  private async checkAndPersist(chain: SupportedChain): Promise<void> {
+    const config = this.chainService.getChainConfig(chain);
+    const provider = this.chainService.getProvider(chain);
+    const start = Date.now();
+
+    let latencyMs: number | null = null;
+    let blockNumber: number | null = null;
+    let blockAge: number | null = null;
+
+    try {
+      const block = await Promise.race([
+        provider.getBlock('latest'),
+        new Promise<never>((_, reject) =>
+          setTimeout(() => reject(new Error('RPC timeout')), 10_000),
+        ),
+      ]);
+
+      latencyMs = Date.now() - start;
+
+      if (block) {
+        blockNumber = block.number;
+        const nowSec = Math.floor(Date.now() / 1000);
+        blockAge = nowSec - block.timestamp;
+      }
+    } catch (err) {
+      this.logger.warn(
+        `Chain ${chain} health check failed: ${(err as Error).message}`,
+      );
+      // latencyMs remains null → DOWN
+    }
+
+    const status = this.classifyHealth(latencyMs, blockAge);
+
+    // Paymaster balance
+    let paymasterBalance: string | null = null;
+    let paymasterBalanceWarning = false;
+
+    if (this.paymasterAddress && latencyMs !== null) {
+      try {
+        const raw = await provider.getBalance(this.paymasterAddress);
+        const formatted = parseFloat(ethers.formatEther(raw));
+        paymasterBalance = formatted.toFixed(6);
+        paymasterBalanceWarning = formatted < this.balanceWarnThreshold;
+      } catch (err) {
+        this.logger.warn(
+          `Could not fetch paymaster balance on ${chain}: ${(err as Error).message}`,
+        );
+      }
+    }
+
+    const result: ChainHealthResult = {
+      chain,
+      rpcUrl: config.rpcUrl,
+      status,
+      latencyMs,
+      blockNumber,
+      blockAge,
+      paymasterBalance,
+      paymasterBalanceWarning,
+      lastCheckedAt: new Date().toISOString(),
+    };
+
+    // Persist to Redis
+    await this.redisService.set(
+      `${REDIS_KEY_PREFIX}${chain}`,
+      JSON.stringify(result),
+      REDIS_TTL_S,
+    );
+
+    // Persist to DB for history
+    await this.healthRecordRepository.save(
+      this.healthRecordRepository.create({
+        chain,
+        status,
+        latencyMs,
+        blockNumber,
+        blockAge,
+        paymasterBalance,
+        paymasterBalanceWarning,
+      }),
+    );
+
+    // Emit WebSocket security alert if paymaster balance is low
+    if (paymasterBalanceWarning) {
+      this.eventEmitter.emit(ADMIN_STREAM_EVENTS.SECURITY_ALERT, {
+        type: 'security.alert',
+        timestamp: new Date().toISOString(),
+        entity: {
+          alertType: 'low_paymaster_balance',
+          chain,
+          details: `Paymaster balance on ${chain} is ${paymasterBalance} ETH — below threshold of ${this.balanceWarnThreshold}`,
+          paymasterBalance,
+          threshold: String(this.balanceWarnThreshold),
+        },
+      });
+    }
+  }
+
+  private async pruneOldRecords(): Promise<void> {
+    try {
+      const cutoff = new Date(
+        Date.now() - CLEANUP_OLDER_THAN_HOURS * 60 * 60 * 1000,
+      );
+      await this.healthRecordRepository
+        .createQueryBuilder()
+        .delete()
+        .from(ChainHealthRecord)
+        .where('checkedAt < :cutoff', { cutoff })
+        .execute();
+    } catch (err) {
+      this.logger.warn(
+        `Failed to prune chain health records: ${(err as Error).message}`,
+      );
+    }
+  }
+}

--- a/src/database/migrations/1772100000000-CreateChainHealthRecordsTable.ts
+++ b/src/database/migrations/1772100000000-CreateChainHealthRecordsTable.ts
@@ -1,0 +1,74 @@
+import { MigrationInterface, QueryRunner, Table, TableIndex } from 'typeorm';
+
+export class CreateChainHealthRecordsTable1772100000000 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.createTable(
+      new Table({
+        name: 'chain_health_records',
+        columns: [
+          {
+            name: 'id',
+            type: 'uuid',
+            isPrimary: true,
+            isGenerated: true,
+            generationStrategy: 'uuid',
+          },
+          {
+            name: 'chain',
+            type: 'varchar',
+            length: '20',
+            isNullable: false,
+          },
+          {
+            name: 'status',
+            type: 'enum',
+            enum: ['healthy', 'degraded', 'down'],
+            isNullable: false,
+          },
+          {
+            name: 'latencyMs',
+            type: 'int',
+            isNullable: true,
+          },
+          {
+            name: 'blockNumber',
+            type: 'bigint',
+            isNullable: true,
+          },
+          {
+            name: 'blockAge',
+            type: 'int',
+            isNullable: true,
+          },
+          {
+            name: 'paymasterBalance',
+            type: 'varchar',
+            length: '40',
+            isNullable: true,
+          },
+          {
+            name: 'paymasterBalanceWarning',
+            type: 'boolean',
+            default: false,
+            isNullable: false,
+          },
+          {
+            name: 'checkedAt',
+            type: 'timestamp',
+            default: 'CURRENT_TIMESTAMP',
+            isNullable: false,
+          },
+        ],
+        indices: [
+          new TableIndex({ columnNames: ['chain', 'checkedAt'] }),
+          new TableIndex({ columnNames: ['checkedAt'] }),
+        ],
+      }),
+      true,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropTable('chain_health_records');
+  }
+}


### PR DESCRIPTION
PR closes #243 
- Add ChainHealthRecord entity persisting status/latency/blockAge/paymasterBalance per chain
- Add ChainHealthStatus enum (healthy | degraded | down) with thresholds: healthy: latency < 500ms AND blockAge < 30s degraded: latency > 500ms OR blockAge 30–120s down: no RPC response OR blockAge > 120s
- Add ChainHealthService with @Cron every 30s: fetches latest block via ethers.js, derives blockAge from block.timestamp, checks paymaster ETH balance
- Results stored in Redis (admin:chain:health:{chain}, TTL 120s) for instant GET response
- Results persisted to DB for 24h history; records older than 25h pruned automatically
- Emit security.alert WebSocket event via EventEmitter2 when paymaster balance < PAYMASTER_BALANCE_WARN_THRESHOLD
- Add GET /admin/chains/health — reads Redis, no live RPC on request (ADMIN+)
- Add GET /admin/chains/health/history?chain= — last 24h records from DB (ADMIN+)
- Add security.alert to AdminStreamEventType and ADMIN_STREAM_EVENTS constant
- Register ChainModule in AdminModule so ChainService providers are available
- Add migration for chain_health_records table with indexes on [chain, checkedAt]
- Add unit tests: 13 classifyHealth boundary tests, getCurrentHealth, getHealthHistory, checkAllChains (persist, DOWN on error, security alert emission, DB warning flag)