### PR TITLE
feat: implement Message Editing and Deletion with Audit Trail

### DIFF
--- a/src/messages/dto/update-message.dto.ts
+++ b/src/messages/dto/update-message.dto.ts
@@ -1,0 +1,7 @@
+import { IsString, IsNotEmpty } from 'class-validator';
+
+export class UpdateMessageDto {
+  @IsString()
+  @IsNotEmpty()
+  content: string;
+}

--- a/src/messages/entities/message-edit.entity.ts
+++ b/src/messages/entities/message-edit.entity.ts
@@ -1,0 +1,37 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  ManyToOne,
+  JoinColumn,
+  CreateDateColumn,
+  Index,
+} from 'typeorm';
+import { Message } from './message.entity';
+
+@Entity('message_edits')
+@Index(['messageId', 'editedAt'])
+export class MessageEdit {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @ManyToOne(() => Message, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'message_id' })
+  message: Message;
+
+  @Column({ name: 'message_id' })
+  messageId: string;
+
+  @Column({ type: 'text', name: 'previous_content', nullable: true })
+  previousContent: string | null;
+
+  @ManyToOne('User', { onDelete: 'SET NULL' })
+  @JoinColumn({ name: 'edited_by' })
+  editedBy: unknown;
+
+  @Column({ name: 'edited_by', nullable: true })
+  editedById: string | null;
+
+  @CreateDateColumn({ name: 'edited_at' })
+  editedAt: Date;
+}

--- a/src/messages/entities/message.entity.ts
+++ b/src/messages/entities/message.entity.ts
@@ -1,54 +1,61 @@
 import {
-    Entity,
-    PrimaryGeneratedColumn,
-    Column,
-    ManyToOne,
-    JoinColumn,
-    CreateDateColumn,
-    Index,
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  ManyToOne,
+  JoinColumn,
+  CreateDateColumn,
+  Index,
 } from 'typeorm';
 
 export enum MessageType {
-    TEXT = 'TEXT',
-    MEDIA = 'MEDIA',
-    TIP = 'TIP',
+  TEXT = 'TEXT',
+  MEDIA = 'MEDIA',
+  TIP = 'TIP',
+  SYSTEM = 'SYSTEM',
 }
 
 @Entity('messages')
 @Index(['roomId', 'createdAt'])
 @Index(['senderId', 'createdAt'])
 export class Message {
-    @PrimaryGeneratedColumn('uuid')
-    id: string;
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
 
-    @ManyToOne('User', { onDelete: 'CASCADE' })
-    @JoinColumn({ name: 'sender_id' })
-    sender: unknown;
+  @ManyToOne('User', { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'sender_id' })
+  sender: unknown;
 
-    @Column({ name: 'sender_id' })
-    senderId: string;
+  @Column({ name: 'sender_id' })
+  senderId: string;
 
-    @Column({ name: 'room_id' })
-    roomId: string;
+  @Column({ name: 'room_id' })
+  roomId: string;
 
-    @Column({
-        type: 'enum',
-        enum: MessageType,
-        default: MessageType.TEXT,
-    })
-    type: MessageType;
+  @Column({
+    type: 'enum',
+    enum: MessageType,
+    default: MessageType.TEXT,
+  })
+  type: MessageType;
 
-    @Column({ type: 'text', nullable: true })
-    content: string | null;
+  @Column({ type: 'text', nullable: true })
+  content: string | null;
 
-    @Column({ name: 'payment_id', nullable: true })
-    @Index()
-    paymentId: string | null;
+  @Column({ name: 'payment_id', nullable: true })
+  @Index()
+  paymentId: string | null;
 
-    @ManyToOne('Payment', { onDelete: 'SET NULL', nullable: true })
-    @JoinColumn({ name: 'payment_id' })
-    payment: unknown | null;
+  @ManyToOne('Payment', { onDelete: 'SET NULL', nullable: true })
+  @JoinColumn({ name: 'payment_id' })
+  payment: unknown | null;
 
-    @CreateDateColumn({ name: 'created_at' })
-    createdAt: Date;
+  @Column({ name: 'is_deleted', default: false })
+  isDeleted: boolean;
+
+  @Column({ name: 'edited_at', nullable: true })
+  editedAt: Date | null;
+
+  @CreateDateColumn({ name: 'created_at' })
+  createdAt: Date;
 }

