### PR TITLE
feat(contracts): implement on-chain contact management

### DIFF
--- a/contracts/Cargo.lock
+++ b/contracts/Cargo.lock
@@ -242,6 +242,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
+name = "contact-management"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/contracts/contracts/contact_management/Cargo.toml
+++ b/contracts/contracts/contact_management/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "contact-management"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+doctest = false
+
+[dependencies]
+soroban-sdk = { workspace = true }
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/contracts/contracts/contact_management/src/lib.rs
+++ b/contracts/contracts/contact_management/src/lib.rs
@@ -1,0 +1,192 @@
+#![no_std]
+
+use soroban_sdk::{
+    contract, contracterror, contractimpl, contracttype, symbol_short, Address, Env, Vec,
+};
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[contracttype]
+pub enum ContactStatus {
+    Contact = 0,
+    Blocked = 1,
+}
+
+#[derive(Clone)]
+#[contracttype]
+pub enum DataKey {
+    ContactRecord(Address, Address),
+    ContactList(Address),
+}
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum ContractError {
+    InvalidTarget = 1,
+    ContactNotFound = 2,
+    AlreadyBlocked = 3,
+    NotBlocked = 4,
+    BlockedRelationship = 5,
+}
+
+#[contract]
+pub struct ContactManagementContract;
+
+#[contractimpl]
+impl ContactManagementContract {
+    pub fn add_contact(env: Env, owner: Address, contact: Address) -> Result<(), ContractError> {
+        owner.require_auth();
+
+        if owner == contact {
+            return Err(ContractError::InvalidTarget);
+        }
+
+        if Self::is_blocked_pair(&env, owner.clone(), contact.clone()) {
+            return Err(ContractError::BlockedRelationship);
+        }
+
+        env.storage().persistent().set(
+            &DataKey::ContactRecord(owner.clone(), contact.clone()),
+            &ContactStatus::Contact,
+        );
+
+        Self::append_unique_contact(&env, owner.clone(), contact.clone());
+
+        env.events().publish(
+            (symbol_short!("cont_add"), owner, contact),
+            env.ledger().timestamp(),
+        );
+
+        Ok(())
+    }
+
+    pub fn remove_contact(env: Env, owner: Address, contact: Address) -> Result<(), ContractError> {
+        owner.require_auth();
+
+        if owner == contact {
+            return Err(ContractError::InvalidTarget);
+        }
+
+        let key = DataKey::ContactRecord(owner.clone(), contact.clone());
+        if !env.storage().persistent().has(&key) {
+            return Err(ContractError::ContactNotFound);
+        }
+
+        env.storage().persistent().remove(&key);
+        Self::remove_contact_from_list(&env, owner.clone(), contact.clone());
+
+        env.events().publish(
+            (symbol_short!("cont_rem"), owner, contact),
+            env.ledger().timestamp(),
+        );
+
+        Ok(())
+    }
+
+    pub fn block_user(env: Env, owner: Address, user: Address) -> Result<(), ContractError> {
+        owner.require_auth();
+
+        if owner == user {
+            return Err(ContractError::InvalidTarget);
+        }
+
+        let key = DataKey::ContactRecord(owner.clone(), user.clone());
+        if let Some(status) = env.storage().persistent().get::<_, ContactStatus>(&key) {
+            if status == ContactStatus::Blocked {
+                return Err(ContractError::AlreadyBlocked);
+            }
+        }
+
+        env.storage().persistent().set(&key, &ContactStatus::Blocked);
+
+        // Hide both directions in contact views once a block is active.
+        Self::remove_contact_from_list(&env, owner.clone(), user.clone());
+        Self::remove_contact_from_list(&env, user.clone(), owner.clone());
+
+        env.events().publish(
+            (symbol_short!("usr_blk"), owner, user),
+            env.ledger().timestamp(),
+        );
+
+        Ok(())
+    }
+
+    pub fn unblock_user(env: Env, owner: Address, user: Address) -> Result<(), ContractError> {
+        owner.require_auth();
+
+        if owner == user {
+            return Err(ContractError::InvalidTarget);
+        }
+
+        let key = DataKey::ContactRecord(owner.clone(), user.clone());
+        let status = env.storage().persistent().get::<_, ContactStatus>(&key);
+        if status != Some(ContactStatus::Blocked) {
+            return Err(ContractError::NotBlocked);
+        }
+
+        env.storage().persistent().remove(&key);
+
+        env.events().publish(
+            (symbol_short!("usr_unblk"), owner, user),
+            env.ledger().timestamp(),
+        );
+
+        Ok(())
+    }
+
+    pub fn get_contacts(env: Env, address: Address) -> Vec<Address> {
+        address.require_auth();
+
+        let contacts: Vec<Address> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::ContactList(address))
+            .unwrap_or(Vec::new(&env));
+
+        contacts
+    }
+
+    pub fn is_blocked(env: Env, user_a: Address, user_b: Address) -> bool {
+        user_a.require_auth();
+        Self::is_blocked_pair(&env, user_a, user_b)
+    }
+
+    fn is_blocked_pair(env: &Env, user_a: Address, user_b: Address) -> bool {
+        let a_to_b = env
+            .storage()
+            .persistent()
+            .get::<_, ContactStatus>(&DataKey::ContactRecord(user_a.clone(), user_b.clone()));
+        let b_to_a = env
+            .storage()
+            .persistent()
+            .get::<_, ContactStatus>(&DataKey::ContactRecord(user_b, user_a));
+
+        a_to_b == Some(ContactStatus::Blocked) || b_to_a == Some(ContactStatus::Blocked)
+    }
+
+    fn append_unique_contact(env: &Env, owner: Address, contact: Address) {
+        let key = DataKey::ContactList(owner);
+        let mut contacts: Vec<Address> = env.storage().persistent().get(&key).unwrap_or(Vec::new(env));
+
+        if !contacts.contains(&contact) {
+            contacts.push_back(contact);
+            env.storage().persistent().set(&key, &contacts);
+        }
+    }
+
+    fn remove_contact_from_list(env: &Env, owner: Address, contact: Address) {
+        let key = DataKey::ContactList(owner);
+        let contacts: Vec<Address> = env.storage().persistent().get(&key).unwrap_or(Vec::new(env));
+
+        let mut filtered = Vec::new(env);
+        for current in contacts.iter() {
+            if current != contact {
+                filtered.push_back(current);
+            }
+        }
+
+        env.storage().persistent().set(&key, &filtered);
+    }
+}
+
+#[cfg(test)]
+mod test;

