### PR TITLE
feat(contracts): implement dao treasury proposals and voting

### DIFF
--- a/contracts/Cargo.lock
+++ b/contracts/Cargo.lock
@@ -334,6 +334,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "dao-treasury"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk",
+]
+
+[[package]]
 name = "darling"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/contracts/contracts/dao_treasury/Cargo.toml
+++ b/contracts/contracts/dao_treasury/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "dao-treasury"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+doctest = false
+
+[dependencies]
+soroban-sdk = { workspace = true }
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/contracts/contracts/dao_treasury/src/lib.rs
+++ b/contracts/contracts/dao_treasury/src/lib.rs
@@ -1,0 +1,306 @@
+#![no_std]
+
+use soroban_sdk::{
+    contract, contracterror, contractimpl, contracttype, Address, Bytes, BytesN, Env, Symbol,
+};
+
+const DEFAULT_QUORUM_VOTES: u32 = 2;
+const DEFAULT_MAJORITY_BPS: u32 = 5001;
+const DEFAULT_PROPOSAL_TTL_LEDGERS: u32 = 100;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[contracttype]
+pub struct TreasuryRecord {
+    pub group_id: BytesN<32>,
+    pub balance: i128,
+    pub quorum_votes: u32,
+    pub majority_bps: u32,
+    pub proposal_ttl_ledgers: u32,
+    pub next_proposal_nonce: u64,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[contracttype]
+pub struct ProposalRecord {
+    pub proposal_id: BytesN<32>,
+    pub group_id: BytesN<32>,
+    pub recipient: Address,
+    pub amount: i128,
+    pub description: Symbol,
+    pub created_ledger: u32,
+    pub expires_ledger: u32,
+    pub yes_votes: u32,
+    pub no_votes: u32,
+    pub total_votes: u32,
+    pub executed: bool,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[contracttype]
+pub struct VoteRecord {
+    pub proposal_id: BytesN<32>,
+    pub vote_index: u32,
+    pub approve: bool,
+    pub voted_ledger: u32,
+}
+
+#[derive(Clone)]
+#[contracttype]
+pub enum DataKey {
+    Treasury(BytesN<32>),
+    Proposal(BytesN<32>),
+    ProposalVote(BytesN<32>, u32),
+}
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum ContractError {
+    InvalidAmount = 1,
+    ProposalNotFound = 2,
+    TreasuryNotFound = 3,
+    InsufficientTreasuryBalance = 4,
+    ProposalExpired = 5,
+    ProposalAlreadyExecuted = 6,
+    QuorumNotMet = 7,
+    MajorityNotMet = 8,
+    InvalidThreshold = 9,
+}
+
+#[contract]
+pub struct DaoTreasuryContract;
+
+#[contractimpl]
+impl DaoTreasuryContract {
+    pub fn deposit(env: Env, group_id: BytesN<32>, amount: i128) -> Result<(), ContractError> {
+        if amount <= 0 {
+            return Err(ContractError::InvalidAmount);
+        }
+
+        let mut treasury = Self::get_or_create_treasury(&env, group_id.clone())?;
+        treasury.balance = treasury
+            .balance
+            .checked_add(amount)
+            .ok_or(ContractError::InvalidAmount)?;
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::Treasury(group_id.clone()), &treasury);
+
+        env.events().publish(
+            (Symbol::new(&env, "deposit"), group_id),
+            (amount, treasury.balance, env.ledger().timestamp()),
+        );
+
+        Ok(())
+    }
+
+    pub fn create_proposal(
+        env: Env,
+        group_id: BytesN<32>,
+        recipient: Address,
+        amount: i128,
+        description: Symbol,
+    ) -> Result<BytesN<32>, ContractError> {
+        if amount <= 0 {
+            return Err(ContractError::InvalidAmount);
+        }
+
+        let mut treasury = Self::get_or_create_treasury(&env, group_id.clone())?;
+
+        let proposal_id = Self::build_proposal_id(&env, &group_id, treasury.next_proposal_nonce);
+        treasury.next_proposal_nonce = treasury
+            .next_proposal_nonce
+            .checked_add(1)
+            .ok_or(ContractError::InvalidAmount)?;
+
+        let created_ledger = env.ledger().sequence();
+        let expires_ledger = created_ledger.saturating_add(treasury.proposal_ttl_ledgers);
+
+        let proposal = ProposalRecord {
+            proposal_id: proposal_id.clone(),
+            group_id: group_id.clone(),
+            recipient: recipient.clone(),
+            amount,
+            description,
+            created_ledger,
+            expires_ledger,
+            yes_votes: 0,
+            no_votes: 0,
+            total_votes: 0,
+            executed: false,
+        };
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::Treasury(group_id.clone()), &treasury);
+        env.storage()
+            .persistent()
+            .set(&DataKey::Proposal(proposal_id.clone()), &proposal);
+
+        env.events().publish(
+            (Symbol::new(&env, "proposal_created"), proposal_id.clone()),
+            (
+                group_id,
+                recipient,
+                amount,
+                proposal.expires_ledger,
+                env.ledger().timestamp(),
+            ),
+        );
+
+        Ok(proposal_id)
+    }
+
+    pub fn vote(env: Env, proposal_id: BytesN<32>, approve: bool) -> Result<(), ContractError> {
+        let mut proposal = Self::get_proposal(env.clone(), proposal_id.clone())?;
+
+        if proposal.executed {
+            return Err(ContractError::ProposalAlreadyExecuted);
+        }
+
+        if Self::is_expired(&env, &proposal) {
+            return Err(ContractError::ProposalExpired);
+        }
+
+        if approve {
+            proposal.yes_votes = proposal.yes_votes.saturating_add(1);
+        } else {
+            proposal.no_votes = proposal.no_votes.saturating_add(1);
+        }
+        proposal.total_votes = proposal.total_votes.saturating_add(1);
+
+        let vote_record = VoteRecord {
+            proposal_id: proposal_id.clone(),
+            vote_index: proposal.total_votes,
+            approve,
+            voted_ledger: env.ledger().sequence(),
+        };
+
+        env.storage().persistent().set(
+            &DataKey::ProposalVote(proposal_id.clone(), vote_record.vote_index),
+            &vote_record,
+        );
+        env.storage()
+            .persistent()
+            .set(&DataKey::Proposal(proposal_id.clone()), &proposal);
+
+        env.events().publish(
+            (Symbol::new(&env, "vote_cast"), proposal_id),
+            (
+                approve,
+                proposal.yes_votes,
+                proposal.no_votes,
+                proposal.total_votes,
+                env.ledger().timestamp(),
+            ),
+        );
+
+        Ok(())
+    }
+
+    pub fn execute_proposal(env: Env, proposal_id: BytesN<32>) -> Result<(), ContractError> {
+        let mut proposal = Self::get_proposal(env.clone(), proposal_id.clone())?;
+
+        if proposal.executed {
+            return Err(ContractError::ProposalAlreadyExecuted);
+        }
+
+        if Self::is_expired(&env, &proposal) {
+            return Err(ContractError::ProposalExpired);
+        }
+
+        let mut treasury = env
+            .storage()
+            .persistent()
+            .get::<_, TreasuryRecord>(&DataKey::Treasury(proposal.group_id.clone()))
+            .ok_or(ContractError::TreasuryNotFound)?;
+
+        if proposal.total_votes < treasury.quorum_votes {
+            return Err(ContractError::QuorumNotMet);
+        }
+
+        let lhs = (proposal.yes_votes as u128) * 10_000u128;
+        let rhs = (proposal.total_votes as u128) * (treasury.majority_bps as u128);
+        if lhs < rhs {
+            return Err(ContractError::MajorityNotMet);
+        }
+
+        if proposal.amount > treasury.balance {
+            return Err(ContractError::InsufficientTreasuryBalance);
+        }
+
+        treasury.balance -= proposal.amount;
+        proposal.executed = true;
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::Treasury(proposal.group_id.clone()), &treasury);
+        env.storage()
+            .persistent()
+            .set(&DataKey::Proposal(proposal_id.clone()), &proposal);
+
+        env.events().publish(
+            (Symbol::new(&env, "proposal_executed"), proposal_id),
+            (
+                proposal.group_id,
+                proposal.recipient,
+                proposal.amount,
+                treasury.balance,
+                env.ledger().timestamp(),
+            ),
+        );
+
+        Ok(())
+    }
+
+    pub fn get_treasury_balance(env: Env, group_id: BytesN<32>) -> i128 {
+        env.storage()
+            .persistent()
+            .get::<_, TreasuryRecord>(&DataKey::Treasury(group_id))
+            .map(|record| record.balance)
+            .unwrap_or(0)
+    }
+
+    pub fn get_proposal(env: Env, proposal_id: BytesN<32>) -> Result<ProposalRecord, ContractError> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Proposal(proposal_id))
+            .ok_or(ContractError::ProposalNotFound)
+    }
+
+    fn get_or_create_treasury(env: &Env, group_id: BytesN<32>) -> Result<TreasuryRecord, ContractError> {
+        if let Some(record) = env
+            .storage()
+            .persistent()
+            .get::<_, TreasuryRecord>(&DataKey::Treasury(group_id.clone()))
+        {
+            if record.majority_bps == 0 || record.majority_bps > 10_000 {
+                return Err(ContractError::InvalidThreshold);
+            }
+            return Ok(record);
+        }
+
+        Ok(TreasuryRecord {
+            group_id,
+            balance: 0,
+            quorum_votes: DEFAULT_QUORUM_VOTES,
+            majority_bps: DEFAULT_MAJORITY_BPS,
+            proposal_ttl_ledgers: DEFAULT_PROPOSAL_TTL_LEDGERS,
+            next_proposal_nonce: 1,
+        })
+    }
+
+    fn build_proposal_id(env: &Env, group_id: &BytesN<32>, nonce: u64) -> BytesN<32> {
+        let mut seed = Bytes::new(env);
+        seed.append(&Bytes::from_array(env, &group_id.to_array()));
+        seed.append(&Bytes::from_array(env, &nonce.to_be_bytes()));
+        env.crypto().sha256(&seed).into()
+    }
+
+    fn is_expired(env: &Env, proposal: &ProposalRecord) -> bool {
+        env.ledger().sequence() > proposal.expires_ledger
+    }
+}
+
+#[cfg(test)]
+mod test;