--- a/src/messages/messages.controller.ts
+++ b/src/messages/messages.controller.ts
@@ -1,6 +1,9 @@
 import {
   Controller,
   Post,
+  Patch,
+  Delete,
+  Param,
   Body,
   Request,
   UseGuards,
@@ -19,6 +22,7 @@ import { RequiresSessionKeyScope } from '../session-keys/decorators/requires-ses
 import { SessionKeyScope } from '../session-keys/entities/session-key.entity';
 import { MessagesService } from './messages.service';
 import { SendMessageDto } from './dto/send-message.dto';
+import { UpdateMessageDto } from './dto/update-message.dto';
 import { IMAGE_MAX_BYTES, VIDEO_MAX_BYTES } from './services/ipfs.service';
 
 const ALLOWED_MIMES = ['image/jpeg', 'image/png', 'image/gif', 'video/mp4'];
@@ -112,5 +116,32 @@ export class MessagesController {
         transactionHash: result.transactionHash,
       },
     };
+  }
+
+  @Patch(':id')
+  @ApiOperation({ summary: 'Edit a message (within 15 minutes)' })
+  async editMessage(
+    @Request() req: { user: { id?: string; sub?: string } },
+    @Param('id') messageId: string,
+    @Body() dto: UpdateMessageDto,
+  ) {
+    const userId = req.user.id ?? req.user.sub;
+    if (!userId) throw new BadRequestException('User not authenticated');
+
+    return this.messagesService.editMessage(userId, messageId, dto.content);
+  }
+
+  @Delete(':id')
+  @ApiOperation({
+    summary: 'Soft delete a message (sender, moderator, or creator)',
+  })
+  async deleteMessage(
+    @Request() req: { user: { id?: string; sub?: string } },
+    @Param('id') messageId: string,
+  ) {
+    const userId = req.user.id ?? req.user.sub;
+    if (!userId) throw new BadRequestException('User not authenticated');
+
+    return this.messagesService.deleteMessage(userId, messageId);
   }
 }

--- a/src/messages/messages.gateway.ts
+++ b/src/messages/messages.gateway.ts
@@ -1,0 +1,54 @@
+import {
+  WebSocketGateway,
+  WebSocketServer,
+  OnGatewayConnection,
+  OnGatewayDisconnect,
+} from '@nestjs/websockets';
+import { Server, Socket } from 'socket.io';
+
+@WebSocketGateway({
+  cors: {
+    origin: '*',
+  },
+  namespace: '/messages',
+})
+export class MessagesGateway
+  implements OnGatewayConnection, OnGatewayDisconnect
+{
+  @WebSocketServer()
+  server: Server;
+
+  handleConnection(client: Socket) {
+    // Client connected
+  }
+
+  handleDisconnect(client: Socket) {
+    // Client disconnected
+  }
+
+  emitMessageEdited(
+    roomId: string,
+    messageId: string,
+    newContent: string,
+    editedAt: Date,
+  ) {
+    this.server.to(`room_${roomId}`).emit('message.edited', {
+      messageId,
+      content: newContent,
+      editedAt,
+      roomId,
+    });
+  }
+
+  emitMessageDeleted(roomId: string, messageId: string) {
+    this.server.to(`room_${roomId}`).emit('message.deleted', {
+      messageId,
+      roomId,
+    });
+  }
+
+  // Example method to join a room, if clients need to join rooms
+  joinRoom(client: Socket, roomId: string) {
+    client.join(`room_${roomId}`);
+  }
+}

--- a/src/messages/messages.module.ts
+++ b/src/messages/messages.module.ts
@@ -3,6 +3,9 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { JwtModule } from '@nestjs/jwt';
 import { ConfigModule } from '@nestjs/config';
 import { MessageMedia } from './entities/message-media.entity';
+import { Message } from './entities/message.entity';
+import { MessageEdit } from './entities/message-edit.entity';
+import { RoomMember } from '../rooms/entities/room-member.entity';
 import { User } from '../user/entities/user.entity';
 import { MessagesController } from './messages.controller';
 import { MessagesService } from './messages.service';
@@ -10,10 +13,17 @@ import { IpfsService } from './services/ipfs.service';
 import { NoOpMediaScanService } from './services/no-op-media-scan.service';
 import { ContractMessageService } from './services/contract-message.service';
 import { MEDIA_SCAN_SERVICE } from './services/media-scan.service';
+import { MessagesGateway } from './messages.gateway';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([MessageMedia, User]),
+    TypeOrmModule.forFeature([
+      MessageMedia,
+      User,
+      Message,
+      MessageEdit,
+      RoomMember,
+    ]),
     JwtModule.register({}),
     ConfigModule,
   ],
