### PR TITLE
feat: Implement real-time messaging with WebSocket

### DIFF
--- a/src/messages/entities/message.entity.ts
+++ b/src/messages/entities/message.entity.ts
@@ -42,6 +42,15 @@ export class Message {
   @Column({ type: 'text', nullable: true })
   content: string | null;
 
+  /** IPFS CID / hash for media messages */
+  @Column({ name: 'ipfs_hash', nullable: true, type: 'varchar', length: 128 })
+  ipfsHash: string | null;
+
+  /** ID of the message being replied to (threaded replies) */
+  @Column({ name: 'reply_to_id', nullable: true, type: 'uuid' })
+  @Index()
+  replyToId: string | null;
+
   @Column({ name: 'payment_id', nullable: true })
   @Index()
   paymentId: string | null;
@@ -53,8 +62,12 @@ export class Message {
   @Column({ name: 'is_deleted', default: false })
   isDeleted: boolean;
 
-  @Column({ name: 'edited_at', nullable: true })
+  @Column({ name: 'edited_at', nullable: true, type: 'timestamp' })
   editedAt: Date | null;
+
+  /** Soft-delete timestamp – set when message is removed */
+  @Column({ name: 'deleted_at', nullable: true, type: 'timestamp' })
+  deletedAt: Date | null;
 
   @CreateDateColumn({ name: 'created_at' })
   createdAt: Date;

--- a/src/messages/messages.gateway.ts
+++ b/src/messages/messages.gateway.ts
@@ -1,16 +1,80 @@
 import {
   WebSocketGateway,
   WebSocketServer,
+  SubscribeMessage,
   OnGatewayConnection,
   OnGatewayDisconnect,
+  ConnectedSocket,
+  MessageBody,
 } from '@nestjs/websockets';
+import { Logger, UnauthorizedException } from '@nestjs/common';
 import { Server, Socket } from 'socket.io';
+import { JwtService } from '@nestjs/jwt';
+import { Message, MessageType } from './entities/message.entity';
 
+// ─── Event name constants ────────────────────────────────────────────────────
+
+export const MSG_EVENTS = {
+  /** Client → Server: subscribe to a room channel */
+  ROOM_SUBSCRIBE: 'room.subscribe',
+  /** Client → Server: unsubscribe from a room channel */
+  ROOM_UNSUBSCRIBE: 'room.unsubscribe',
+  /** Client → Server: send a new message */
+  MESSAGE_SEND: 'message.send',
+  /** Client → Server: mark a message as read */
+  MESSAGE_READ: 'message.read',
+
+  /** Server → Client: broadcast new message to room subscribers */
+  MESSAGE_RECEIVED: 'message.received',
+  /** Server → Client: message delivery confirmed back to sender */
+  MESSAGE_DELIVERED: 'message.delivered',
+  /** Server → Client: someone edited a message */
+  MESSAGE_EDITED: 'message.edited',
+  /** Server → Client: someone deleted a message */
+  MESSAGE_DELETED: 'message.deleted',
+  /** Server → Client: a user's read-receipt update */
+  MESSAGE_READ_ACK: 'message.read_ack',
+} as const;
+
+// ─── Payloads ────────────────────────────────────────────────────────────────
+
+export interface SubscribeRoomPayload {
+  roomId: string;
+}
+
+export interface SendMessagePayloadWs {
+  roomId: string;
+  content?: string;
+  type?: MessageType;
+  ipfsHash?: string;
+  replyToId?: string;
+}
+
+export interface ReadReceiptPayload {
+  roomId: string;
+  messageId: string;
+}
+
+// ─── Gateway ─────────────────────────────────────────────────────────────────
+
+/**
+ * MessagesGateway – Socket.IO namespace /messages
+ *
+ * Connection flow:
+ *  1. Client connects with   { auth: { token: "<JWT>" } }
+ *  2. Server verifies JWT, stores userId in socket.data.userId
+ *  3. Client emits  room.subscribe  { roomId }  → socket joins room channel
+ *  4. Client emits  message.send    { roomId, content, … }
+ *     → Message persisted via MessagesService.persistAndBroadcast()
+ *     → room channel receives  message.received
+ *     → sender receives        message.delivered  (ack)
+ */
 @WebSocketGateway({
-  cors: {
-    origin: '*',
-  },
   namespace: '/messages',
+  cors: {
+    origin: process.env.CORS_ORIGIN || '*',
+    credentials: true,
+  },
 })
 export class MessagesGateway
   implements OnGatewayConnection, OnGatewayDisconnect
@@ -18,12 +82,163 @@ export class MessagesGateway
   @WebSocketServer()
   server: Server;
 
+  private readonly logger = new Logger(MessagesGateway.name);
+
+  // Lazy reference to break circular dep (MessagesGateway ↔ MessagesService)
+  private messagesServiceRef: {
+    persistAndBroadcast: (
+      senderId: string,
+      payload: SendMessagePayloadWs,
+    ) => Promise<Message>;
+  } | null = null;
+
+  constructor(private readonly jwtService: JwtService) {}
+
+  /** Called by MessagesModule after both providers are instantiated */
+  setMessagesService(svc: MessagesGateway['messagesServiceRef']) {
+    this.messagesServiceRef = svc;
+  }
+
+  // ─── Connection lifecycle ─────────────────────────────────────────────────
+
   handleConnection(client: Socket) {
-    // Client connected
+    try {
+      const token =
+        (client.handshake.auth as { token?: string })?.token ??
+        (client.handshake.headers['authorization'] as string | undefined)
+          ?.split(' ')
+          .at(1);
+
+      if (!token) {
+        this.logger.warn(`[/messages] no token – disconnecting ${client.id}`);
+        client.emit('error', { message: 'Authentication token required' });
+        client.disconnect();
+        return;
+      }
+
+      const payload = this.jwtService.verify<{ sub: string }>(token);
+      if (!payload?.sub) {
+        throw new UnauthorizedException('Invalid token payload');
+      }
+
+      client.data.userId = payload.sub;
+      // Auto-join a personal channel so we can target this user directly
+      void client.join(`user:${payload.sub}`);
+
+      this.logger.log(
+        `[/messages] connected: userId=${payload.sub} sock=${client.id}`,
+      );
+    } catch {
+      this.logger.warn(`[/messages] auth failed – disconnecting ${client.id}`);
+      client.emit('error', { message: 'Unauthorized' });
+      client.disconnect();
+    }
   }
 
   handleDisconnect(client: Socket) {
-    // Client disconnected
+    this.logger.log(
+      `[/messages] disconnected: userId=${client.data?.userId} sock=${client.id}`,
+    );
+  }
+
+  // ─── Room subscription ────────────────────────────────────────────────────
+
+  @SubscribeMessage(MSG_EVENTS.ROOM_SUBSCRIBE)
+  async handleRoomSubscribe(
+    @ConnectedSocket() client: Socket,
+    @MessageBody() payload: SubscribeRoomPayload,
+  ) {
+    if (!payload?.roomId) return;
+    await client.join(`room_${payload.roomId}`);
+    this.logger.debug(
+      `userId=${client.data.userId} joined room_${payload.roomId}`,
+    );
+    return { event: MSG_EVENTS.ROOM_SUBSCRIBE, data: { ok: true } };
+  }
+
+  @SubscribeMessage(MSG_EVENTS.ROOM_UNSUBSCRIBE)
+  async handleRoomUnsubscribe(
+    @ConnectedSocket() client: Socket,
+    @MessageBody() payload: SubscribeRoomPayload,
+  ) {
+    if (!payload?.roomId) return;
+    await client.leave(`room_${payload.roomId}`);
+    this.logger.debug(
+      `userId=${client.data.userId} left room_${payload.roomId}`,
+    );
+    return { event: MSG_EVENTS.ROOM_UNSUBSCRIBE, data: { ok: true } };
+  }
+
+  // ─── Send message ─────────────────────────────────────────────────────────
+
+  @SubscribeMessage(MSG_EVENTS.MESSAGE_SEND)
+  async handleMessageSend(
+    @ConnectedSocket() client: Socket,
+    @MessageBody() payload: SendMessagePayloadWs,
+  ) {
+    const userId = client.data?.userId as string | undefined;
+
+    if (!userId) {
+      client.emit('error', { message: 'Unauthorized' });
+      return;
+    }
+
+    if (!payload?.roomId) {
+      client.emit('error', { message: 'roomId is required' });
+      return;
+    }
+
+    if (!this.messagesServiceRef) {
+      client.emit('error', { message: 'Messaging service unavailable' });
+      return;
+    }
+
+    try {
+      const saved = await this.messagesServiceRef.persistAndBroadcast(
+        userId,
+        payload,
+      );
+
+      // Delivery ack – sent only to the originating socket
+      client.emit(MSG_EVENTS.MESSAGE_DELIVERED, {
+        messageId: saved.id,
+        roomId: saved.roomId,
+        createdAt: saved.createdAt,
+      });
+    } catch (err: unknown) {
+      const message =
+        err instanceof Error ? err.message : 'Failed to send message';
+      client.emit('error', { message });
+    }
+  }
+
+  // ─── Read receipt ─────────────────────────────────────────────────────────
+
+  @SubscribeMessage(MSG_EVENTS.MESSAGE_READ)
+  handleMessageRead(
+    @ConnectedSocket() client: Socket,
+    @MessageBody() payload: ReadReceiptPayload,
+  ) {
+    const userId = client.data?.userId as string | undefined;
+    if (!userId || !payload?.messageId || !payload?.roomId) return;
+
+    // Broadcast the read receipt to everyone in the room (sender can update UI)
+    this.server.to(`room_${payload.roomId}`).emit(MSG_EVENTS.MESSAGE_READ_ACK, {
+      userId,
+      messageId: payload.messageId,
+      roomId: payload.roomId,
+      readAt: new Date().toISOString(),
+    });
+  }
+
+  // ─── Server-side broadcast helpers (used by MessagesService) ─────────────
+
+  /**
+   * Broadcast a persisted message to all subscribers of a room.
+   * Called by MessagesService.persistAndBroadcast() after the DB save.
+   */
+  broadcastMessage(roomId: string, message: Message): void {
+    this.server.to(`room_${roomId}`).emit(MSG_EVENTS.MESSAGE_RECEIVED, message);
   }
 
   emitMessageEdited(
@@ -32,7 +247,7 @@ export class MessagesGateway
     newContent: string,
     editedAt: Date,
   ) {
-    this.server.to(`room_${roomId}`).emit('message.edited', {
+    this.server.to(`room_${roomId}`).emit(MSG_EVENTS.MESSAGE_EDITED, {
       messageId,
       content: newContent,
       editedAt,
@@ -41,14 +256,14 @@ export class MessagesGateway
   }
 
   emitMessageDeleted(roomId: string, messageId: string) {
-    this.server.to(`room_${roomId}`).emit('message.deleted', {
+    this.server.to(`room_${roomId}`).emit(MSG_EVENTS.MESSAGE_DELETED, {
       messageId,
       roomId,
     });
   }
 
-  // Example method to join a room, if clients need to join rooms
+  /** Legacy helper kept for compatibility */
   joinRoom(client: Socket, roomId: string) {
-    client.join(`room_${roomId}`);
+    void client.join(`room_${roomId}`);
   }
 }

--- a/src/messages/messages.module.ts
+++ b/src/messages/messages.module.ts
@@ -1,7 +1,7 @@
-import { Module } from '@nestjs/common';
+import { Module, OnModuleInit } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { JwtModule } from '@nestjs/jwt';
-import { ConfigModule } from '@nestjs/config';
+import { ConfigModule, ConfigService } from '@nestjs/config';
 import { EventEmitterModule } from '@nestjs/event-emitter';
 import { MessageMedia } from './entities/message-media.entity';
 import { Message } from './entities/message.entity';
@@ -10,13 +10,25 @@ import { RoomMember } from '../rooms/entities/room-member.entity';
 import { User } from '../user/entities/user.entity';
 import { MessagesController } from './messages.controller';
 import { MessagesService } from './messages.service';
+import { MessagesGateway } from './messages.gateway';
 import { IpfsService } from './services/ipfs.service';
 import { NoOpMediaScanService } from './services/no-op-media-scan.service';
 import { ContractMessageService } from './services/contract-message.service';
 import { MEDIA_SCAN_SERVICE } from './services/media-scan.service';
 import { AnalyticsModule } from '../analytics/analytics.module';
-import { MessagesGateway } from './messages.gateway';
+import { XpModule } from '../xp/xp.module';
 
+/**
+ * MessagesModule
+ *
+ * Wires:
+ *  - Socket.IO gateway (/messages) with JWT auth
+ *  - MessagesService (DB-first persist, XP awards, analytics)
+ *  - XpModule for SEND_MESSAGE XP awards
+ *
+ * The circular dependency between MessagesGateway and MessagesService is
+ * resolved at init time via gateway.setMessagesService().
+ */
 @Module({
   imports: [
     TypeOrmModule.forFeature([
@@ -26,17 +38,24 @@ import { MessagesGateway } from './messages.gateway';
       MessageEdit,
       RoomMember,
     ]),
-    JwtModule.register({}),
+    JwtModule.registerAsync({
+      imports: [ConfigModule],
+      inject: [ConfigService],
+      useFactory: (cfg: ConfigService) => ({
+        secret: cfg.get<string>('JWT_SECRET'),
+      }),
+    }),
     ConfigModule,
     EventEmitterModule.forRoot(),
     AnalyticsModule,
+    XpModule,
   ],
   controllers: [MessagesController],
   providers: [
     MessagesService,
+    MessagesGateway,
     IpfsService,
     ContractMessageService,
-    MessagesGateway,
     {
       provide: MEDIA_SCAN_SERVICE,
       useClass: NoOpMediaScanService,
@@ -44,4 +63,17 @@ import { MessagesGateway } from './messages.gateway';
   ],
   exports: [MessagesService],
 })
-export class MessagesModule {}
+export class MessagesModule implements OnModuleInit {
+  constructor(
+    private readonly gateway: MessagesGateway,
+    private readonly service: MessagesService,
+  ) {}
+
+  /**
+   * Wire the gateway → service reference after both are constructed.
+   * This avoids a circular provider dependency.
+   */
+  onModuleInit() {
+    this.gateway.setMessagesService(this.service);
+  }
+}

--- a/src/messages/messages.service.ts
+++ b/src/messages/messages.service.ts
@@ -2,6 +2,9 @@ import {
   Injectable,
   Logger,
   BadRequestException,
+  ForbiddenException,
+  NotFoundException,
+  ConflictException,
   Inject,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
@@ -21,14 +24,15 @@ import { AnalyticsService } from '../analytics/analytics.service';
 import { EventType } from '../analytics/entities/analytics-event.entity';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { MessagesGateway } from './messages.gateway';
-import {
-  ForbiddenException,
-  NotFoundException,
-  ConflictException,
-} from '@nestjs/common';
+import { UserXpService } from '../xp/user-xp.service';
+import { XpReason } from '../xp/entities/xp-transaction.entity';
 
 const MEDIA_RATE_LIMIT_PER_HOUR = 10;
 const ONE_HOUR_MS = 60 * 60 * 1000;
+
+/** Max XP gainable from messages per hour (rate-limit cap) */
+const MESSAGE_XP_CAP_PER_HOUR = 100;
+const MESSAGE_XP_AMOUNT = 10;
 
 export interface UploadMediaResult {
   ipfsHash: string;
@@ -37,9 +41,27 @@ export interface UploadMediaResult {
   mediaType: MediaType;
 }
 
+export interface SendMessagePayload {
+  roomId: string;
+  content?: string;
+  type?: MessageType;
+  ipfsHash?: string;
+  replyToId?: string;
+}
+
 @Injectable()
 export class MessagesService {
   private readonly logger = new Logger(MessagesService.name);
+
+  /**
+   * In-memory rolling XP totals per user for the current hour.
+   * Key: userId  Value: { xpThisHour, windowStart }
+   * Resets automatically once the window is older than ONE_HOUR_MS.
+   */
+  private readonly xpHourlyTracker = new Map<
+    string,
+    { xpThisHour: number; windowStart: number }
+  >();
 
   constructor(
     @InjectRepository(MessageMedia)
@@ -56,15 +78,13 @@ export class MessagesService {
     @Inject(MEDIA_SCAN_SERVICE)
     private readonly mediaScanService: IMediaScanService,
     private readonly contractMessageService: ContractMessageService,
-<<<<<<< HEAD
     private readonly analyticsService: AnalyticsService,
     private readonly eventEmitter: EventEmitter2,
-||||||| 3641dcb4
-    private readonly analyticsService: AnalyticsService,
-=======
     private readonly messagesGateway: MessagesGateway,
->>>>>>> fe3df2de6c21aa9e7001133f69f1a04d881a871b
+    private readonly xpService: UserXpService,
   ) {}
+
+  // ─── Media upload ─────────────────────────────────────────────────────────
 
   async uploadMedia(
     userId: string,
@@ -133,6 +153,112 @@ export class MessagesService {
     };
   }
 
+  // ─── Persist & broadcast ─────────────────────────────────────────────────
+
+  /**
+   * Persist a message to the DB first, then broadcast it.
+   * Awards +10 XP (rate-capped at 100 XP/hour from messages).
+   */
+  async persistAndBroadcast(
+    senderId: string,
+    payload: SendMessagePayload,
+  ): Promise<Message> {
+    const {
+      roomId,
+      content,
+      type = MessageType.TEXT,
+      ipfsHash,
+      replyToId,
+    } = payload;
+
+    // Verify room exists and is not expired / archived
+    const roomCheck = await this.messageRepository.manager.query(
+      `SELECT id, is_expired, is_active FROM rooms WHERE id = $1`,
+      [roomId],
+    );
+    if (!roomCheck || roomCheck.length === 0) {
+      throw new NotFoundException('Room not found');
+    }
+    const room = roomCheck[0];
+    if (room.is_expired) {
+      throw new ForbiddenException(
+        'Room has expired – no new messages allowed',
+      );
+    }
+    if (!room.is_active) {
+      throw new ForbiddenException('Room is archived');
+    }
+
+    // Persist message BEFORE broadcasting (never lose a message)
+    const message = this.messageRepository.create({
+      senderId,
+      roomId,
+      content: content ?? null,
+      type,
+      ipfsHash: ipfsHash ?? null,
+      replyToId: replyToId ?? null,
+    });
+    const saved = await this.messageRepository.save(message);
+
+    // Broadcast to room
+    this.messagesGateway.broadcastMessage(roomId, saved);
+
+    // Emit internal event for room stats
+    this.eventEmitter.emit('message.sent', {
+      roomId,
+      userId: senderId,
+    });
+
+    // Analytics
+    await this.analyticsService
+      .track(senderId, EventType.MESSAGE_SENT, {
+        roomId,
+        messageId: saved.id,
+        type,
+      })
+      .catch(() => {
+        /* non-critical */
+      });
+
+    // XP award (rate-capped: max 100 XP/hour from messages)
+    this.awardMessageXp(senderId).catch((err) =>
+      this.logger.warn(`XP award failed for ${senderId}: ${err.message}`),
+    );
+
+    return saved;
+  }
+
+  /**
+   * Awards +10 XP for sending a message.
+   * A rolling in-memory window ensures the user earns ≤ 100 XP/hour
+   * from message-send events regardless of concurrency spikes.
+   */
+  private async awardMessageXp(userId: string): Promise<void> {
+    const now = Date.now();
+    let tracker = this.xpHourlyTracker.get(userId);
+
+    // Reset window if older than 1 hour
+    if (!tracker || now - tracker.windowStart >= ONE_HOUR_MS) {
+      tracker = { xpThisHour: 0, windowStart: now };
+      this.xpHourlyTracker.set(userId, tracker);
+    }
+
+    if (tracker.xpThisHour >= MESSAGE_XP_CAP_PER_HOUR) {
+      this.logger.debug(`XP cap reached for ${userId} – skipping award`);
+      return;
+    }
+
+    const toAward = Math.min(
+      MESSAGE_XP_AMOUNT,
+      MESSAGE_XP_CAP_PER_HOUR - tracker.xpThisHour,
+    );
+
+    tracker.xpThisHour += toAward;
+    await this.xpService.award(userId, XpReason.SEND_MESSAGE);
+  }
+
+  // ─── Legacy on-chain send ───────────────────────────────────────────────
+
   async sendMessage(
     userId: string,
     roomId: bigint,
@@ -154,14 +280,12 @@ export class MessagesService {
       tipAmount,
     );
 
-    // Emit event for room stats
     this.eventEmitter.emit('message.sent', {
       roomId: roomId.toString(),
       userId,
       tipAmount,
     });
 
-    // Track analytics
     await this.analyticsService.track(userId, EventType.MESSAGE_SENT, {
       roomId: roomId.toString(),
       contentHash,
@@ -177,6 +301,8 @@ export class MessagesService {
 
     return result;
   }
+
+  // ─── Edit ────────────────────────────────────────────────────────────────
 
   async editMessage(userId: string, messageId: string, newContent: string) {
     const message = await this.messageRepository.findOne({
@@ -209,7 +335,6 @@ export class MessagesService {
       );
     }
 
-    // Preserve previous content in audit table
     const messageEdit = this.messageEditRepository.create({
       messageId: message.id,
       previousContent: message.content,
@@ -217,12 +342,10 @@ export class MessagesService {
     });
     await this.messageEditRepository.save(messageEdit);
 
-    // Update message
     message.content = newContent;
     message.editedAt = new Date();
     await this.messageRepository.save(message);
 
-    // Broadcast edit
     this.messagesGateway.emitMessageEdited(
       message.roomId.toString(),
       message.id,
@@ -233,10 +356,12 @@ export class MessagesService {
     return { success: true, data: message };
   }
 
+  // ─── Delete ──────────────────────────────────────────────────────────────
+
   async deleteMessage(userId: string, messageId: string) {
     const message = await this.messageRepository.findOne({
       where: { id: messageId },
-      relations: ['sender'], // may need if relying on sender checks
+      relations: ['sender'],
     });
 
     if (!message) {
@@ -252,30 +377,27 @@ export class MessagesService {
     if (message.senderId === userId) {
       isAuthorized = true;
     } else {
-      // Check if user is moderator or creator
       const rm = await this.roomMemberRepository.findOne({
         where: { roomId: message.roomId, userId },
         relations: ['room'],
       });
 
       if (rm) {
-        // user is the creator or a moderator
-        const roomObj = rm.room as any; // The entity isn't fully typed for nested 'room' here due to 'unknown' in RoomMember, safely cast
+        const roomObj = rm.room as any;
         if (roomObj?.creatorId === userId) {
           isAuthorized = true;
         } else if ((rm as any).role === 'MODERATOR') {
           isAuthorized = true;
         }
       } else {
-        // Check Room explicitly if rm is missing but they are creator
-        const rmCreatorCheck = await this.roomMemberRepository.manager.query(
+        const creatorCheck = await this.roomMemberRepository.manager.query(
           `SELECT creator_id FROM rooms WHERE id = $1`,
           [message.roomId],
         );
         if (
-          rmCreatorCheck &&
-          rmCreatorCheck.length > 0 &&
-          rmCreatorCheck[0].creator_id === userId
+          creatorCheck &&
+          creatorCheck.length > 0 &&
+          creatorCheck[0].creator_id === userId
         ) {
           isAuthorized = true;
         }
@@ -288,7 +410,6 @@ export class MessagesService {
       );
     }
 
-    // Save delete state as an edit trail
     const messageEdit = this.messageEditRepository.create({
       messageId: message.id,
       previousContent: message.content,
@@ -296,13 +417,12 @@ export class MessagesService {
     });
     await this.messageEditRepository.save(messageEdit);
 
-    // Soft delete / placeholder
     message.isDeleted = true;
     message.content = '[Message deleted]';
-    message.editedAt = new Date(); // To satisfy "editedAt timestamp updated on edit" potentially
+    message.deletedAt = new Date();
+    message.editedAt = new Date();
     await this.messageRepository.save(message);
 
-    // Broadcast delete event
     this.messagesGateway.emitMessageDeleted(
       message.roomId.toString(),
       message.id,


### PR DESCRIPTION


This PR implements the core real-time messaging system using NestJS WebSocket gateways (`Socket.IO`). It establishes a secure, authenticated WebSocket connection for users to join rooms, send messages, and receive real-time updates while ensuring data is persisted to PostgreSQL before broadcasting. It also integrates XP rewards with rate-limiting for active participants.

## Key Changes

### Database & Entities

- **`Message` Entity Enhancements**:
  - Added `ipfsHash` for storing IPFS CIDs for media messages.
  - Added `replyToId` to support threaded replies.
  - Added `deletedAt` timestamp for comprehensive soft-delete tracking alongside `isDeleted`.

### Real-Time Gateway (`MessagesGateway`)

- **Authentication**: WebSocket connections require a valid JWT via `handshake.auth.token` or `Authorization` headers. Unauthenticated sockets are immediately rejected.
- **Room Management**:
  - `room.subscribe`: Allows authenticated clients to join a room's WebSocket channel.
  - `room.unsubscribe`: Allows clients to leave a room's channel.
- **Message Flow & Acknowledgments**:
  - `message.send`: Client emits this to send a message.
  - `message.received`: Broadcast to all room subscribers when a new message is successfully persisted.
  - `message.delivered`: Delivery acknowledgment sent exclusively back to the sender confirming DB persistence.
- **Read Receipts**:
  - `message.read`: Client emits this to mark a message as read.
  - `message.read_ack`: Broadcasts the read receipt to all room subscribers.
- **Circular Dependency Resolution**: Implemented a lazy-loading setter (`setMessagesService`) wired via `onModuleInit` in the module to cleanly resolve the circular dependency between the gateway and service without relying on `forwardRef`.

### Service Logic (`MessagesService`)

- **Persist-First Guarantee**: Implemented `persistAndBroadcast()` which ensures every message is saved to PostgreSQL _before_ it is broadcast to WebSocket subscribers, eliminating lost messages.
- **XP Integration & Rate Limiting**:
  - Sending a message awards **+10 XP** to the user.
  - Implemented an in-memory rolling window to cap message XP gains at **100 XP per hour** per user to prevent spam abuse.

 closes #296