--- a/contracts/contracts/dao_treasury/src/test.rs
+++ b/contracts/contracts/dao_treasury/src/test.rs
@@ -1,0 +1,101 @@
+use super::*;
+use soroban_sdk::{
+    testutils::{Address as _, Events, Ledger},
+    Address, BytesN, Env, Symbol,
+};
+
+fn setup() -> (Env, Address, BytesN<32>) {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(DaoTreasuryContract, ());
+
+    let group_id = BytesN::from_array(&env, &[7u8; 32]);
+    (env, contract_id, group_id)
+}
+
+#[test]
+fn test_deposit_credited_immediately() {
+    let (env, contract_id, group_id) = setup();
+    let client = DaoTreasuryContractClient::new(&env, &contract_id);
+
+    client.deposit(&group_id, &500);
+    assert_eq!(client.get_treasury_balance(&group_id), 500);
+}
+
+#[test]
+fn test_execute_requires_quorum_and_majority() {
+    let (env, contract_id, group_id) = setup();
+    let client = DaoTreasuryContractClient::new(&env, &contract_id);
+    let recipient = Address::generate(&env);
+
+    client.deposit(&group_id, &1_000);
+    let proposal_id = client.create_proposal(&group_id, &recipient, &300, &Symbol::new(&env, "payout"));
+
+    let early_execute = client.try_execute_proposal(&proposal_id);
+    assert!(matches!(early_execute, Err(Ok(ContractError::QuorumNotMet))));
+
+    client.vote(&proposal_id, &true);
+    let still_quorum_fail = client.try_execute_proposal(&proposal_id);
+    assert!(matches!(still_quorum_fail, Err(Ok(ContractError::QuorumNotMet))));
+
+    client.vote(&proposal_id, &false);
+    let majority_fail = client.try_execute_proposal(&proposal_id);
+    assert!(matches!(majority_fail, Err(Ok(ContractError::MajorityNotMet))));
+
+    client.vote(&proposal_id, &true);
+    client.execute_proposal(&proposal_id);
+
+    assert_eq!(client.get_treasury_balance(&group_id), 700);
+}
+
+#[test]
+fn test_expired_proposal_cannot_be_executed() {
+    let (env, contract_id, group_id) = setup();
+    let client = DaoTreasuryContractClient::new(&env, &contract_id);
+    let recipient = Address::generate(&env);
+
+    client.deposit(&group_id, &1_000);
+    let proposal_id = client.create_proposal(&group_id, &recipient, &200, &Symbol::new(&env, "expire"));
+
+    env.ledger().with_mut(|li| {
+        li.sequence_number += DEFAULT_PROPOSAL_TTL_LEDGERS + 1;
+    });
+
+    let res = client.try_execute_proposal(&proposal_id);
+    assert!(matches!(res, Err(Ok(ContractError::ProposalExpired))));
+}
+
+#[test]
+fn test_treasury_balance_after_operations() {
+    let (env, contract_id, group_id) = setup();
+    let client = DaoTreasuryContractClient::new(&env, &contract_id);
+    let recipient = Address::generate(&env);
+
+    client.deposit(&group_id, &900);
+    let proposal_id = client.create_proposal(&group_id, &recipient, &250, &Symbol::new(&env, "fund"));
+
+    client.vote(&proposal_id, &true);
+    client.vote(&proposal_id, &true);
+    client.execute_proposal(&proposal_id);
+
+    assert_eq!(client.get_treasury_balance(&group_id), 650);
+}
+
+#[test]
+fn test_full_audit_trail_events_emitted() {
+    let (env, contract_id, group_id) = setup();
+    let client = DaoTreasuryContractClient::new(&env, &contract_id);
+    let recipient = Address::generate(&env);
+
+    let before = env.events().all().len();
+
+    client.deposit(&group_id, &1_000);
+    let proposal_id = client.create_proposal(&group_id, &recipient, &100, &Symbol::new(&env, "audit"));
+    client.vote(&proposal_id, &true);
+    client.vote(&proposal_id, &true);
+    client.execute_proposal(&proposal_id);
+
+    let after = env.events().all().len();
+    assert_eq!(after - before, 5);
+}

