### PR TITLE
feat(admin): implement limited-time XP boost events system

### DIFF
--- a/src/admin/admin.module.ts
+++ b/src/admin/admin.module.ts
@@ -42,6 +42,7 @@ import { SessionModule } from '../sessions/sessions.module';
 import { MessageModule } from '../message/message.module';
 import { NotificationsModule } from '../notifications/notifications.module';
 import { QueueModule } from '../queue/queue.module';
+import { UsersModule } from '../users/users.module';
 import { AdminAuthModule } from './auth/admin-auth.module';
 import { ModerationQueue } from '../moderation/moderation-queue.entity';
 import { FlaggedMessage } from '../moderation/flagged-message.entity';
@@ -57,6 +58,10 @@ import { WebhookDelivery } from './entities/webhook-delivery.entity';
 import { WebhookService } from './services/webhook.service';
 import { WebhookDeliveryProcessor } from './jobs/webhook-delivery.processor';
 import { WebhookController } from './controllers/webhook.controller';
+import { XpBoostEvent } from './entities/xp-boost-event.entity';
+import { XpBoostService } from './services/xp-boost.service';
+import { XpBoostCronJob } from './jobs/xp-boost-cron.job';
+import { XpBoostController } from './controllers/xp-boost.controller';
 
 @Module({
   imports: [
@@ -95,9 +100,10 @@ import { WebhookController } from './controllers/webhook.controller';
       NotificationDelivery,
       WebhookSubscription,
       WebhookDelivery,
+      XpBoostEvent,
     ]),
   ],
-  controllers: [AdminController, IpWhitelistController, WebhookController],
+  controllers: [AdminController, IpWhitelistController, WebhookController, XpBoostController],
   providers: [
     AdminConfigService,
     AdminService,
@@ -114,6 +120,8 @@ import { WebhookController } from './controllers/webhook.controller';
     BroadcastDeliveryStatsService,
     WebhookService,
     WebhookDeliveryProcessor,
+    XpBoostService,
+    XpBoostCronJob,
   ],
   exports: [
     AdminConfigService,
@@ -123,6 +131,7 @@ import { WebhookController } from './controllers/webhook.controller';
     AdminBroadcastService,
     BroadcastDeliveryStatsService,
     WebhookService,
+    XpBoostService,
   ],
 })
 export class AdminModule {

--- a/src/admin/controllers/xp-boost.controller.ts
+++ b/src/admin/controllers/xp-boost.controller.ts
@@ -1,0 +1,89 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Patch,
+  Delete,
+  Body,
+  Param,
+  UseGuards,
+  Req,
+  HttpCode,
+  HttpStatus,
+} from '@nestjs/common';
+import {
+  ApiTags,
+  ApiBearerAuth,
+  ApiOperation,
+  ApiResponse,
+  ApiParam,
+} from '@nestjs/swagger';
+import { Request } from 'express';
+import { RoleGuard } from '../../roles/guards/role.guard';
+import { Roles } from '../../roles/decorators/roles.decorator';
+import { UserRole } from '../../roles/entities/role.entity';
+import { CurrentUser } from '../../auth/decorators/current-user.decorator';
+import { XpBoostService } from '../services/xp-boost.service';
+import { CreateXpBoostEventDto } from '../dto/xp-boost/create-xp-boost-event.dto';
+import { UpdateXpBoostEventDto } from '../dto/xp-boost/update-xp-boost-event.dto';
+
+@ApiTags('admin-xp-events')
+@ApiBearerAuth()
+@UseGuards(RoleGuard)
+@Roles(UserRole.ADMIN, UserRole.SUPER_ADMIN)
+@Controller('admin/xp-events')
+export class XpBoostController {
+  constructor(private readonly xpBoostService: XpBoostService) {}
+
+  @Get()
+  @ApiOperation({ summary: 'List all XP boost events (past, active, scheduled)' })
+  @ApiResponse({ status: 200, description: 'Array of XP boost events ordered by startAt DESC' })
+  async findAll() {
+    return this.xpBoostService.findAll();
+  }
+
+  @Get('active')
+  @ApiOperation({ summary: 'Get currently active XP boost event' })
+  @ApiResponse({ status: 200, description: 'The active event, or null' })
+  async getActive() {
+    return this.xpBoostService.getActive();
+  }
+
+  @Post()
+  @ApiOperation({ summary: 'Create a new XP boost event' })
+  @ApiResponse({ status: 201, description: 'XP boost event created' })
+  async create(
+    @Body() dto: CreateXpBoostEventDto,
+    @CurrentUser() user: any,
+    @Req() req: Request,
+  ) {
+    const adminId = (user?.user ?? user)?.id;
+    return this.xpBoostService.create(dto, adminId, req);
+  }
+
+  @Patch(':eventId')
+  @ApiOperation({ summary: 'Update a scheduled (not active) XP boost event' })
+  @ApiParam({ name: 'eventId', description: 'XP boost event ID' })
+  async update(
+    @Param('eventId') eventId: string,
+    @Body() dto: UpdateXpBoostEventDto,
+    @CurrentUser() user: any,
+    @Req() req: Request,
+  ) {
+    const adminId = (user?.user ?? user)?.id;
+    return this.xpBoostService.update(eventId, dto, adminId, req);
+  }
+
+  @Delete(':eventId')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOperation({ summary: 'Delete a scheduled (not active or past) XP boost event' })
+  @ApiParam({ name: 'eventId', description: 'XP boost event ID' })
+  async remove(
+    @Param('eventId') eventId: string,
+    @CurrentUser() user: any,
+    @Req() req: Request,
+  ) {
+    const adminId = (user?.user ?? user)?.id;
+    await this.xpBoostService.remove(eventId, adminId, req);
+  }
+}