--- a/contracts/contracts/contact_management/src/test.rs
+++ b/contracts/contracts/contact_management/src/test.rs
@@ -1,0 +1,123 @@
+use super::*;
+use soroban_sdk::{
+    contract, contractimpl,
+    testutils::Events,
+    Address, Env,
+};
+
+#[contract]
+struct DummyInvoker;
+
+#[contractimpl]
+impl DummyInvoker {}
+
+fn setup() -> (Env, Address, Address, Address, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(ContactManagementContract, ());
+
+    let user_a = env.register(DummyInvoker, ());
+    let user_b = env.register(DummyInvoker, ());
+    let user_c = env.register(DummyInvoker, ());
+
+    (env, contract_id, user_a, user_b, user_c)
+}
+
+#[test]
+fn test_add_and_remove_contact() {
+    let (env, contract_id, user_a, user_b, _) = setup();
+    let client = ContactManagementContractClient::new(&env, &contract_id);
+
+    client.add_contact(&user_a, &user_b);
+
+    let contacts = client.get_contacts(&user_a);
+    assert_eq!(contacts.len(), 1);
+    assert_eq!(contacts.get(0).unwrap(), user_b);
+
+    client.remove_contact(&user_a, &user_b);
+
+    let contacts = client.get_contacts(&user_a);
+    assert_eq!(contacts.len(), 0);
+}
+
+#[test]
+fn test_block_is_unilateral_and_hides_contact() {
+    let (env, contract_id, user_a, user_b, _) = setup();
+    let client = ContactManagementContractClient::new(&env, &contract_id);
+
+    client.add_contact(&user_a, &user_b);
+    client.add_contact(&user_b, &user_a);
+
+    client.block_user(&user_a, &user_b);
+
+    let contacts_a = client.get_contacts(&user_a);
+    let contacts_b = client.get_contacts(&user_b);
+
+    assert_eq!(contacts_a.len(), 0);
+    assert_eq!(contacts_b.len(), 0);
+
+    let blocked = client.is_blocked(&user_a, &user_b);
+    assert!(blocked);
+}
+
+#[test]
+fn test_unblock_user() {
+    let (env, contract_id, user_a, user_b, _) = setup();
+    let client = ContactManagementContractClient::new(&env, &contract_id);
+
+    client.block_user(&user_a, &user_b);
+
+    let blocked_before = client.is_blocked(&user_a, &user_b);
+    assert!(blocked_before);
+
+    client.unblock_user(&user_a, &user_b);
+
+    let blocked_after = client.is_blocked(&user_a, &user_b);
+    assert!(!blocked_after);
+}
+
+#[test]
+fn test_blocked_users_cannot_add_contact() {
+    let (env, contract_id, user_a, user_b, _) = setup();
+    let client = ContactManagementContractClient::new(&env, &contract_id);
+
+    client.block_user(&user_a, &user_b);
+
+    let res = client.try_add_contact(&user_b, &user_a);
+    assert!(matches!(res, Err(Ok(ContractError::BlockedRelationship))));
+}
+
+#[test]
+fn test_events_emitted_for_state_changes() {
+    let (env, contract_id, user_a, user_b, _) = setup();
+    let client = ContactManagementContractClient::new(&env, &contract_id);
+
+    let before = env.events().all().len();
+
+    client.add_contact(&user_a, &user_b);
+    client.block_user(&user_a, &user_b);
+    client.unblock_user(&user_a, &user_b);
+    client.add_contact(&user_a, &user_b);
+    client.remove_contact(&user_a, &user_b);
+
+    let after = env.events().all().len();
+    assert_eq!(after - before, 5);
+}
+
+#[test]
+fn test_view_functions_private_scope() {
+    let (env, contract_id, user_a, user_b, user_c) = setup();
+    let client = ContactManagementContractClient::new(&env, &contract_id);
+
+    client.add_contact(&user_a, &user_b);
+    client.add_contact(&user_c, &user_b);
+
+    let contacts_a = client.get_contacts(&user_a);
+    let contacts_c = client.get_contacts(&user_c);
+
+    assert_eq!(contacts_a.len(), 1);
+    assert_eq!(contacts_c.len(), 1);
+    assert_eq!(contacts_a.get(0).unwrap(), user_b);
+    assert_eq!(contacts_c.get(0).unwrap(), user_b);
+}