--- a/contracts/contracts/dao_treasury/tests/integration.rs
+++ b/contracts/contracts/dao_treasury/tests/integration.rs
@@ -1,0 +1,50 @@
+use dao_treasury::DaoTreasuryContract;
+use soroban_sdk::{
+    testutils::{Address as _, Ledger},
+    Address, BytesN, Env, Symbol,
+};
+
+#[test]
+fn test_full_dao_flow_integration() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(DaoTreasuryContract, ());
+    let client = dao_treasury::DaoTreasuryContractClient::new(&env, &contract_id);
+
+    let group_id = BytesN::from_array(&env, &[11u8; 32]);
+    let recipient = Address::generate(&env);
+
+    client.deposit(&group_id, &2_000);
+    assert_eq!(client.get_treasury_balance(&group_id), 2_000);
+
+    let proposal_id = client.create_proposal(&group_id, &recipient, &600, &Symbol::new(&env, "ops"));
+
+    client.vote(&proposal_id, &true);
+    client.vote(&proposal_id, &true);
+    client.execute_proposal(&proposal_id);
+
+    assert_eq!(client.get_treasury_balance(&group_id), 1_400);
+}
+
+#[test]
+fn test_expiry_blocks_execution_integration() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(DaoTreasuryContract, ());
+    let client = dao_treasury::DaoTreasuryContractClient::new(&env, &contract_id);
+
+    let group_id = BytesN::from_array(&env, &[12u8; 32]);
+    let recipient = Address::generate(&env);
+
+    client.deposit(&group_id, &500);
+    let proposal_id = client.create_proposal(&group_id, &recipient, &100, &Symbol::new(&env, "exp"));
+
+    env.ledger().with_mut(|li| {
+        li.sequence_number += 101;
+    });
+
+    let res = client.try_execute_proposal(&proposal_id);
+    assert!(matches!(res, Err(Ok(dao_treasury::ContractError::ProposalExpired))));
+}


