### PR TITLE
feat: Implement room search and discovery feed

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3491,7 +3491,7 @@
       "version": "1.15.13",
       "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.15.13.tgz",
       "integrity": "sha512-0l1gl/72PErwUZuavcRpRAQN9uSst+Nk++niC5IX6lmMWpXoScYx3oq/narT64/sKv/eRiPTaAjBFGDEQiWJIw==",
-      "devOptional": true,
+      "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -3533,6 +3533,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -3549,6 +3550,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -3565,6 +3567,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3581,6 +3584,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -3597,6 +3601,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -3613,6 +3618,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -3629,6 +3635,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -3645,6 +3652,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -3661,6 +3669,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -3677,6 +3686,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -3690,14 +3700,14 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
       "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/@swc/types": {
       "version": "0.1.25",
       "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.25.tgz",
       "integrity": "sha512-iAoY/qRhNH8a/hBvm3zKj9qQ4oc2+3w1unPJa2XvTK3XjeLXtzcCingVPw/9e5mn1+0yPqxcBGp9Jf0pkfMb1g==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@swc/counter": "^0.1.3"

--- a/src/rooms/dto/create-room.dto.ts
+++ b/src/rooms/dto/create-room.dto.ts
@@ -1,4 +1,16 @@
-import { IsString, IsEnum, IsOptional, IsNumber, IsDateString, Length, Min, Max } from 'class-validator';
+import {
+  IsString,
+  IsEnum,
+  IsOptional,
+  IsNumber,
+  IsDateString,
+  Length,
+  Min,
+  Max,
+  IsArray,
+  ArrayMaxSize,
+  MaxLength,
+} from 'class-validator';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { RoomType } from '../entities/room.entity';
 
@@ -38,4 +50,28 @@ export class CreateRoomDto {
   @IsOptional()
   @IsDateString()
   expiresAt?: string;
+
+  @ApiPropertyOptional({
+    example: ['crypto', 'defi', 'stellar'],
+    description: 'Topic tags for room discovery (max 5)',
+    type: [String],
+  })
+  @IsOptional()
+  @IsArray()
+  @ArrayMaxSize(5, { message: 'A room can have at most 5 tags' })
+  @IsString({ each: true })
+  @MaxLength(32, {
+    each: true,
+    message: 'Each tag must be at most 32 characters',
+  })
+  tags?: string[];
+
+  @ApiPropertyOptional({
+    example: 'stellar',
+    description: 'Blockchain network identifier for chain-based filtering',
+  })
+  @IsOptional()
+  @IsString()
+  @MaxLength(64)
+  chain?: string;
 }

--- a/src/rooms/dto/discover-rooms.dto.ts
+++ b/src/rooms/dto/discover-rooms.dto.ts
@@ -1,0 +1,24 @@
+import { IsOptional, IsString, IsNumber, Min } from 'class-validator';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+
+export class DiscoverRoomsDto {
+  /** Cursor-based pagination: pass the `nextCursor` value from a previous response. */
+  @ApiPropertyOptional({
+    description: 'Pagination cursor (base64 encoded trendingScore + id)',
+    example: 'eyJ0cmVuZGluZ1Njb3JlIjo1MDAsImlkIjoiMTIzIn0=',
+  })
+  @IsOptional()
+  @IsString()
+  cursor?: string;
+
+  @ApiPropertyOptional({
+    description: 'Number of results per page',
+    example: 20,
+  })
+  @IsOptional()
+  @Type(() => Number)
+  @IsNumber()
+  @Min(1)
+  limit?: number = 20;
+}

--- a/src/rooms/dto/search-rooms.dto.ts
+++ b/src/rooms/dto/search-rooms.dto.ts
@@ -1,0 +1,90 @@
+import {
+  IsOptional,
+  IsString,
+  IsNumber,
+  Min,
+  IsArray,
+  ArrayMaxSize,
+} from 'class-validator';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { Type, Transform } from 'class-transformer';
+
+export class SearchRoomsDto {
+  @ApiPropertyOptional({
+    description: 'Full-text search across room name and description',
+    example: 'crypto',
+  })
+  @IsOptional()
+  @IsString()
+  q?: string;
+
+  /**
+   * Comma-separated tags passed as a query string (?tags=defi,stellar).
+   * Transformed to an array by the Transform decorator.
+   */
+  @ApiPropertyOptional({
+    description: 'Filter by topic tags (max 5, comma-separated in URL)',
+    example: 'defi,stellar',
+    type: [String],
+  })
+  @IsOptional()
+  @Transform(({ value }) =>
+    typeof value === 'string'
+      ? value
+          .split(',')
+          .map((t: string) => t.trim())
+          .filter(Boolean)
+      : value,
+  )
+  @IsArray()
+  @ArrayMaxSize(5)
+  @IsString({ each: true })
+  tags?: string[];
+
+  @ApiPropertyOptional({
+    description: 'Minimum entry fee (inclusive)',
+    example: 0.01,
+  })
+  @IsOptional()
+  @Type(() => Number)
+  @IsNumber()
+  @Min(0)
+  minFee?: number;
+
+  @ApiPropertyOptional({
+    description: 'Maximum entry fee (inclusive)',
+    example: 10,
+  })
+  @IsOptional()
+  @Type(() => Number)
+  @IsNumber()
+  @Min(0)
+  maxFee?: number;
+
+  @ApiPropertyOptional({
+    description: 'Blockchain network identifier (e.g. "stellar")',
+    example: 'stellar',
+  })
+  @IsOptional()
+  @IsString()
+  chain?: string;
+
+  /** Cursor-based pagination: pass the `nextCursor` value from a previous response. */
+  @ApiPropertyOptional({
+    description: 'Pagination cursor (base64 encoded timestamp)',
+    example: 'eyJjcmVhdGVkQXQiOiIyMDI1LTAxLTAxIn0=',
+  })
+  @IsOptional()
+  @IsString()
+  cursor?: string;
+
+  @ApiPropertyOptional({
+    description: 'Number of results per page',
+    example: 20,
+  })
+  @IsOptional()
+  @Type(() => Number)
+  @IsNumber()
+  @Min(1)
+  limit?: number = 20;
+}

--- a/src/rooms/entities/room.entity.ts
+++ b/src/rooms/entities/room.entity.ts
@@ -58,6 +58,33 @@ export class Room {
   @Column({ name: 'is_active', default: true })
   isActive: boolean;
 
+  /**
+   * Topic tags for discovery (max 5 items).
+   * Stored as a comma-separated text column via TypeORM's simple-array strategy.
+   */
+  @Column({ type: 'simple-array', nullable: true, default: null })
+  tags: string[];
+
+  /**
+   * Blockchain network identifier (e.g. "stellar", "ethereum").
+   * Used for chain-based filtering in the discovery API.
+   */
+  @Column({ length: 64, nullable: true, default: null })
+  chain: string;
+
+  /**
+   * Trending score = messageCount24h × memberCount.
+   * Recalculated every 15 minutes by the cron job.
+   */
+  @Column({
+    name: 'trending_score',
+    type: 'numeric',
+    precision: 20,
+    scale: 4,
+    default: 0,
+  })
+  trendingScore: number;
+
   @CreateDateColumn({ name: 'created_at' })
   createdAt: Date;
 

--- a/src/rooms/rooms.controller.ts
+++ b/src/rooms/rooms.controller.ts
@@ -1,15 +1,64 @@
-import { Controller, Post, Get, Patch, Delete, Param, Body, UseGuards, Request, Query } from '@nestjs/common';
+import {
+  Controller,
+  Post,
+  Get,
+  Patch,
+  Delete,
+  Param,
+  Body,
+  UseGuards,
+  Request,
+  Query,
+} from '@nestjs/common';
+import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { RoomsService } from './rooms.service';
 import { JoinRoomDto, ConfirmJoinDto } from './dto/join-room.dto';
 import { CreateRoomDto } from './dto/create-room.dto';
 import { UpdateRoomDto } from './dto/update-room.dto';
 import { GetRoomsDto } from './dto/get-rooms.dto';
+import { SearchRoomsDto } from './dto/search-rooms.dto';
+import { DiscoverRoomsDto } from './dto/discover-rooms.dto';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 
+@ApiTags('rooms')
 @Controller('rooms')
 @UseGuards(JwtAuthGuard)
 export class RoomsController {
   constructor(private readonly roomsService: RoomsService) {}
+
+  // ─── Discovery endpoints ─────────────────────────────────────────────────────
+
+  @Get('discover')
+  @ApiOperation({
+    summary: 'Trending rooms',
+    description:
+      'Returns active rooms ranked by trending score (messageCount24h × memberCount), ' +
+      'recalculated every 15 minutes. Supports cursor-based pagination.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'List of trending rooms with nextCursor',
+  })
+  async getTrendingRooms(@Query() dto: DiscoverRoomsDto) {
+    return this.roomsService.getTrendingRooms(dto);
+  }
+
+  @Get('search')
+  @ApiOperation({
+    summary: 'Search rooms',
+    description:
+      'Filter rooms by keyword (q), tags, entry fee range (minFee / maxFee), ' +
+      'and blockchain network (chain). Cursor-based pagination.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Filtered room list with nextCursor',
+  })
+  async searchRooms(@Query() dto: SearchRoomsDto) {
+    return this.roomsService.searchRooms(dto);
+  }
+
+  // ─── Standard CRUD ───────────────────────────────────────────────────────────
 
   @Post()
   async createRoom(@Body() createRoomDto: CreateRoomDto, @Request() req) {
@@ -29,7 +78,11 @@ export class RoomsController {
   }
 
   @Patch(':id')
-  async updateRoom(@Param('id') id: string, @Body() updateRoomDto: UpdateRoomDto, @Request() req) {
+  async updateRoom(
+    @Param('id') id: string,
+    @Body() updateRoomDto: UpdateRoomDto,
+    @Request() req,
+  ) {
     const userId = req.user.sub;
     return this.roomsService.updateRoom(id, updateRoomDto, userId);
   }
@@ -37,19 +90,35 @@ export class RoomsController {
   @Delete(':id')
   async deleteRoom(@Param('id') id: string, @Request() req) {
     const userId = req.user.sub;
-    const isAdmin = req.user.role === 'admin'; // Assuming role is in JWT
+    const isAdmin = req.user.role === 'admin';
     return this.roomsService.deleteRoom(id, userId, isAdmin);
   }
 
   @Post(':id/join')
-  async joinRoom(@Param('id') roomId: string, @Body() joinRoomDto: JoinRoomDto, @Request() req) {
+  async joinRoom(
+    @Param('id') roomId: string,
+    @Body() joinRoomDto: JoinRoomDto,
+    @Request() req,
+  ) {
     const userId = req.user.sub;
-    return this.roomsService.initiateJoin(roomId, userId, joinRoomDto.userWalletAddress);
+    return this.roomsService.initiateJoin(
+      roomId,
+      userId,
+      joinRoomDto.userWalletAddress,
+    );
   }
 
   @Post(':id/join/confirm')
-  async confirmJoin(@Param('id') roomId: string, @Body() confirmJoinDto: ConfirmJoinDto, @Request() req) {
+  async confirmJoin(
+    @Param('id') roomId: string,
+    @Body() confirmJoinDto: ConfirmJoinDto,
+    @Request() req,
+  ) {
     const userId = req.user.sub;
-    return this.roomsService.confirmJoin(roomId, userId, confirmJoinDto.transactionHash);
+    return this.roomsService.confirmJoin(
+      roomId,
+      userId,
+      confirmJoinDto.transactionHash,
+    );
   }
 }

--- a/src/rooms/rooms.module.ts
+++ b/src/rooms/rooms.module.ts
@@ -1,16 +1,22 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
+import { ScheduleModule } from '@nestjs/schedule';
 import { RoomsController } from './rooms.controller';
 import { RoomsService } from './rooms.service';
 import { Room } from './entities/room.entity';
 import { RoomMember } from './entities/room-member.entity';
 import { RoomBlockchainService } from './services/room-blockchain.service';
+import { RoomTrendingCronService } from './services/room-trending-cron.service';
 import { UserModule } from '../user/user.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Room, RoomMember]), UserModule],
+  imports: [
+    TypeOrmModule.forFeature([Room, RoomMember]),
+    ScheduleModule.forRoot(),
+    UserModule,
+  ],
   controllers: [RoomsController],
-  providers: [RoomsService, RoomBlockchainService],
+  providers: [RoomsService, RoomBlockchainService, RoomTrendingCronService],
   exports: [RoomsService],
 })
 export class RoomsModule {}

--- a/src/rooms/rooms.service.ts
+++ b/src/rooms/rooms.service.ts
@@ -1,6 +1,12 @@
-import { Injectable, NotFoundException, BadRequestException, ConflictException, ForbiddenException } from '@nestjs/common';
+import {
+  Injectable,
+  NotFoundException,
+  BadRequestException,
+  ConflictException,
+  ForbiddenException,
+} from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { Repository, DataSource } from 'typeorm';
 import { ConfigService } from '@nestjs/config';
 import { Room, RoomType } from './entities/room.entity';
 import { RoomMember } from './entities/room-member.entity';
@@ -9,7 +15,25 @@ import { PaymentInstructionsDto } from './dto/join-room.dto';
 import { CreateRoomDto } from './dto/create-room.dto';
 import { UpdateRoomDto } from './dto/update-room.dto';
 import { GetRoomsDto } from './dto/get-rooms.dto';
+import { SearchRoomsDto } from './dto/search-rooms.dto';
+import { DiscoverRoomsDto } from './dto/discover-rooms.dto';
 import { UserService } from '../user/user.service';
+
+// ─── Cursor helpers ───────────────────────────────────────────────────────────
+
+function encodeCursor(payload: Record<string, unknown>): string {
+  return Buffer.from(JSON.stringify(payload)).toString('base64');
+}
+
+function decodeCursor(cursor: string): Record<string, unknown> | null {
+  try {
+    return JSON.parse(Buffer.from(cursor, 'base64').toString('utf8'));
+  } catch {
+    return null;
+  }
+}
+
+// ─── Service ─────────────────────────────────────────────────────────────────
 
 @Injectable()
 export class RoomsService {
@@ -21,15 +45,29 @@ export class RoomsService {
     private roomBlockchainService: RoomBlockchainService,
     private configService: ConfigService,
     private userService: UserService,
+    private dataSource: DataSource,
   ) {}
 
-  async createRoom(createRoomDto: CreateRoomDto, creatorId: string, creatorWalletAddress?: string): Promise<Room> {
-    // Validate room type specific requirements
-    if (createRoomDto.type === RoomType.TOKEN_GATED && (!createRoomDto.entryFee || !createRoomDto.tokenAddress)) {
-      throw new BadRequestException('Token-gated rooms require entryFee and tokenAddress');
+  // ─── Create ─────────────────────────────────────────────────────────────────
+
+  async createRoom(
+    createRoomDto: CreateRoomDto,
+    creatorId: string,
+    creatorWalletAddress?: string,
+  ): Promise<Room> {
+    if (
+      createRoomDto.type === RoomType.TOKEN_GATED &&
+      (!createRoomDto.entryFee || !createRoomDto.tokenAddress)
+    ) {
+      throw new BadRequestException(
+        'Token-gated rooms require entryFee and tokenAddress',
+      );
     }
     if (createRoomDto.type === RoomType.TIMED && !createRoomDto.expiresAt) {
       throw new BadRequestException('Timed rooms require expiresAt');
+    }
+    if (createRoomDto.tags && createRoomDto.tags.length > 5) {
+      throw new BadRequestException('A room can have at most 5 tags');
     }
 
     const room = this.roomRepository.create({
@@ -37,34 +75,225 @@ export class RoomsService {
       creatorId,
       creatorWalletAddress,
       maxMembers: createRoomDto.maxMembers || 100,
-      expiresAt: createRoomDto.expiresAt ? new Date(createRoomDto.expiresAt) : null,
-    });
+      expiresAt: createRoomDto.expiresAt
+        ? new Date(createRoomDto.expiresAt)
+        : null,
+    } as any);
 
     const savedRoom = await this.roomRepository.save(room);
-    
-    // Award XP to creator
     await this.userService.addXP(creatorId, 50);
-    
     return savedRoom;
   }
 
-  async getRooms(getRoomsDto: GetRoomsDto): Promise<{ rooms: Room[]; total: number }> {
+  // ─── List / Paginate ─────────────────────────────────────────────────────────
+
+  async getRooms(
+    getRoomsDto: GetRoomsDto,
+  ): Promise<{ rooms: Room[]; total: number }> {
     const { page = 1, limit = 10 } = getRoomsDto;
     const skip = (page - 1) * limit;
 
     const [rooms, total] = await this.roomRepository.findAndCount({
-      where: { 
-        type: RoomType.PUBLIC, 
-        isActive: true,
-        expiresAt: null // Only non-expired rooms or rooms without expiry
-      },
-      order: { createdAt: 'DESC' }, // Sort by activity (using createdAt as proxy)
+      where: { type: RoomType.PUBLIC, isActive: true, expiresAt: require('typeorm').IsNull() },
+      order: { createdAt: 'DESC' },
       skip,
       take: limit,
     });
 
     return { rooms, total };
   }
+
+  // ─── Discover (trending) ─────────────────────────────────────────────────────
+
+  /**
+   * Returns active rooms sorted by trendingScore DESC.
+   * Cursor encodes { trendingScore, id } for stable keyset pagination.
+   * Each room in the response includes memberCount and messageCount24h.
+   */
+  async getTrendingRooms(dto: DiscoverRoomsDto): Promise<{
+    rooms: (Room & { memberCount: number; messageCount24h: number })[];
+    nextCursor: string | null;
+  }> {
+    const limit = Math.min(dto.limit ?? 20, 100);
+    const since24h = new Date(Date.now() - 24 * 60 * 60 * 1000);
+
+    let cursorScore: number | null = null;
+    let cursorId: string | null = null;
+    if (dto.cursor) {
+      const decoded = decodeCursor(dto.cursor);
+      if (decoded) {
+        cursorScore = decoded.trendingScore as number;
+        cursorId = decoded.id as string;
+      }
+    }
+
+    const qb = this.dataSource
+      .createQueryBuilder(Room, 'room')
+      .where('room.is_active = :active', { active: true })
+      .addSelect(
+        (sub) =>
+          sub
+            .select('COUNT(rm.id)', 'memberCount')
+            .from(RoomMember, 'rm')
+            .where('rm.room_id = room.id'),
+        'memberCount',
+      )
+      .addSelect(
+        (sub) =>
+          sub
+            .select('COUNT(m.id)', 'messageCount24h')
+            .from('messages', 'm')
+            .where('m.room_id = room.id')
+            .andWhere('m.created_at >= :since24h', { since24h }),
+        'messageCount24h',
+      )
+      .orderBy('room.trending_score', 'DESC')
+      .addOrderBy('room.id', 'ASC')
+      .limit(limit + 1);
+
+    if (cursorScore !== null && cursorId !== null) {
+      qb.andWhere(
+        '(room.trending_score < :cursorScore OR (room.trending_score = :cursorScore AND room.id > :cursorId))',
+        { cursorScore, cursorId },
+      );
+    }
+
+    const raw = await qb.getRawAndEntities();
+
+    const rooms = raw.entities.map((room, idx) => {
+      const rawRow = raw.raw[idx];
+      return Object.assign(room, {
+        memberCount: parseInt(rawRow['memberCount'] ?? '0', 10),
+        messageCount24h: parseInt(rawRow['messageCount24h'] ?? '0', 10),
+        trendingScore: parseFloat(String(room.trendingScore ?? 0)),
+      });
+    }) as (Room & { memberCount: number; messageCount24h: number })[];
+
+    let nextCursor: string | null = null;
+    if (rooms.length > limit) {
+      rooms.splice(limit);
+      const last = rooms[rooms.length - 1];
+      nextCursor = encodeCursor({
+        trendingScore: last.trendingScore,
+        id: last.id,
+      });
+    }
+
+    return { rooms, nextCursor };
+  }
+
+  // ─── Search ──────────────────────────────────────────────────────────────────
+
+  /**
+   * Filtered room search.
+   *  - q:      ILIKE on name + description
+   *  - tags:   OR-based ILIKE match against the simple-array column
+   *  - minFee / maxFee: entry fee numeric range
+   *  - chain:  exact match
+   *  - cursor: keyset pagination by createdAt DESC, id ASC
+   */
+  async searchRooms(dto: SearchRoomsDto): Promise<{
+    rooms: (Room & { memberCount: number; messageCount24h: number })[];
+    nextCursor: string | null;
+  }> {
+    const limit = Math.min(dto.limit ?? 20, 100);
+    const since24h = new Date(Date.now() - 24 * 60 * 60 * 1000);
+
+    let cursorCreatedAt: Date | null = null;
+    let cursorId: string | null = null;
+    if (dto.cursor) {
+      const decoded = decodeCursor(dto.cursor);
+      if (decoded) {
+        cursorCreatedAt = new Date(decoded.createdAt as string);
+        cursorId = decoded.id as string;
+      }
+    }
+
+    const qb = this.dataSource
+      .createQueryBuilder(Room, 'room')
+      .where('room.is_active = :active', { active: true })
+      .addSelect(
+        (sub) =>
+          sub
+            .select('COUNT(rm.id)', 'memberCount')
+            .from(RoomMember, 'rm')
+            .where('rm.room_id = room.id'),
+        'memberCount',
+      )
+      .addSelect(
+        (sub) =>
+          sub
+            .select('COUNT(m.id)', 'messageCount24h')
+            .from('messages', 'm')
+            .where('m.room_id = room.id')
+            .andWhere('m.created_at >= :since24h', { since24h }),
+        'messageCount24h',
+      )
+      .orderBy('room.created_at', 'DESC')
+      .addOrderBy('room.id', 'ASC')
+      .limit(limit + 1);
+
+    if (dto.q) {
+      qb.andWhere('(room.name ILIKE :q OR room.description ILIKE :q)', {
+        q: `%${dto.q}%`,
+      });
+    }
+
+    if (dto.tags && dto.tags.length > 0) {
+      const tagConditions = dto.tags.map((tag, i) => {
+        qb.setParameter(`tag${i}`, `%${tag}%`);
+        return `room.tags ILIKE :tag${i}`;
+      });
+      qb.andWhere(`(${tagConditions.join(' OR ')})`);
+    }
+
+    if (dto.minFee !== undefined) {
+      qb.andWhere('CAST(room.entry_fee AS NUMERIC) >= :minFee', {
+        minFee: dto.minFee,
+      });
+    }
+    if (dto.maxFee !== undefined) {
+      qb.andWhere('CAST(room.entry_fee AS NUMERIC) <= :maxFee', {
+        maxFee: dto.maxFee,
+      });
+    }
+
+    if (dto.chain) {
+      qb.andWhere('room.chain = :chain', { chain: dto.chain });
+    }
+
+    if (cursorCreatedAt !== null && cursorId !== null) {
+      qb.andWhere(
+        '(room.created_at < :cursorCreatedAt OR (room.created_at = :cursorCreatedAt AND room.id > :cursorId))',
+        { cursorCreatedAt, cursorId },
+      );
+    }
+
+    const raw = await qb.getRawAndEntities();
+
+    const rooms = raw.entities.map((room, idx) => {
+      const rawRow = raw.raw[idx];
+      return Object.assign(room, {
+        memberCount: parseInt(rawRow['memberCount'] ?? '0', 10),
+        messageCount24h: parseInt(rawRow['messageCount24h'] ?? '0', 10),
+        trendingScore: parseFloat(String(room.trendingScore ?? 0)),
+      });
+    }) as (Room & { memberCount: number; messageCount24h: number })[];
+
+    let nextCursor: string | null = null;
+    if (rooms.length > limit) {
+      rooms.splice(limit);
+      const last = rooms[rooms.length - 1];
+      nextCursor = encodeCursor({
+        createdAt: last.createdAt.toISOString(),
+        id: last.id,
+      });
+    }
+
+    return { rooms, nextCursor };
+  }
+
+  // ─── CRUD helpers ─────────────────────────────────────────────────────────────
 
   async getRoomById(id: string): Promise<Room> {
     const room = await this.roomRepository.findOne({ where: { id } });
@@ -74,39 +303,56 @@ export class RoomsService {
     return room;
   }
 
-  async updateRoom(id: string, updateRoomDto: UpdateRoomDto, userId: string): Promise<Room> {
+  async updateRoom(
+    id: string,
+    updateRoomDto: UpdateRoomDto,
+    userId: string,
+  ): Promise<Room> {
     const room = await this.getRoomById(id);
-    
+
     if (room.creatorId !== userId) {
       throw new ForbiddenException('Only room creator can update the room');
     }
 
     Object.assign(room, {
       ...updateRoomDto,
-      expiresAt: updateRoomDto.expiresAt ? new Date(updateRoomDto.expiresAt) : room.expiresAt,
+      expiresAt: updateRoomDto.expiresAt
+        ? new Date(updateRoomDto.expiresAt)
+        : room.expiresAt,
     });
 
     return this.roomRepository.save(room);
   }
 
-  async deleteRoom(id: string, userId: string, isAdmin: boolean = false): Promise<void> {
+  async deleteRoom(
+    id: string,
+    userId: string,
+    isAdmin: boolean = false,
+  ): Promise<void> {
     const room = await this.getRoomById(id);
-    
+
     if (!isAdmin && room.creatorId !== userId) {
-      throw new ForbiddenException('Only room creator or admin can delete the room');
+      throw new ForbiddenException(
+        'Only room creator or admin can delete the room',
+      );
     }
 
     room.isActive = false;
     await this.roomRepository.save(room);
   }
 
-  async initiateJoin(roomId: string, userId: string, userWalletAddress: string): Promise<PaymentInstructionsDto | { success: boolean }> {
+  // ─── Join flow ───────────────────────────────────────────────────────────────
+
+  async initiateJoin(
+    roomId: string,
+    userId: string,
+    userWalletAddress: string,
+  ): Promise<PaymentInstructionsDto | { success: boolean }> {
     const room = await this.roomRepository.findOne({ where: { id: roomId } });
     if (!room) {
       throw new NotFoundException('Room not found');
     }
 
-    // Check if user is already a member
     const existingMember = await this.roomMemberRepository.findOne({
       where: { roomId, userId },
     });
@@ -115,7 +361,6 @@ export class RoomsService {
     }
 
     if (room.type === RoomType.PUBLIC) {
-      // For public rooms, join immediately
       await this.roomMemberRepository.save({
         roomId,
         userId,
@@ -126,9 +371,9 @@ export class RoomsService {
     }
 
     if (room.type === RoomType.TOKEN_GATED) {
-      // Return payment instructions
       return {
-        contractAddress: this.configService.get('PAYMENT_CONTRACT_ADDRESS') || 'GCEXAMPLE',
+        contractAddress:
+          this.configService.get('PAYMENT_CONTRACT_ADDRESS') || 'GCEXAMPLE',
         amount: room.entryFee,
         tokenAddress: room.tokenAddress || 'native',
         recipientAddress: room.creatorWalletAddress,
@@ -138,7 +383,11 @@ export class RoomsService {
     throw new BadRequestException('Invalid room type');
   }
 
-  async confirmJoin(roomId: string, userId: string, transactionHash: string): Promise<{ success: boolean; error?: string }> {
+  async confirmJoin(
+    roomId: string,
+    userId: string,
+    transactionHash: string,
+  ): Promise<{ success: boolean; error?: string }> {
     const room = await this.roomRepository.findOne({ where: { id: roomId } });
     if (!room) {
       throw new NotFoundException('Room not found');
@@ -148,7 +397,6 @@ export class RoomsService {
       throw new BadRequestException('Room is not token-gated');
     }
 
-    // Check if transaction hash is already used
     const existingMember = await this.roomMemberRepository.findOne({
       where: { transactionHash },
     });
@@ -156,7 +404,6 @@ export class RoomsService {
       throw new ConflictException('Transaction hash already used');
     }
 
-    // Verify transaction on-chain
     const verification = await this.roomBlockchainService.verifyTransaction(
       transactionHash,
       room.entryFee,
@@ -167,8 +414,8 @@ export class RoomsService {
       return { success: false, error: verification.error };
     }
 
-    // Distribute fees
-    const treasuryWallet = this.configService.get('TREASURY_WALLET_ADDRESS') || 'GTREASURY';
+    const treasuryWallet =
+      this.configService.get('TREASURY_WALLET_ADDRESS') || 'GTREASURY';
     const feeDistribution = await this.roomBlockchainService.distributeFees(
       room.entryFee,
       room.creatorWalletAddress,
@@ -179,7 +426,6 @@ export class RoomsService {
       return { success: false, error: feeDistribution.error };
     }
 
-    // Create room membership
     await this.roomMemberRepository.save({
       roomId,
       userId,

--- a/src/rooms/services/room-trending-cron.service.ts
+++ b/src/rooms/services/room-trending-cron.service.ts
@@ -1,0 +1,102 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron, CronExpression } from '@nestjs/schedule';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository, DataSource } from 'typeorm';
+import { Room } from '../entities/room.entity';
+import { RoomMember } from '../entities/room-member.entity';
+
+/**
+ * Recalculates trendingScore for every active room every 15 minutes.
+ *
+ * Formula:
+ *   trendingScore = messageCount24h × memberCount
+ *
+ * The score is stored on the Room entity so discovery queries can simply
+ * ORDER BY trending_score DESC without running expensive aggregations on
+ * every request.
+ */
+@Injectable()
+export class RoomTrendingCronService {
+  private readonly logger = new Logger(RoomTrendingCronService.name);
+
+  constructor(
+    @InjectRepository(Room)
+    private roomRepository: Repository<Room>,
+    private dataSource: DataSource,
+  ) {}
+
+  @Cron('0 */15 * * * *')
+  async recalculateTrendingScores(): Promise<void> {
+    this.logger.log('Starting trending score recalculation...');
+
+    const since24h = new Date(Date.now() - 24 * 60 * 60 * 1000);
+
+    try {
+      /**
+       * Run a single UPDATE ... FROM (...) query for efficiency instead
+       * of loading all rooms into memory.
+       *
+       * PostgreSQL syntax:
+       *   UPDATE rooms r
+       *   SET trending_score = aggregated.score
+       *   FROM (
+       *     SELECT
+       *       r2.id,
+       *       COALESCE(m.msg_count, 0) * COALESCE(rm.member_count, 0) AS score
+       *     FROM rooms r2
+       *     LEFT JOIN (
+       *       SELECT room_id, COUNT(*) AS msg_count
+       *       FROM   messages
+       *       WHERE  created_at >= :since24h
+       *       GROUP  BY room_id
+       *     ) m ON m.room_id = r2.id
+       *     LEFT JOIN (
+       *       SELECT room_id, COUNT(*) AS member_count
+       *       FROM   room_members
+       *       GROUP  BY room_id
+       *     ) rm ON rm.room_id = r2.id
+       *     WHERE r2.is_active = true
+       *   ) aggregated
+       *   WHERE r.id = aggregated.id
+       */
+      await this.dataSource.query(
+        `
+        UPDATE rooms r
+        SET trending_score = aggregated.score
+        FROM (
+          SELECT
+            r2.id,
+            COALESCE(m.msg_count, 0) * COALESCE(rm.member_count, 0) AS score
+          FROM rooms r2
+          LEFT JOIN (
+            SELECT room_id, COUNT(*) AS msg_count
+            FROM   messages
+            WHERE  created_at >= $1
+            GROUP  BY room_id
+          ) m ON m.room_id = r2.id
+          LEFT JOIN (
+            SELECT room_id, COUNT(*) AS member_count
+            FROM   room_members
+            GROUP  BY room_id
+          ) rm ON rm.room_id = r2.id
+          WHERE r2.is_active = true
+        ) aggregated
+        WHERE r.id = aggregated.id
+        `,
+        [since24h],
+      );
+
+      const updatedCount = await this.roomRepository.count({
+        where: { isActive: true },
+      });
+      this.logger.log(
+        `Trending scores updated for ${updatedCount} active rooms.`,
+      );
+    } catch (error) {
+      this.logger.error(
+        'Failed to recalculate trending scores',
+        (error as Error).stack,
+      );
+    }
+  }
+}


### PR DESCRIPTION
# Implement Room Discovery and Search API

## Description
This PR introduces the Room Discovery and Search API to allow users to find relevant rooms based on activity, trending metrics, specific topics/tags, and fee parameters. As part of these features, a trending score ranks rooms based on the message volume and member growth.

## Changes Included

### Database Updates
- Added `tags` column (max 5 strings) to the `Room` entity to enable topic-based searches.
- Added `chain` column to the `Room` entity to filter rooms by the underlying blockchain network.
- Added `trending_score` column to store room activity values for rapid indexing and sorting.

### New API Endpoints
- `GET /rooms/discover` - Retrieves the top trending rooms ranked by their `trendingScore`, pulling in the latest active rooms. Supports cursor-based keyset pagination.
- `GET /rooms/search` - Provides a filtered search functionality parameterized by query string (`q`), `tags`, `minFee`, `maxFee`, and `chain`. Supports cursor-based keyset pagination.

### DTOs & Validations
- Created `DiscoverRoomsDto` and `SearchRoomsDto` to handle incoming query parameters and ensure strict validation (e.g., maximum limits and ranges).
- Updated `CreateRoomDto` to support the incoming `tags` array and `chain` value upon room creation.

### Trending Score Recalculation (Cron)
- Added a new `RoomTrendingCronService` schedule (using `@nestjs/schedule`) that runs every 15 minutes.
- Implemented an optimized bulk SQL `UPDATE ... FROM (...)` query within the cron job to recalculate the `trendingScore` dynamically based on the 24-hour message count multiplied by the current member count. 

### Subqueries
- Modified the room fetch requests using TypeORM QueryBuilder to append `memberCount` and `messageCount24h` inside the object responses dynamically.

## Acceptance Criteria Met
- [x] Trending rooms endpoint (ranked by 24h message count × member count)
- [x] Search endpoint with detailed filtering
- [x] Tags field constrained to an array of max 5 strings
- [x] Trending score recalculates automatically via a 15-minute cron job
- [x] Output response correctly includes `memberCount`, `messageCount24h`, and `trendingScore`
- [x] Proper cursor-based pagination across data endpoints




closes #295 