--- a/contracts/contracts/contact_management/tests/integration.rs
+++ b/contracts/contracts/contact_management/tests/integration.rs
@@ -1,0 +1,42 @@
+use contact_management::{ContactManagementContract, ContactManagementContractClient};
+use soroban_sdk::{contract, contractimpl, Env};
+
+#[contract]
+struct DummyInvoker;
+
+#[contractimpl]
+impl DummyInvoker {}
+
+#[test]
+fn test_block_prevents_conversation_initiation_rule() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(ContactManagementContract, ());
+    let client = ContactManagementContractClient::new(&env, &contract_id);
+
+    let user_a = env.register(DummyInvoker, ());
+    let user_b = env.register(DummyInvoker, ());
+
+    client.block_user(&user_a, &user_b);
+
+    let blocked = client.is_blocked(&user_b, &user_a);
+    assert!(blocked);
+}
+
+#[test]
+fn test_block_prevents_transfer_initiation_rule() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(ContactManagementContract, ());
+    let client = ContactManagementContractClient::new(&env, &contract_id);
+
+    let user_a = env.register(DummyInvoker, ());
+    let user_b = env.register(DummyInvoker, ());
+
+    client.block_user(&user_a, &user_b);
+
+    let blocked = client.is_blocked(&user_b, &user_a);
+    assert!(blocked);
+}


### PR DESCRIPTION
closes #372 

# Summary
Implements an on-chain contact management contract for adding, removing, blocking, and unblocking user relationships.

This PR adds a dedicated Soroban contract crate:
- `contracts/contracts/contact_management`

## Issue Scope Covered
- Design `ContactRecord` storage: `Map<(Address, Address), ContactStatus>`
- Implement `add_contact(contact: Address)`
- Implement `remove_contact(contact: Address)`
- Implement `block_user(user: Address)`
- Implement `unblock_user(user: Address)`
- Implement `get_contacts(address: Address) -> Vec` view
- Implement `is_blocked(user_a: Address, user_b: Address) -> bool` view
- Add event emission for contact and block state changes
- Write unit and integration tests

## What Changed
### New crate
- `contracts/contracts/contact_management/Cargo.toml`
- `contracts/contracts/contact_management/src/lib.rs`
- `contracts/contracts/contact_management/src/test.rs`
- `contracts/contracts/contact_management/tests/integration.rs`

### Contract model
- `ContactStatus` enum:
  - `Contact`
  - `Blocked`
- Storage keys:
  - `ContactRecord(Address, Address)` for relationship state
  - `ContactList(Address)` for per-user contact list

### Contract methods
- `add_contact(env, owner, contact)`
- `remove_contact(env, owner, contact)`
- `block_user(env, owner, user)`
- `unblock_user(env, owner, user)`
- `get_contacts(env, address)`
- `is_blocked(env, user_a, user_b)`

## Acceptance Criteria Mapping
- **Blocked users cannot initiate conversations or transfers**
  - `is_blocked` returns true if either direction is blocked.
  - Integration tests validate blocked relationship signal for conversation/transfer gating.
- **Contact list is per-user and private**
  - Contacts are stored per owner (`ContactList(owner)`).
  - `get_contacts` requires auth for requested address.
- **Block is unilateral (A blocks B, B cannot see A)**
  - Block is stored on `(A, B)`.
  - Contact view entries are removed from both contact lists when block occurs.
- **Events emitted for all relationship state changes**
  - Events emitted on add, remove, block, unblock.
- **View functions respect privacy rules**
  - `get_contacts(address)` requires `address` auth.
  - `is_blocked(user_a, user_b)` requires `user_a` auth.

## Tests
### Unit tests
- Add/remove flow
- Unilateral block behavior and contact visibility
- Unblock flow
- Blocked relationship prevents contact addition
- Event emission count for relationship state changes
- View scoping behavior for per-user contacts

### Integration tests
- Blocked relationship signal for conversation initiation rule
- Blocked relationship signal for transfer initiation rule

## Verification
Executed in contracts workspace:
- `cargo test -p contact-management`
- `cargo test`

Both commands pass.

## Notes
- Method signatures include explicit `owner` argument for auth checks (`owner.require_auth()`), matching the Soroban SDK usage in this workspace.
- `contracts/Cargo.lock` updated to include the new crate package entry.