--- a/src/admin/dto/xp-boost/create-xp-boost-event.dto.ts
+++ b/src/admin/dto/xp-boost/create-xp-boost-event.dto.ts
@@ -1,0 +1,50 @@
+import {
+  IsString,
+  IsNumber,
+  IsArray,
+  IsDateString,
+  Min,
+  Max,
+  ArrayMinSize,
+  IsIn,
+  IsNotEmpty,
+} from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+import { XpAction } from '../../../users/constants/xp-actions.constants';
+
+const VALID_ACTIONS = ['all', ...Object.values(XpAction)];
+
+export class CreateXpBoostEventDto {
+  @ApiProperty({ example: 'Double XP Weekend' })
+  @IsString()
+  @IsNotEmpty()
+  name: string;
+
+  @ApiProperty({
+    example: 2.0,
+    minimum: 1.0,
+    maximum: 10.0,
+    description: 'XP multiplier to apply (1.0–10.0)',
+  })
+  @IsNumber()
+  @Min(1.0)
+  @Max(10.0)
+  multiplier: number;
+
+  @ApiProperty({
+    example: ['all'],
+    description: "List of XpAction values to boost, or ['all'] for all actions",
+  })
+  @IsArray()
+  @ArrayMinSize(1)
+  @IsIn(VALID_ACTIONS, { each: true })
+  appliesToActions: string[];
+
+  @ApiProperty({ example: '2024-06-01T00:00:00Z' })
+  @IsDateString()
+  startAt: string;
+
+  @ApiProperty({ example: '2024-06-03T00:00:00Z' })
+  @IsDateString()
+  endAt: string;
+}

--- a/src/admin/dto/xp-boost/update-xp-boost-event.dto.ts
+++ b/src/admin/dto/xp-boost/update-xp-boost-event.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/swagger';
+import { CreateXpBoostEventDto } from './create-xp-boost-event.dto';
+
+export class UpdateXpBoostEventDto extends PartialType(CreateXpBoostEventDto) {}

--- a/src/admin/entities/audit-log.entity.ts
+++ b/src/admin/entities/audit-log.entity.ts
@@ -64,6 +64,11 @@ export enum AuditAction {
   WEBHOOK_UPDATED = 'webhook.updated',
   WEBHOOK_DELETED = 'webhook.deleted',
   WEBHOOK_TESTED = 'webhook.tested',
+  XP_BOOST_CREATED = 'xp_boost.created',
+  XP_BOOST_UPDATED = 'xp_boost.updated',
+  XP_BOOST_DELETED = 'xp_boost.deleted',
+  XP_BOOST_ACTIVATED = 'xp_boost.activated',
+  XP_BOOST_DEACTIVATED = 'xp_boost.deactivated',
 }
 
 export enum AuditEventType {

--- a/src/admin/entities/xp-boost-event.entity.ts
+++ b/src/admin/entities/xp-boost-event.entity.ts
@@ -1,0 +1,49 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+  ManyToOne,
+  JoinColumn,
+  Index,
+} from 'typeorm';
+import { User } from '../../user/entities/user.entity';
+
+@Entity('xp_boost_events')
+@Index(['isActive', 'startAt', 'endAt'])
+export class XpBoostEvent {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ type: 'varchar', length: 255 })
+  name: string;
+
+  @Column({ type: 'decimal', precision: 4, scale: 2 })
+  multiplier: number;
+
+  @Column({ type: 'simple-array' })
+  appliesToActions: string[];
+
+  @Column({ type: 'timestamptz' })
+  startAt: Date;
+
+  @Column({ type: 'timestamptz' })
+  endAt: Date;
+
+  @Column({ type: 'boolean', default: false })
+  isActive: boolean;
+
+  @Column({ type: 'uuid' })
+  createdById: string;
+
+  @ManyToOne(() => User)
+  @JoinColumn({ name: 'createdById' })
+  createdBy: User;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/src/admin/jobs/xp-boost-cron.job.ts
+++ b/src/admin/jobs/xp-boost-cron.job.ts
@@ -1,0 +1,49 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron } from '@nestjs/schedule';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository, LessThanOrEqual, MoreThan } from 'typeorm';
+import { XpBoostEvent } from '../entities/xp-boost-event.entity';
+import { XpBoostService } from '../services/xp-boost.service';
+
+@Injectable()
+export class XpBoostCronJob {
+  private readonly logger = new Logger(XpBoostCronJob.name);
+
+  constructor(
+    @InjectRepository(XpBoostEvent)
+    private readonly xpBoostEventRepository: Repository<XpBoostEvent>,
+    private readonly xpBoostService: XpBoostService,
+  ) {}
+
+  @Cron('*/1 * * * *')
+  async handleXpBoostEvents(): Promise<void> {
+    try {
+      const now = new Date();
+
+      const eventsToActivate = await this.xpBoostEventRepository.find({
+        where: {
+          isActive: false,
+          startAt: LessThanOrEqual(now),
+          endAt: MoreThan(now),
+        },
+      });
+
+      for (const event of eventsToActivate) {
+        await this.xpBoostService.activateEvent(event);
+      }
+
+      const eventsToDeactivate = await this.xpBoostEventRepository.find({
+        where: {
+          isActive: true,
+          endAt: LessThanOrEqual(now),
+        },
+      });
+
+      for (const event of eventsToDeactivate) {
+        await this.xpBoostService.deactivateEvent(event);
+      }
+    } catch (error) {
+      this.logger.error('Error in XP boost event cron job:', error);
+    }
+  }
+}