@@ -22,6 +32,7 @@ import { MEDIA_SCAN_SERVICE } from './services/media-scan.service';
     MessagesService,
     IpfsService,
     ContractMessageService,
+    MessagesGateway,
     {
       provide: MEDIA_SCAN_SERVICE,
       useClass: NoOpMediaScanService,

--- a/src/messages/messages.service.ts
+++ b/src/messages/messages.service.ts
@@ -1,11 +1,28 @@
-import { Injectable, Logger, BadRequestException, Inject } from '@nestjs/common';
+import {
+  Injectable,
+  Logger,
+  BadRequestException,
+  Inject,
+} from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository, MoreThan } from 'typeorm';
 import { MessageMedia, MediaType } from './entities/message-media.entity';
+import { Message, MessageType } from './entities/message.entity';
+import { MessageEdit } from './entities/message-edit.entity';
 import { User } from '../user/entities/user.entity';
+import { RoomMember } from '../rooms/entities/room-member.entity';
 import { IpfsService } from './services/ipfs.service';
-import { IMediaScanService, MEDIA_SCAN_SERVICE } from './services/media-scan.service';
+import {
+  IMediaScanService,
+  MEDIA_SCAN_SERVICE,
+} from './services/media-scan.service';
 import { ContractMessageService } from './services/contract-message.service';
+import { MessagesGateway } from './messages.gateway';
+import {
+  ForbiddenException,
+  NotFoundException,
+  ConflictException,
+} from '@nestjs/common';
 
 const MEDIA_RATE_LIMIT_PER_HOUR = 10;
 const ONE_HOUR_MS = 60 * 60 * 1000;
@@ -26,10 +43,17 @@ export class MessagesService {
     private readonly messageMediaRepository: Repository<MessageMedia>,
     @InjectRepository(User)
     private readonly userRepository: Repository<User>,
+    @InjectRepository(Message)
+    private readonly messageRepository: Repository<Message>,
+    @InjectRepository(MessageEdit)
+    private readonly messageEditRepository: Repository<MessageEdit>,
+    @InjectRepository(RoomMember)
+    private readonly roomMemberRepository: Repository<RoomMember>,
     private readonly ipfsService: IpfsService,
     @Inject(MEDIA_SCAN_SERVICE)
     private readonly mediaScanService: IMediaScanService,
     private readonly contractMessageService: ContractMessageService,
+    private readonly messagesGateway: MessagesGateway,
   ) {}
 
   async uploadMedia(
@@ -119,5 +143,138 @@ export class MessagesService {
       contentHash,
       tipAmount,
     );
+  }
+
+  async editMessage(userId: string, messageId: string, newContent: string) {
+    const message = await this.messageRepository.findOne({
+      where: { id: messageId },
+    });
+
+    if (!message) {
+      throw new NotFoundException('Message not found');
+    }
+
+    if (message.isDeleted) {
+      throw new ForbiddenException('Cannot edit a deleted message');
+    }
+
+    if (
+      message.type === MessageType.SYSTEM ||
+      message.type === MessageType.TIP
+    ) {
+      throw new ForbiddenException('Cannot edit SYSTEM or TIP messages');
+    }
+
+    if (message.senderId !== userId) {
+      throw new ForbiddenException('You can only edit your own messages');
+    }
+
+    const editWindowMs = 15 * 60 * 1000; // 15 minutes
+    if (Date.now() - message.createdAt.getTime() > editWindowMs) {
+      throw new ForbiddenException(
+        'Messages can only be edited within 15 minutes of sending',
+      );
+    }
+
+    // Preserve previous content in audit table
+    const messageEdit = this.messageEditRepository.create({
+      messageId: message.id,
+      previousContent: message.content,
+      editedById: userId,
+    });
+    await this.messageEditRepository.save(messageEdit);
+
+    // Update message
+    message.content = newContent;
+    message.editedAt = new Date();
+    await this.messageRepository.save(message);
+
+    // Broadcast edit
+    this.messagesGateway.emitMessageEdited(
+      message.roomId.toString(),
+      message.id,
+      message.content,
+      message.editedAt,
+    );
+
+    return { success: true, data: message };
+  }
+
+  async deleteMessage(userId: string, messageId: string) {
+    const message = await this.messageRepository.findOne({
+      where: { id: messageId },
+      relations: ['sender'], // may need if relying on sender checks
+    });
+
+    if (!message) {
+      throw new NotFoundException('Message not found');
+    }
+
+    if (message.isDeleted) {
+      throw new ConflictException('Message already deleted');
+    }
+
+    let isAuthorized = false;
+
+    if (message.senderId === userId) {
+      isAuthorized = true;
+    } else {
+      // Check if user is moderator or creator
+      const rm = await this.roomMemberRepository.findOne({
+        where: { roomId: message.roomId, userId },
+        relations: ['room'],
+      });
+
+      if (rm) {
+        // user is the creator or a moderator
+        const roomObj = rm.room as any; // The entity isn't fully typed for nested 'room' here due to 'unknown' in RoomMember, safely cast
+        if (roomObj?.creatorId === userId) {
+          isAuthorized = true;
+        } else if ((rm as any).role === 'MODERATOR') {
+          isAuthorized = true;
+        }
+      } else {
+        // Check Room explicitly if rm is missing but they are creator
+        const rmCreatorCheck = await this.roomMemberRepository.manager.query(
+          `SELECT creator_id FROM rooms WHERE id = $1`,
+          [message.roomId],
+        );
+        if (
+          rmCreatorCheck &&
+          rmCreatorCheck.length > 0 &&
+          rmCreatorCheck[0].creator_id === userId
+        ) {
+          isAuthorized = true;
+        }
+      }
+    }
+
+    if (!isAuthorized) {
+      throw new ForbiddenException(
+        'Only the sender or a room moderator/creator can delete this message',
+      );
+    }
+
+    // Save delete state as an edit trail
+    const messageEdit = this.messageEditRepository.create({
+      messageId: message.id,
+      previousContent: message.content,
+      editedById: userId,
+    });
+    await this.messageEditRepository.save(messageEdit);
+
+    // Soft delete / placeholder
+    message.isDeleted = true;
+    message.content = '[Message deleted]';
+    message.editedAt = new Date(); // To satisfy "editedAt timestamp updated on edit" potentially
+    await this.messageRepository.save(message);
+
+    // Broadcast delete event
+    this.messagesGateway.emitMessageDeleted(
+      message.roomId.toString(),
+      message.id,
+    );
+
+    return { success: true };
   }
 }


