### PR TITLE
feat: Implement timedrooms with auto-deletion

### DIFF
--- a/src/messages/messages.service.ts
+++ b/src/messages/messages.service.ts
@@ -56,14 +56,9 @@ export class MessagesService {
     @Inject(MEDIA_SCAN_SERVICE)
     private readonly mediaScanService: IMediaScanService,
     private readonly contractMessageService: ContractMessageService,
-<<<<<<< HEAD
     private readonly analyticsService: AnalyticsService,
     private readonly eventEmitter: EventEmitter2,
-||||||| 3641dcb4
-    private readonly analyticsService: AnalyticsService,
-=======
     private readonly messagesGateway: MessagesGateway,
->>>>>>> fe3df2de6c21aa9e7001133f69f1a04d881a871b
   ) {}
 
   async uploadMedia(

--- a/src/rooms/entities/room.entity.ts
+++ b/src/rooms/entities/room.entity.ts
@@ -58,6 +58,17 @@ export class Room {
   @Column({ name: 'is_active', default: true })
   isActive: boolean;
 
+  @Column({ name: 'is_expired', default: false })
+  isExpired: boolean;
+
+  @Column({
+    name: 'archived_at',
+    nullable: true,
+    type: 'timestamp',
+    default: null,
+  })
+  archivedAt: Date | null;
+
   /**
    * Topic tags for discovery (max 5 items).
    * Stored as a comma-separated text column via TypeORM's simple-array strategy.

--- a/src/rooms/gateways/rooms.gateway.ts
+++ b/src/rooms/gateways/rooms.gateway.ts
@@ -34,4 +34,14 @@ export class RoomsGateway implements OnGatewayConnection, OnGatewayDisconnect {
   handleDisconnect(client: Socket) {
     // Clean up connections if needed
   }
+
+  /**
+   * Broadcast room.expired to every WebSocket client currently in this room channel.
+   */
+  notifyRoomExpired(roomId: string): void {
+    this.server.to(roomId).emit('room.expired', {
+      roomId,
+      expiredAt: new Date().toISOString(),
+    });
+  }
 }

--- a/src/rooms/processors/room-expiry.processor.ts
+++ b/src/rooms/processors/room-expiry.processor.ts
@@ -1,0 +1,123 @@
+import { Processor, WorkerHost } from '@nestjs/bullmq';
+import { Logger } from '@nestjs/common';
+import { Job } from 'bullmq';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { InjectQueue } from '@nestjs/bullmq';
+import { Queue } from 'bullmq';
+import { ConfigService } from '@nestjs/config';
+import { Room } from '../entities/room.entity';
+import { RoomsGateway } from '../gateways/rooms.gateway';
+import { QUEUE_NAMES } from '../../queues/queues.module';
+
+export const EXPIRE_ROOM_JOB = 'expire-room';
+export const GRACE_PERIOD_CLEANUP_JOB = 'grace-period-cleanup';
+
+export interface ExpireRoomJobData {
+  roomId: string;
+}
+
+export interface GracePeriodJobData {
+  roomId: string;
+}
+
+@Processor(QUEUE_NAMES.ROOM_EXPIRY)
+export class RoomExpiryProcessor extends WorkerHost {
+  private readonly logger = new Logger(RoomExpiryProcessor.name);
+
+  constructor(
+    @InjectRepository(Room)
+    private readonly roomRepository: Repository<Room>,
+    private readonly roomsGateway: RoomsGateway,
+    @InjectQueue(QUEUE_NAMES.ROOM_EXPIRY)
+    private readonly roomExpiryQueue: Queue,
+    private readonly configService: ConfigService,
+  ) {
+    super();
+  }
+
+  async process(job: Job): Promise<void> {
+    if (job.name === EXPIRE_ROOM_JOB) {
+      await this.handleExpireRoom(job as Job<ExpireRoomJobData>);
+    } else if (job.name === GRACE_PERIOD_CLEANUP_JOB) {
+      await this.handleGracePeriodCleanup(job as Job<GracePeriodJobData>);
+    }
+  }
+
+  private async handleExpireRoom(job: Job<ExpireRoomJobData>): Promise<void> {
+    const { roomId } = job.data;
+    this.logger.log(`Processing expiry for room ${roomId}`);
+
+    const room = await this.roomRepository.findOne({ where: { id: roomId } });
+    if (!room) {
+      this.logger.warn(`Room ${roomId} not found — skipping expiry`);
+      return;
+    }
+
+    if (room.isExpired) {
+      this.logger.log(`Room ${roomId} already expired — skipping`);
+      return;
+    }
+
+    // Mark as expired
+    room.isExpired = true;
+    await this.roomRepository.save(room);
+
+    // Notify members via WebSocket
+    this.roomsGateway.notifyRoomExpired(roomId);
+
+    // Schedule grace-period cleanup
+    const gracePeriodHours = this.configService.get<number>(
+      'ROOM_GRACE_PERIOD_HOURS',
+      24,
+    );
+    const gracePeriodMs = gracePeriodHours * 60 * 60 * 1000;
+
+    await this.roomExpiryQueue.add(
+      GRACE_PERIOD_CLEANUP_JOB,
+      { roomId } as GracePeriodJobData,
+      {
+        delay: gracePeriodMs,
+        attempts: 3,
+        backoff: { type: 'exponential', delay: 5000 },
+      },
+    );
+
+    this.logger.log(
+      `Room ${roomId} expired. Grace-period cleanup scheduled in ${gracePeriodHours}h`,
+    );
+  }
+
+  private async handleGracePeriodCleanup(
+    job: Job<GracePeriodJobData>,
+  ): Promise<void> {
+    const { roomId } = job.data;
+    this.logger.log(`Grace-period cleanup for room ${roomId}`);
+
+    const room = await this.roomRepository.findOne({ where: { id: roomId } });
+    if (!room) {
+      this.logger.warn(`Room ${roomId} not found during grace-period cleanup`);
+      return;
+    }
+
+    if (room.archivedAt) {
+      this.logger.log(`Room ${roomId} already archived — skipping`);
+      return;
+    }
+
+    // Hard-delete all messages in this room
+    await this.roomRepository.manager.query(
+      `DELETE FROM messages WHERE room_id = $1`,
+      [roomId],
+    );
+
+    // Archive the room
+    room.isActive = false;
+    room.archivedAt = new Date();
+    await this.roomRepository.save(room);
+
+    this.logger.log(
+      `Room ${roomId} archived. All messages permanently deleted.`,
+    );
+  }
+}

--- a/src/rooms/services/room-expiry-cron.service.ts
+++ b/src/rooms/services/room-expiry-cron.service.ts
@@ -1,0 +1,56 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron } from '@nestjs/schedule';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository, LessThanOrEqual, IsNull, Not } from 'typeorm';
+import { InjectQueue } from '@nestjs/bullmq';
+import { Queue } from 'bullmq';
+import { Room } from '../entities/room.entity';
+import { QUEUE_NAMES } from '../../queues/queues.module';
+import {
+  EXPIRE_ROOM_JOB,
+  ExpireRoomJobData,
+} from '../processors/room-expiry.processor';
+
+/**
+ * Cron fallback: runs every minute and fires expiry jobs for any timed rooms
+ * that have passed their expiresAt but were not caught by the scheduled BullMQ job
+ * (e.g. due to a Redis outage or server restart).
+ */
+@Injectable()
+export class RoomExpiryCronService {
+  private readonly logger = new Logger(RoomExpiryCronService.name);
+
+  constructor(
+    @InjectRepository(Room)
+    private readonly roomRepository: Repository<Room>,
+    @InjectQueue(QUEUE_NAMES.ROOM_EXPIRY)
+    private readonly roomExpiryQueue: Queue,
+  ) {}
+
+  @Cron('0 * * * * *') // every minute
+  async checkExpiredRooms(): Promise<void> {
+    const now = new Date();
+
+    const missedRooms = await this.roomRepository.find({
+      where: {
+        isExpired: false,
+        expiresAt: LessThanOrEqual(now),
+      },
+      select: ['id', 'expiresAt', 'isExpired'],
+    });
+
+    if (missedRooms.length === 0) return;
+
+    this.logger.warn(
+      `Cron fallback: found ${missedRooms.length} missed room expiry(ies). Enqueuing...`,
+    );
+
+    for (const room of missedRooms) {
+      await this.roomExpiryQueue.add(
+        EXPIRE_ROOM_JOB,
+        { roomId: room.id } as ExpireRoomJobData,
+        { attempts: 3, backoff: { type: 'exponential', delay: 3000 } },
+      );
+    }
+  }
+}