### PR DESCRIPTION
closes #369 

# Summary
Implements a new on-chain DAO treasury contract for group-managed shared funds with proposals, voting, quorum/majority checks, and expiry enforcement.

## Scope Delivered
- Designed storage records:
  - `TreasuryRecord`
  - `ProposalRecord`
  - `VoteRecord`
- Implemented:
  - `deposit(group_id, amount)`
  - `create_proposal(group_id, recipient, amount, description) -> ProposalId`
  - `vote(proposal_id, approve)`
  - `execute_proposal(proposal_id)`
  - `get_treasury_balance(group_id) -> i128`
- Added quorum + majority threshold enforcement
- Added proposal expiry logic
- Added event emission for deposits, proposals, votes, and executions
- Added unit + integration tests for full DAO flow

## Files Added
- `contracts/contracts/dao_treasury/Cargo.toml`
- `contracts/contracts/dao_treasury/src/lib.rs`
- `contracts/contracts/dao_treasury/src/test.rs`
- `contracts/contracts/dao_treasury/tests/integration.rs`

## Acceptance Criteria Mapping
- **Deposits credited to group treasury immediately**
  - `deposit` updates group treasury balance atomically and emits `deposit` event.
- **Proposals execute only after quorum + majority approval**
  - `execute_proposal` enforces:
    - minimum votes (`quorum_votes`)
    - majority basis points (`majority_bps`)
- **Expired proposals cannot be executed**
  - Proposal contains `expires_ledger`; execution fails with `ProposalExpired` after expiry.
- **Treasury balance accurate after all operations**
  - Balance is increased on deposit and reduced only on successful proposal execution.
- **Full audit trail via on-chain events**
  - Events emitted for:
    - `deposit`
    - `proposal_created`
    - `vote_cast`
    - `proposal_executed`

## Tests
### Unit tests (`src/test.rs`)
- Deposit credits treasury immediately
- Execute path requires quorum + majority
- Expired proposal cannot execute
- Treasury balance correctness after execute
- Audit trail event emission count

### Integration tests (`tests/integration.rs`)
- Full DAO flow: deposit -> create proposal -> vote -> execute
- Expiry path: proposal becomes non-executable after ledger threshold

## Validation
Executed in contracts workspace:
- `cargo test -p dao-treasury`
- `cargo test`

Both pass.

## Notes
- This implementation is scoped strictly to issue requirements and pipeline compatibility.
- `contracts/Cargo.lock` was updated to include the new `dao-treasury` crate.