### PR DESCRIPTION


This PR implements message editing and soft-deletion functionalities with a comprehensive audit trail. Users can now edit or delete their own messages within a 15-minute window, and room moderators/creators can delete any message. All modifications are logged to ensure accountability and transparency.

## Acceptance Criteria Met

- [x] **PATCH `/messages/:id`**: Implemented endpoint for users to edit their own messages. A strict 15-minute window is enforced.
- [x] **DELETE `/messages/:id`**: Implemented endpoint to soft-delete messages. Senders can delete their own messages, while room creators and moderators can delete any message within their room.
- [x] **Audit Trail (`message_edits`)**: The `editedAt` timestamp is updated on the `Message` entity upon edit. The original content is preserved in the newly created `MessageEdit` audit table, linking `messageId`, `previousContent`, `editedAt`, and `editedBy`.
- [x] **Deleted Messages Handling**: Soft-deleted messages have their content replaced with the `[Message deleted]` placeholder in the database.
- [x] **WebSocket Events**: Created `MessagesGateway` to broadcast `message.edited` and `message.deleted` events to the respective room namespaces in real-time.
- [x] **Message Type Restrictions**: Added `SYSTEM` to the `MessageType` enum. Enforced validation to prevent editing of `TIP` or `SYSTEM` messages.

## Changes Included

- **Entities:**
  - Updated `Message` entity to include `isDeleted` and `editedAt` properties, and added `SYSTEM` to `MessageType`.
  - Created `MessageEdit` entity to store the audit trail of previous message contents.
- **DTOs:**
  - Created `UpdateMessageDto` for message content updates.
- **Services:**
  - Updated `MessagesService` with `editMessage` and `deleteMessage` methods, implementing the core business logic, permission checks, 15-minute window validation, and audit logging.
- **Controllers:**
  - Added `PATCH /messages/:id` and `DELETE /messages/:id` endpoints to `MessagesController`.
- **Gateways:**
  - Created `MessagesGateway` (`/messages` namespace) to emit real-time WebSocket events to connected clients in a room.
- **Modules:**
  - Updated `MessagesModule` to import the new entities (`MessageEdit`, `Message`, `RoomMember`) and provide the `MessagesGateway`.



closes #298 