### PR DESCRIPTION


This PR introduces the timed room expiry feature, allowing rooms to automatically "expire" at a configured `expiresAt` datetime. Upon expiry, members are notified, and a grace period begins. After the grace period, all messages in the room are permanently deleted and the room is archived.

## Key Changes

### Database & Entities

- **Room Entity**: Added `isExpired` (boolean, default `false`) and `archivedAt` (nullable timestamp) to track the lifecycle of timed rooms.

### BullMQ Background Jobs

- **`RoomExpiryProcessor`**: Added a new BullMQ processor to handle:
  - `expire-room`: Marks the room as expired, broadcasts to WebSocket clients, and schedules the cleanup job.
  - `grace-period-cleanup`: Hard-deletes all messages associated with the room and sets `archivedAt` to archive the room.
- **Job Scheduling**: `RoomsService.createRoom()` now automatically schedules the `expire-room` BullMQ job with the appropriate delay if the room has an `expiresAt` value.

### Fallback Mechanism

- **`RoomExpiryCronService`**: Implemented a cron job that runs every minute to sweep for rooms where `expiresAt <= now` but `isExpired === false`. This catches any expirations that might have been missed due to server downtime or Redis restarts.

### API & Real-time Enhancements

- **Time Remaining**: `RoomsService.getRoomById()` now computes and returns `timeRemaining` (in seconds) for timed rooms.
- **WebSocket Notifications**: Added `notifyRoomExpired()` to `RoomsGateway` to broadcast the `room.expired` event to all connected clients in the room's channel when the expiry triggers.


closes #293 