--- a/src/admin/services/xp-boost.service.spec.ts
+++ b/src/admin/services/xp-boost.service.spec.ts
@@ -1,0 +1,230 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { XpBoostService, XP_BOOST_REDIS_KEY } from './xp-boost.service';
+import { XpBoostEvent } from '../entities/xp-boost-event.entity';
+import { AuditLogService } from './audit-log.service';
+import { RedisService } from '../../redis/redis.service';
+import { AuditAction } from '../entities/audit-log.entity';
+
+const mockRepo = () => ({
+  create: jest.fn(),
+  save: jest.fn(),
+  find: jest.fn(),
+  findOne: jest.fn(),
+  remove: jest.fn(),
+});
+
+const mockAuditLogService = () => ({
+  createAuditLog: jest.fn().mockResolvedValue(undefined),
+});
+
+const mockRedisService = () => ({
+  set: jest.fn().mockResolvedValue(undefined),
+  del: jest.fn().mockResolvedValue(undefined),
+  get: jest.fn().mockResolvedValue(null),
+});
+
+const makeEvent = (overrides: Partial<XpBoostEvent> = {}): XpBoostEvent => ({
+  id: 'event-1',
+  name: 'Test Boost',
+  multiplier: 2.0,
+  appliesToActions: ['all'],
+  startAt: new Date(Date.now() + 60_000),
+  endAt: new Date(Date.now() + 3_600_000),
+  isActive: false,
+  createdById: 'admin-1',
+  createdBy: null as any,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  ...overrides,
+});
+
+describe('XpBoostService', () => {
+  let service: XpBoostService;
+  let repo: jest.Mocked<Repository<XpBoostEvent>>;
+  let auditLogService: jest.Mocked<AuditLogService>;
+  let redisService: jest.Mocked<RedisService>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        XpBoostService,
+        { provide: getRepositoryToken(XpBoostEvent), useFactory: mockRepo },
+        { provide: AuditLogService, useFactory: mockAuditLogService },
+        { provide: RedisService, useFactory: mockRedisService },
+      ],
+    }).compile();
+
+    service = module.get(XpBoostService);
+    repo = module.get(getRepositoryToken(XpBoostEvent));
+    auditLogService = module.get(AuditLogService);
+    redisService = module.get(RedisService);
+  });
+
+  describe('create', () => {
+    it('creates and saves a new event', async () => {
+      const dto = {
+        name: 'Double XP',
+        multiplier: 2.0,
+        appliesToActions: ['all'],
+        startAt: new Date(Date.now() + 1000).toISOString(),
+        endAt: new Date(Date.now() + 100_000).toISOString(),
+      };
+      const event = makeEvent();
+      repo.create.mockReturnValue(event);
+      repo.save.mockResolvedValue(event);
+
+      const result = await service.create(dto, 'admin-1');
+
+      expect(repo.create).toHaveBeenCalledWith(
+        expect.objectContaining({ name: 'Double XP', isActive: false }),
+      );
+      expect(repo.save).toHaveBeenCalledWith(event);
+      expect(result).toBe(event);
+      expect(auditLogService.createAuditLog).toHaveBeenCalledWith(
+        expect.objectContaining({ action: AuditAction.XP_BOOST_CREATED }),
+      );
+    });
+
+    it('throws if endAt <= startAt', async () => {
+      const now = new Date();
+      await expect(
+        service.create(
+          {
+            name: 'Bad',
+            multiplier: 2.0,
+            appliesToActions: ['all'],
+            startAt: new Date(now.getTime() + 5000).toISOString(),
+            endAt: new Date(now.getTime() + 1000).toISOString(),
+          },
+          'admin-1',
+        ),
+      ).rejects.toThrow(BadRequestException);
+    });
+  });
+
+  describe('update', () => {
+    it('updates a scheduled event', async () => {
+      const event = makeEvent();
+      repo.findOne.mockResolvedValue(event);
+      repo.save.mockResolvedValue({ ...event, name: 'Updated' });
+
+      const result = await service.update(
+        'event-1',
+        { name: 'Updated' },
+        'admin-1',
+      );
+
+      expect(result.name).toBe('Updated');
+      expect(auditLogService.createAuditLog).toHaveBeenCalledWith(
+        expect.objectContaining({ action: AuditAction.XP_BOOST_UPDATED }),
+      );
+    });
+
+    it('throws NotFoundException for unknown event', async () => {
+      repo.findOne.mockResolvedValue(null);
+      await expect(
+        service.update('bad-id', { name: 'x' }, 'admin-1'),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('throws BadRequestException when event is active', async () => {
+      repo.findOne.mockResolvedValue(makeEvent({ isActive: true }));
+      await expect(
+        service.update('event-1', { name: 'x' }, 'admin-1'),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('throws BadRequestException when event is past', async () => {
+      repo.findOne.mockResolvedValue(
+        makeEvent({
+          endAt: new Date(Date.now() - 1000),
+          startAt: new Date(Date.now() - 10_000),
+        }),
+      );
+      await expect(
+        service.update('event-1', { name: 'x' }, 'admin-1'),
+      ).rejects.toThrow(BadRequestException);
+    });
+  });
+
+  describe('remove', () => {
+    it('removes a scheduled event', async () => {
+      const event = makeEvent();
+      repo.findOne.mockResolvedValue(event);
+      repo.remove.mockResolvedValue(event);
+
+      await service.remove('event-1', 'admin-1');
+
+      expect(repo.remove).toHaveBeenCalledWith(event);
+      expect(auditLogService.createAuditLog).toHaveBeenCalledWith(
+        expect.objectContaining({ action: AuditAction.XP_BOOST_DELETED }),
+      );
+    });
+
+    it('throws when event is active', async () => {
+      repo.findOne.mockResolvedValue(makeEvent({ isActive: true }));
+      await expect(service.remove('event-1', 'admin-1')).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+
+    it('throws when event is in the past', async () => {
+      repo.findOne.mockResolvedValue(
+        makeEvent({
+          endAt: new Date(Date.now() - 1000),
+          startAt: new Date(Date.now() - 10_000),
+        }),
+      );
+      await expect(service.remove('event-1', 'admin-1')).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+
+    it('throws NotFoundException for unknown event', async () => {
+      repo.findOne.mockResolvedValue(null);
+      await expect(service.remove('bad-id', 'admin-1')).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+  });
+
+  describe('activateEvent', () => {
+    it('sets isActive=true and writes to Redis', async () => {
+      const event = makeEvent({ isActive: false });
+      repo.save.mockResolvedValue({ ...event, isActive: true });
+
+      await service.activateEvent(event);
+
+      expect(repo.save).toHaveBeenCalledWith(
+        expect.objectContaining({ isActive: true }),
+      );
+      expect(redisService.set).toHaveBeenCalledWith(
+        XP_BOOST_REDIS_KEY,
+        expect.stringContaining('"multiplier":2'),
+      );
+      expect(auditLogService.createAuditLog).toHaveBeenCalledWith(
+        expect.objectContaining({ action: AuditAction.XP_BOOST_ACTIVATED }),
+      );
+    });
+  });
+
+  describe('deactivateEvent', () => {
+    it('sets isActive=false and removes from Redis', async () => {
+      const event = makeEvent({ isActive: true });
+      repo.save.mockResolvedValue({ ...event, isActive: false });
+
+      await service.deactivateEvent(event);
+
+      expect(repo.save).toHaveBeenCalledWith(
+        expect.objectContaining({ isActive: false }),
+      );
+      expect(redisService.del).toHaveBeenCalledWith(XP_BOOST_REDIS_KEY);
+      expect(auditLogService.createAuditLog).toHaveBeenCalledWith(
+        expect.objectContaining({ action: AuditAction.XP_BOOST_DEACTIVATED }),
+      );
+    });
+  });
+});

--- a/src/admin/services/xp-boost.service.ts
+++ b/src/admin/services/xp-boost.service.ts
@@ -1,0 +1,239 @@
+import {
+  Injectable,
+  NotFoundException,
+  BadRequestException,
+  Logger,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import type { Request } from 'express';
+import { XpBoostEvent } from '../entities/xp-boost-event.entity';
+import { CreateXpBoostEventDto } from '../dto/xp-boost/create-xp-boost-event.dto';
+import { UpdateXpBoostEventDto } from '../dto/xp-boost/update-xp-boost-event.dto';
+import { AuditLogService } from './audit-log.service';
+import {
+  AuditAction,
+  AuditEventType,
+  AuditOutcome,
+  AuditSeverity,
+} from '../entities/audit-log.entity';
+import { RedisService } from '../../redis/redis.service';
+
+export const XP_BOOST_REDIS_KEY = 'xp:boost:active';
+
+@Injectable()
+export class XpBoostService {
+  private readonly logger = new Logger(XpBoostService.name);
+
+  constructor(
+    @InjectRepository(XpBoostEvent)
+    private readonly xpBoostEventRepository: Repository<XpBoostEvent>,
+    private readonly auditLogService: AuditLogService,
+    private readonly redisService: RedisService,
+  ) {}
+
+  async create(
+    dto: CreateXpBoostEventDto,
+    adminId: string,
+    req?: Request,
+  ): Promise<XpBoostEvent> {
+    if (new Date(dto.endAt) <= new Date(dto.startAt)) {
+      throw new BadRequestException('endAt must be after startAt');
+    }
+
+    const event = this.xpBoostEventRepository.create({
+      name: dto.name,
+      multiplier: dto.multiplier,
+      appliesToActions: dto.appliesToActions,
+      startAt: new Date(dto.startAt),
+      endAt: new Date(dto.endAt),
+      isActive: false,
+      createdById: adminId,
+    });
+
+    const saved = await this.xpBoostEventRepository.save(event);
+
+    await this.auditLogService.createAuditLog({
+      actorUserId: adminId,
+      action: AuditAction.XP_BOOST_CREATED,
+      eventType: AuditEventType.ADMIN,
+      outcome: AuditOutcome.SUCCESS,
+      severity: AuditSeverity.MEDIUM,
+      details: `XP boost event "${saved.name}" created`,
+      metadata: {
+        eventId: saved.id,
+        multiplier: saved.multiplier,
+        appliesToActions: saved.appliesToActions,
+        startAt: saved.startAt,
+        endAt: saved.endAt,
+      },
+      resourceType: 'xp_boost_event',
+      resourceId: saved.id,
+      req,
+    });
+
+    return saved;
+  }
+
+  async findAll(): Promise<XpBoostEvent[]> {
+    return this.xpBoostEventRepository.find({
+      order: { startAt: 'DESC' },
+    });
+  }
+
+  async getActive(): Promise<XpBoostEvent | null> {
+    return this.xpBoostEventRepository.findOne({
+      where: { isActive: true },
+    });
+  }
+
+  async update(
+    eventId: string,
+    dto: UpdateXpBoostEventDto,
+    adminId: string,
+    req?: Request,
+  ): Promise<XpBoostEvent> {
+    const event = await this.xpBoostEventRepository.findOne({
+      where: { id: eventId },
+    });
+
+    if (!event) {
+      throw new NotFoundException('XP boost event not found');
+    }
+
+    if (event.isActive) {
+      throw new BadRequestException('Cannot update an active XP boost event');
+    }
+
+    if (event.endAt <= new Date()) {
+      throw new BadRequestException('Cannot update a past XP boost event');
+    }
+
+    const newStartAt = dto.startAt ? new Date(dto.startAt) : event.startAt;
+    const newEndAt = dto.endAt ? new Date(dto.endAt) : event.endAt;
+
+    if (newEndAt <= newStartAt) {
+      throw new BadRequestException('endAt must be after startAt');
+    }
+
+    if (dto.name !== undefined) event.name = dto.name;
+    if (dto.multiplier !== undefined) event.multiplier = dto.multiplier;
+    if (dto.appliesToActions !== undefined)
+      event.appliesToActions = dto.appliesToActions;
+    if (dto.startAt !== undefined) event.startAt = new Date(dto.startAt);
+    if (dto.endAt !== undefined) event.endAt = new Date(dto.endAt);
+
+    const updated = await this.xpBoostEventRepository.save(event);
+
+    await this.auditLogService.createAuditLog({
+      actorUserId: adminId,
+      action: AuditAction.XP_BOOST_UPDATED,
+      eventType: AuditEventType.ADMIN,
+      outcome: AuditOutcome.SUCCESS,
+      severity: AuditSeverity.LOW,
+      details: `XP boost event "${updated.name}" updated`,
+      metadata: { eventId: updated.id },
+      resourceType: 'xp_boost_event',
+      resourceId: updated.id,
+      req,
+    });
+
+    return updated;
+  }
+
+  async remove(
+    eventId: string,
+    adminId: string,
+    req?: Request,
+  ): Promise<void> {
+    const event = await this.xpBoostEventRepository.findOne({
+      where: { id: eventId },
+    });
+
+    if (!event) {
+      throw new NotFoundException('XP boost event not found');
+    }
+
+    if (event.isActive) {
+      throw new BadRequestException('Cannot delete an active XP boost event');
+    }
+
+    if (event.endAt <= new Date()) {
+      throw new BadRequestException('Cannot delete a past XP boost event');
+    }
+
+    const eventName = event.name;
+    await this.xpBoostEventRepository.remove(event);
+
+    await this.auditLogService.createAuditLog({
+      actorUserId: adminId,
+      action: AuditAction.XP_BOOST_DELETED,
+      eventType: AuditEventType.ADMIN,
+      outcome: AuditOutcome.SUCCESS,
+      severity: AuditSeverity.HIGH,
+      details: `XP boost event "${eventName}" deleted`,
+      metadata: { eventId, name: eventName },
+      resourceType: 'xp_boost_event',
+      resourceId: eventId,
+      req,
+    });
+  }
+
+  async activateEvent(event: XpBoostEvent): Promise<void> {
+    event.isActive = true;
+    await this.xpBoostEventRepository.save(event);
+
+    const redisValue = JSON.stringify({
+      eventId: event.id,
+      name: event.name,
+      multiplier: Number(event.multiplier),
+      appliesToActions: event.appliesToActions,
+      startAt: event.startAt.toISOString(),
+      endAt: event.endAt.toISOString(),
+    });
+    await this.redisService.set(XP_BOOST_REDIS_KEY, redisValue);
+
+    await this.auditLogService.createAuditLog({
+      actorUserId: null,
+      action: AuditAction.XP_BOOST_ACTIVATED,
+      eventType: AuditEventType.SYSTEM,
+      outcome: AuditOutcome.SUCCESS,
+      severity: AuditSeverity.MEDIUM,
+      details: `XP boost event "${event.name}" activated (system)`,
+      metadata: {
+        eventId: event.id,
+        multiplier: event.multiplier,
+        appliesToActions: event.appliesToActions,
+      },
+      resourceType: 'xp_boost_event',
+      resourceId: event.id,
+    });
+
+    this.logger.log(
+      `XP boost event "${event.name}" (${event.id}) activated — multiplier x${event.multiplier}`,
+    );
+  }
+
+  async deactivateEvent(event: XpBoostEvent): Promise<void> {
+    event.isActive = false;
+    await this.xpBoostEventRepository.save(event);
+
+    await this.redisService.del(XP_BOOST_REDIS_KEY);
+
+    await this.auditLogService.createAuditLog({
+      actorUserId: null,
+      action: AuditAction.XP_BOOST_DEACTIVATED,
+      eventType: AuditEventType.SYSTEM,
+      outcome: AuditOutcome.SUCCESS,
+      severity: AuditSeverity.MEDIUM,
+      details: `XP boost event "${event.name}" deactivated (system)`,
+      metadata: { eventId: event.id },
+      resourceType: 'xp_boost_event',
+      resourceId: event.id,
+    });
+
+    this.logger.log(
+      `XP boost event "${event.name}" (${event.id}) deactivated`,
+    );
+  }
+}

--- a/src/database/migrations/1772200000000-CreateXpBoostEventsTable.ts
+++ b/src/database/migrations/1772200000000-CreateXpBoostEventsTable.ts
@@ -1,0 +1,118 @@
+import {
+  MigrationInterface,
+  QueryRunner,
+  Table,
+  TableForeignKey,
+  TableIndex,
+} from 'typeorm';
+
+export class CreateXpBoostEventsTable1772200000000
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TYPE "audit_logs_action_enum"
+        ADD VALUE IF NOT EXISTS 'xp_boost.created'
+    `);
+    await queryRunner.query(`
+      ALTER TYPE "audit_logs_action_enum"
+        ADD VALUE IF NOT EXISTS 'xp_boost.updated'
+    `);
+    await queryRunner.query(`
+      ALTER TYPE "audit_logs_action_enum"
+        ADD VALUE IF NOT EXISTS 'xp_boost.deleted'
+    `);
+    await queryRunner.query(`
+      ALTER TYPE "audit_logs_action_enum"
+        ADD VALUE IF NOT EXISTS 'xp_boost.activated'
+    `);
+    await queryRunner.query(`
+      ALTER TYPE "audit_logs_action_enum"
+        ADD VALUE IF NOT EXISTS 'xp_boost.deactivated'
+    `);
+
+    await queryRunner.createTable(
+      new Table({
+        name: 'xp_boost_events',
+        columns: [
+          {
+            name: 'id',
+            type: 'uuid',
+            isPrimary: true,
+            isGenerated: true,
+            generationStrategy: 'uuid',
+          },
+          {
+            name: 'name',
+            type: 'varchar',
+            length: '255',
+            isNullable: false,
+          },
+          {
+            name: 'multiplier',
+            type: 'decimal',
+            precision: 4,
+            scale: 2,
+            isNullable: false,
+          },
+          {
+            name: 'appliesToActions',
+            type: 'text',
+            isNullable: false,
+          },
+          {
+            name: 'startAt',
+            type: 'timestamptz',
+            isNullable: false,
+          },
+          {
+            name: 'endAt',
+            type: 'timestamptz',
+            isNullable: false,
+          },
+          {
+            name: 'isActive',
+            type: 'boolean',
+            default: false,
+            isNullable: false,
+          },
+          {
+            name: 'createdById',
+            type: 'uuid',
+            isNullable: false,
+          },
+          {
+            name: 'createdAt',
+            type: 'timestamp',
+            default: 'CURRENT_TIMESTAMP',
+            isNullable: false,
+          },
+          {
+            name: 'updatedAt',
+            type: 'timestamp',
+            default: 'CURRENT_TIMESTAMP',
+            isNullable: false,
+          },
+        ],
+        foreignKeys: [
+          new TableForeignKey({
+            columnNames: ['createdById'],
+            referencedTableName: 'users',
+            referencedColumnNames: ['id'],
+            onDelete: 'RESTRICT',
+          }),
+        ],
+        indices: [
+          new TableIndex({ columnNames: ['isActive', 'startAt', 'endAt'] }),
+          new TableIndex({ columnNames: ['isActive'] }),
+          new TableIndex({ columnNames: ['createdById'] }),
+        ],
+      }),
+      true,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropTable('xp_boost_events');
+  }
+}

--- a/src/users/services/xp-boost-multiplier.spec.ts
+++ b/src/users/services/xp-boost-multiplier.spec.ts
@@ -1,0 +1,191 @@
+/**
+ * Tests for the XP boost multiplier integration in XpService.addXp().
+ * Verifies that the active boost event multiplier is correctly applied
+ * based on the Redis key and appliesToActions filter.
+ */
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { XpService } from './xp.service';
+import { User } from '../entities/user.entity';
+import { XpHistory } from '../entities/xp-history.entity';
+import { QueueService } from '../../queue/queue.service';
+import { AdminService } from '../../admin/services/admin.service';
+import { LeaderboardService } from '../../leaderboard/leaderboard.service';
+import { RedisService } from '../../redis/redis.service';
+import { XpAction, XP_VALUES, PREMIUM_XP_MULTIPLIER } from '../constants/xp-actions.constants';
+import { XP_BOOST_REDIS_KEY } from '../../admin/services/xp-boost.service';
+
+const makeUser = (overrides: Partial<User> = {}): User =>
+  ({
+    id: 'user-1',
+    isPremium: false,
+    xpMultiplier: null,
+    currentXp: 0,
+    level: 1,
+    ...overrides,
+  } as User);
+
+describe('XpService — boost multiplier integration', () => {
+  let service: XpService;
+  let userRepo: any;
+  let xpHistoryRepo: any;
+  let adminService: any;
+  let leaderboardService: any;
+  let redisService: jest.Mocked<RedisService>;
+
+  beforeEach(async () => {
+    userRepo = {
+      findOne: jest.fn(),
+      save: jest.fn(),
+      createQueryBuilder: jest.fn().mockReturnValue({
+        select: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        getRawOne: jest.fn().mockResolvedValue({ total: '0' }),
+        getCount: jest.fn().mockResolvedValue(0),
+      }),
+    };
+
+    xpHistoryRepo = {
+      save: jest.fn().mockResolvedValue({}),
+      findAndCount: jest.fn().mockResolvedValue([[], 0]),
+      createQueryBuilder: jest.fn().mockReturnValue({
+        select: jest.fn().mockReturnThis(),
+        addSelect: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        groupBy: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+        getRawOne: jest.fn().mockResolvedValue({ total: '0' }),
+        getRawMany: jest.fn().mockResolvedValue([]),
+      }),
+    };
+
+    adminService = { getConfigValue: jest.fn().mockResolvedValue(1.0) };
+    leaderboardService = { updateLeaderboard: jest.fn().mockResolvedValue(undefined) };
+    redisService = {
+      get: jest.fn().mockResolvedValue(null),
+      set: jest.fn().mockResolvedValue(undefined),
+      del: jest.fn().mockResolvedValue(undefined),
+      exists: jest.fn().mockResolvedValue(false),
+      ttl: jest.fn().mockResolvedValue(-1),
+    } as any;
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        XpService,
+        { provide: getRepositoryToken(User), useValue: userRepo },
+        { provide: getRepositoryToken(XpHistory), useValue: xpHistoryRepo },
+        { provide: QueueService, useValue: { addNotificationJob: jest.fn() } },
+        { provide: AdminService, useValue: adminService },
+        { provide: LeaderboardService, useValue: leaderboardService },
+        { provide: RedisService, useValue: redisService },
+      ],
+    }).compile();
+
+    service = module.get(XpService);
+  });
+
+  it('applies no boost when Redis key is absent', async () => {
+    const user = makeUser();
+    userRepo.findOne.mockResolvedValue(user);
+    redisService.get.mockResolvedValue(null);
+
+    await service.addXp('user-1', XpAction.MESSAGE_SENT);
+
+    const saved: User = userRepo.save.mock.calls[0][0];
+    expect(saved.currentXp).toBe(XP_VALUES[XpAction.MESSAGE_SENT]);
+  });
+
+  it('applies boost multiplier for matching action', async () => {
+    const user = makeUser();
+    userRepo.findOne.mockResolvedValue(user);
+    redisService.get.mockResolvedValue(
+      JSON.stringify({ multiplier: 3, appliesToActions: ['MESSAGE_SENT'] }),
+    );
+
+    await service.addXp('user-1', XpAction.MESSAGE_SENT);
+
+    const saved: User = userRepo.save.mock.calls[0][0];
+    expect(saved.currentXp).toBe(XP_VALUES[XpAction.MESSAGE_SENT] * 3);
+  });
+
+  it("applies boost when appliesToActions is ['all']", async () => {
+    const user = makeUser();
+    userRepo.findOne.mockResolvedValue(user);
+    redisService.get.mockResolvedValue(
+      JSON.stringify({ multiplier: 2, appliesToActions: ['all'] }),
+    );
+
+    await service.addXp('user-1', XpAction.ROOM_JOINED);
+
+    const saved: User = userRepo.save.mock.calls[0][0];
+    expect(saved.currentXp).toBe(XP_VALUES[XpAction.ROOM_JOINED] * 2);
+  });
+
+  it('does NOT apply boost for non-matching action', async () => {
+    const user = makeUser();
+    userRepo.findOne.mockResolvedValue(user);
+    redisService.get.mockResolvedValue(
+      JSON.stringify({ multiplier: 5, appliesToActions: ['ROOM_CREATED'] }),
+    );
+
+    await service.addXp('user-1', XpAction.MESSAGE_SENT);
+
+    const saved: User = userRepo.save.mock.calls[0][0];
+    expect(saved.currentXp).toBe(XP_VALUES[XpAction.MESSAGE_SENT]);
+  });
+
+  it('stacks boost with global XP multiplier', async () => {
+    const user = makeUser();
+    userRepo.findOne.mockResolvedValue(user);
+    adminService.getConfigValue.mockResolvedValue(2.0);
+    redisService.get.mockResolvedValue(
+      JSON.stringify({ multiplier: 3, appliesToActions: ['all'] }),
+    );
+
+    await service.addXp('user-1', XpAction.MESSAGE_SENT);
+
+    const saved: User = userRepo.save.mock.calls[0][0];
+    expect(saved.currentXp).toBe(
+      Math.floor(XP_VALUES[XpAction.MESSAGE_SENT] * 1.0 * 2.0 * 3),
+    );
+  });
+
+  it('stacks boost with premium user multiplier', async () => {
+    const user = makeUser({ isPremium: true, xpMultiplier: PREMIUM_XP_MULTIPLIER });
+    userRepo.findOne.mockResolvedValue(user);
+    redisService.get.mockResolvedValue(
+      JSON.stringify({ multiplier: 2, appliesToActions: ['all'] }),
+    );
+
+    await service.addXp('user-1', XpAction.MESSAGE_SENT);
+
+    const saved: User = userRepo.save.mock.calls[0][0];
+    expect(saved.currentXp).toBe(
+      Math.floor(XP_VALUES[XpAction.MESSAGE_SENT] * PREMIUM_XP_MULTIPLIER * 1.0 * 2),
+    );
+  });
+
+  it('ignores Redis parse errors gracefully', async () => {
+    const user = makeUser();
+    userRepo.findOne.mockResolvedValue(user);
+    redisService.get.mockResolvedValue('not-valid-json');
+
+    await expect(
+      service.addXp('user-1', XpAction.MESSAGE_SENT),
+    ).resolves.toBeDefined();
+
+    const saved: User = userRepo.save.mock.calls[0][0];
+    expect(saved.currentXp).toBe(XP_VALUES[XpAction.MESSAGE_SENT]);
+  });
+
+  it('reads the correct Redis key', async () => {
+    const user = makeUser();
+    userRepo.findOne.mockResolvedValue(user);
+
+    await service.addXp('user-1', XpAction.MESSAGE_SENT);
+
+    expect(redisService.get).toHaveBeenCalledWith(XP_BOOST_REDIS_KEY);
+  });
+});


### PR DESCRIPTION
PR closes #236 
- Add XpBoostEvent entity with multiplier (1.0–10.0), appliesToActions, startAt/endAt, isActive
- Add CRUD endpoints under GET/POST/PATCH/DELETE /admin/xp-events (ADMIN role+)
- GET /admin/xp-events/active returns the currently active event
- XpBoostCronJob (@Cron every minute) auto-activates/deactivates events by time boundary
- Active event writes JSON to Redis key xp:boost:active; deactivation deletes the key
- XpService.addXp reads the Redis boost and stacks it with user/global multipliers
- Migration adds xp_boost_events table and 5 new AuditAction enum values
- Audit logs for create, update, delete, system-triggered activate/deactivate
- Unit tests for XpBoostService CRUD guards and XpService multiplier application