### PR TITLE
feat: add on-chain public key registry contract

### DIFF
--- a/contracts/contracts/encryption_key_registry/Cargo.toml
+++ b/contracts/contracts/encryption_key_registry/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "encryption-key-registry"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+doctest = false
+
+[dependencies]
+soroban-sdk = { workspace = true }
+gasless-common = { workspace = true }
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/contracts/contracts/encryption_key_registry/src/errors.rs
+++ b/contracts/contracts/encryption_key_registry/src/errors.rs
@@ -1,0 +1,14 @@
+use soroban_sdk::contracterror;
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum KeyRegistryError {
+    AlreadyInitialized = 1,
+    NotInitialized = 2,
+    Unauthorized = 3,
+    KeyNotFound = 4,
+    KeyAlreadyRevoked = 5,
+    InvalidPublicKey = 6,
+    NoActiveKey = 7,
+}

--- a/contracts/contracts/encryption_key_registry/src/events.rs
+++ b/contracts/contracts/encryption_key_registry/src/events.rs
@@ -1,0 +1,41 @@
+use soroban_sdk::{symbol_short, Address, BytesN, Env, Symbol};
+
+pub fn emit_key_registered(
+    env: &Env,
+    owner: &Address,
+    public_key: &BytesN<32>,
+    version: u32,
+    timestamp: u64,
+) {
+    env.events().publish(
+        (symbol_short!("key_reg"), owner.clone()),
+        (public_key.clone(), version, timestamp),
+    );
+}
+
+pub fn emit_key_rotated(
+    env: &Env,
+    owner: &Address,
+    old_key: &BytesN<32>,
+    new_key: &BytesN<32>,
+    new_version: u32,
+    timestamp: u64,
+) {
+    env.events().publish(
+        (symbol_short!("key_rot"), owner.clone()),
+        (old_key.clone(), new_key.clone(), new_version, timestamp),
+    );
+}
+
+pub fn emit_key_revoked(
+    env: &Env,
+    owner: &Address,
+    public_key: &BytesN<32>,
+    version: u32,
+    timestamp: u64,
+) {
+    env.events().publish(
+        (symbol_short!("key_rev"), owner.clone()),
+        (public_key.clone(), version, timestamp),
+    );
+}

--- a/contracts/contracts/encryption_key_registry/src/lib.rs
+++ b/contracts/contracts/encryption_key_registry/src/lib.rs
@@ -1,0 +1,253 @@
+#![no_std]
+
+mod errors;
+mod events;
+mod storage;
+mod types;
+
+#[cfg(test)]
+mod test;
+
+use errors::KeyRegistryError;
+use soroban_sdk::{contract, contractimpl, Address, BytesN, Env, Symbol, Vec};
+use storage::DataKey;
+use types::{KeyRecord, KEY_TTL_LEDGERS, MAX_KEY_HISTORY};
+
+// ─── Internal helpers ────────────────────────────────────────────────────────
+
+/// Validate that a public key is not all-zero bytes.
+fn validate_public_key(key: &BytesN<32>) -> Result<(), KeyRegistryError> {
+    if key == &BytesN::from_array(&soroban_sdk::Env::default(), &[0u8; 32]) {
+        return Err(KeyRegistryError::InvalidPublicKey);
+    }
+    Ok(())
+}
+
+fn load_active_key(env: &Env, owner: &Address) -> Result<KeyRecord, KeyRegistryError> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::ActiveKey(owner.clone()))
+        .ok_or(KeyRegistryError::KeyNotFound)
+}
+
+fn save_active_key(env: &Env, owner: &Address, record: &KeyRecord) {
+    env.storage()
+        .persistent()
+        .set(&DataKey::ActiveKey(owner.clone()), record);
+    env.storage().persistent().extend_ttl(
+        &DataKey::ActiveKey(owner.clone()),
+        KEY_TTL_LEDGERS,
+        KEY_TTL_LEDGERS,
+    );
+}
+
+fn next_version(env: &Env, owner: &Address) -> u32 {
+    let version: u32 = env
+        .storage()
+        .persistent()
+        .get(&DataKey::KeyVersion(owner.clone()))
+        .unwrap_or(0)
+        + 1;
+    env.storage()
+        .persistent()
+        .set(&DataKey::KeyVersion(owner.clone()), &version);
+    env.storage().persistent().extend_ttl(
+        &DataKey::KeyVersion(owner.clone()),
+        KEY_TTL_LEDGERS,
+        KEY_TTL_LEDGERS,
+    );
+    version
+}
+
+/// Append a record to the owner's key history, capping at MAX_KEY_HISTORY.
+fn push_history(env: &Env, owner: &Address, record: KeyRecord) {
+    let key = DataKey::KeyHistory(owner.clone());
+    let mut history: Vec<KeyRecord> = env
+        .storage()
+        .persistent()
+        .get(&key)
+        .unwrap_or(Vec::new(env));
+
+    // Evict oldest entry when cap is reached to keep storage bounded.
+    if history.len() >= MAX_KEY_HISTORY {
+        history.remove(0);
+    }
+    history.push_back(record);
+
+    env.storage().persistent().set(&key, &history);
+    env.storage()
+        .persistent()
+        .extend_ttl(&key, KEY_TTL_LEDGERS, KEY_TTL_LEDGERS);
+}
+
+// ─── Contract ────────────────────────────────────────────────────────────────
+
+#[contract]
+pub struct EncryptionKeyRegistryContract;
+
+#[contractimpl]
+impl EncryptionKeyRegistryContract {
+    // ── Initialisation ───────────────────────────────────────────────────────
+
+    pub fn initialize(env: Env, admin: Address) -> Result<(), KeyRegistryError> {
+        if env.storage().instance().has(&DataKey::Admin) {
+            return Err(KeyRegistryError::AlreadyInitialized);
+        }
+        admin.require_auth();
+        env.storage().instance().set(&DataKey::Admin, &admin);
+        Ok(())
+    }
+
+    // ── Key Registration ─────────────────────────────────────────────────────
+
+    /// Register the caller's first public key.  Fails if they already have an
+    /// active key — use `rotate_key` to update it.
+    pub fn register_key(
+        env: Env,
+        owner: Address,
+        public_key: BytesN<32>,
+        key_type: Symbol,
+    ) -> Result<u32, KeyRegistryError> {
+        owner.require_auth();
+
+        // All-zero key is invalid.
+        if public_key == BytesN::from_array(&env, &[0u8; 32]) {
+            return Err(KeyRegistryError::InvalidPublicKey);
+        }
+
+        // Reject if an active (non-revoked) key already exists.
+        if let Some(existing) = env
+            .storage()
+            .persistent()
+            .get::<DataKey, KeyRecord>(&DataKey::ActiveKey(owner.clone()))
+        {
+            if existing.is_active {
+                // They must call rotate_key instead.
+                return Err(KeyRegistryError::Unauthorized);
+            }
+        }
+
+        let now = env.ledger().timestamp();
+        let version = next_version(&env, &owner);
+
+        let record = KeyRecord {
+            public_key: public_key.clone(),
+            key_type,
+            version,
+            registered_at: now,
+            revoked_at: 0,
+            is_active: true,
+        };
+
+        save_active_key(&env, &owner, &record);
+        push_history(&env, &owner, record.clone());
+
+        events::emit_key_registered(&env, &owner, &public_key, version, now);
+
+        Ok(version)
+    }
+
+    /// Atomically replace the caller's active key with a new one.
+    /// The previous key is archived in history with its `is_active` flag cleared.
+    pub fn rotate_key(
+        env: Env,
+        owner: Address,
+        new_public_key: BytesN<32>,
+        key_type: Symbol,
+    ) -> Result<u32, KeyRegistryError> {
+        owner.require_auth();
+
+        if new_public_key == BytesN::from_array(&env, &[0u8; 32]) {
+            return Err(KeyRegistryError::InvalidPublicKey);
+        }
+
+        let mut old_record = load_active_key(&env, &owner)?;
+
+        if !old_record.is_active {
+            return Err(KeyRegistryError::NoActiveKey);
+        }
+
+        let now = env.ledger().timestamp();
+        let old_key = old_record.public_key.clone();
+
+        // Archive the old record — mark inactive (not revoked, just superseded).
+        old_record.is_active = false;
+        push_history(&env, &owner, old_record);
+
+        // Create the new active record.
+        let new_version = next_version(&env, &owner);
+        let new_record = KeyRecord {
+            public_key: new_public_key.clone(),
+            key_type,
+            version: new_version,
+            registered_at: now,
+            revoked_at: 0,
+            is_active: true,
+        };
+
+        save_active_key(&env, &owner, &new_record);
+        push_history(&env, &owner, new_record);
+
+        events::emit_key_rotated(&env, &owner, &old_key, &new_public_key, new_version, now);
+
+        Ok(new_version)
+    }
+
+    /// Revoke the caller's active key without providing a replacement.
+    /// The key record is updated with a `revoked_at` timestamp and `is_active = false`.
+    pub fn revoke_key(env: Env, owner: Address) -> Result<(), KeyRegistryError> {
+        owner.require_auth();
+
+        let mut record = load_active_key(&env, &owner)?;
+
+        if !record.is_active {
+            return Err(KeyRegistryError::KeyAlreadyRevoked);
+        }
+
+        let now = env.ledger().timestamp();
+        let revoked_key = record.public_key.clone();
+        let version = record.version;
+
+        record.is_active = false;
+        record.revoked_at = now;
+
+        // Persist the revoked state as the active-slot record (so callers
+        // learn it is revoked rather than getting KeyNotFound).
+        save_active_key(&env, &owner, &record);
+        push_history(&env, &owner, record);
+
+        events::emit_key_revoked(&env, &owner, &revoked_key, version, now);
+
+        Ok(())
+    }
+
+    // ── Queries ──────────────────────────────────────────────────────────────
+
+    /// Return the active key record for `address`.
+    /// Returns `KeyNotFound` if no key has ever been registered.
+    /// Returns the record (with `is_active = false`) if it has been revoked —
+    /// callers should check `is_active` before trusting the key.
+    pub fn get_key(env: Env, address: Address) -> Result<KeyRecord, KeyRegistryError> {
+        load_active_key(&env, &address)
+    }
+
+    /// Return the full key history for `address`, oldest first.
+    /// Anyone may query this; histories are public by design (public keys are
+    /// not secret).
+    pub fn get_key_history(env: Env, address: Address) -> Vec<KeyRecord> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::KeyHistory(address))
+            .unwrap_or(Vec::new(&env))
+    }
+
+    /// Convenience: returns true only when `address` has an active,
+    /// non-revoked key.
+    pub fn has_active_key(env: Env, address: Address) -> bool {
+        env.storage()
+            .persistent()
+            .get::<DataKey, KeyRecord>(&DataKey::ActiveKey(address))
+            .map(|r| r.is_active)
+            .unwrap_or(false)
+    }
+}

--- a/contracts/contracts/encryption_key_registry/src/storage.rs
+++ b/contracts/contracts/encryption_key_registry/src/storage.rs
@@ -1,0 +1,14 @@
+use soroban_sdk::{contracttype, Address};
+
+#[contracttype]
+#[derive(Clone)]
+pub enum DataKey {
+    /// Contract admin.
+    Admin,
+    /// Active KeyRecord for an address.
+    ActiveKey(Address),
+    /// Current version counter for an address.
+    KeyVersion(Address),
+    /// Historical KeyRecord list (Vec<KeyRecord>) for an address.
+    KeyHistory(Address),
+}

--- a/contracts/contracts/encryption_key_registry/src/test.rs
+++ b/contracts/contracts/encryption_key_registry/src/test.rs
@@ -1,0 +1,325 @@
+#![cfg(test)]
+
+use super::*;
+use soroban_sdk::{
+    symbol_short,
+    testutils::{Address as _, Ledger, LedgerInfo},
+    Address, BytesN, Env,
+};
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+fn setup() -> (Env, EncryptionKeyRegistryContractClient<'static>) {
+    let env = Env::default();
+    let contract_id = env.register(EncryptionKeyRegistryContract, ());
+    let client = EncryptionKeyRegistryContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    env.mock_all_auths();
+    client.initialize(&admin).unwrap();
+    (env, client)
+}
+
+fn make_key(env: &Env, seed: u8) -> BytesN<32> {
+    BytesN::from_array(env, &[seed; 32])
+}
+
+fn x25519(env: &Env) -> soroban_sdk::Symbol {
+    symbol_short!("x25519")
+}
+
+fn advance(env: &Env, secs: u64) {
+    let t = env.ledger().timestamp();
+    env.ledger().set(LedgerInfo {
+        timestamp: t + secs,
+        ..env.ledger().get()
+    });
+}
+
+// ── Initialization ────────────────────────────────────────────────────────────
+
+#[test]
+fn test_double_initialize_fails() {
+    let (env, client) = setup();
+    let admin2 = Address::generate(&env);
+    env.mock_all_auths();
+    let result = client.initialize(&admin2);
+    assert_eq!(result, Err(Ok(KeyRegistryError::AlreadyInitialized)));
+}
+
+// ── Register ─────────────────────────────────────────────────────────────────
+
+#[test]
+fn test_register_key_success() {
+    let (env, client) = setup();
+    let alice = Address::generate(&env);
+    env.mock_all_auths();
+
+    let version = client
+        .register_key(&alice, &make_key(&env, 1), &x25519(&env))
+        .unwrap();
+    assert_eq!(version, 1);
+
+    let record = client.get_key(&alice).unwrap();
+    assert!(record.is_active);
+    assert_eq!(record.version, 1);
+    assert_eq!(record.revoked_at, 0);
+}
+
+#[test]
+fn test_register_zero_key_fails() {
+    let (env, client) = setup();
+    let alice = Address::generate(&env);
+    env.mock_all_auths();
+
+    let result = client.register_key(&alice, &BytesN::from_array(&env, &[0u8; 32]), &x25519(&env));
+    assert_eq!(result, Err(Ok(KeyRegistryError::InvalidPublicKey)));
+}
+
+#[test]
+fn test_register_twice_without_rotation_fails() {
+    let (env, client) = setup();
+    let alice = Address::generate(&env);
+    env.mock_all_auths();
+
+    client
+        .register_key(&alice, &make_key(&env, 1), &x25519(&env))
+        .unwrap();
+    let result = client.register_key(&alice, &make_key(&env, 2), &x25519(&env));
+    assert_eq!(result, Err(Ok(KeyRegistryError::Unauthorized)));
+}
+
+#[test]
+fn test_register_after_revoke_succeeds() {
+    let (env, client) = setup();
+    let alice = Address::generate(&env);
+    env.mock_all_auths();
+
+    client
+        .register_key(&alice, &make_key(&env, 1), &x25519(&env))
+        .unwrap();
+    client.revoke_key(&alice).unwrap();
+
+    let version = client
+        .register_key(&alice, &make_key(&env, 2), &x25519(&env))
+        .unwrap();
+    assert_eq!(version, 2);
+}
+
+// ── Rotation ─────────────────────────────────────────────────────────────────
+
+#[test]
+fn test_rotate_key_success() {
+    let (env, client) = setup();
+    let alice = Address::generate(&env);
+    env.mock_all_auths();
+
+    client
+        .register_key(&alice, &make_key(&env, 1), &x25519(&env))
+        .unwrap();
+    advance(&env, 100);
+
+    let new_version = client
+        .rotate_key(&alice, &make_key(&env, 2), &x25519(&env))
+        .unwrap();
+    assert_eq!(new_version, 2);
+
+    let record = client.get_key(&alice).unwrap();
+    assert!(record.is_active);
+    assert_eq!(record.public_key, make_key(&env, 2));
+    assert_eq!(record.version, 2);
+}
+
+#[test]
+fn test_rotate_without_existing_key_fails() {
+    let (env, client) = setup();
+    let alice = Address::generate(&env);
+    env.mock_all_auths();
+
+    let result = client.rotate_key(&alice, &make_key(&env, 1), &x25519(&env));
+    assert_eq!(result, Err(Ok(KeyRegistryError::KeyNotFound)));
+}
+
+#[test]
+fn test_rotate_zero_key_fails() {
+    let (env, client) = setup();
+    let alice = Address::generate(&env);
+    env.mock_all_auths();
+
+    client
+        .register_key(&alice, &make_key(&env, 1), &x25519(&env))
+        .unwrap();
+    let result = client.rotate_key(&alice, &BytesN::from_array(&env, &[0u8; 32]), &x25519(&env));
+    assert_eq!(result, Err(Ok(KeyRegistryError::InvalidPublicKey)));
+}
+
+#[test]
+fn test_rotate_after_revoke_fails() {
+    let (env, client) = setup();
+    let alice = Address::generate(&env);
+    env.mock_all_auths();
+
+    client
+        .register_key(&alice, &make_key(&env, 1), &x25519(&env))
+        .unwrap();
+    client.revoke_key(&alice).unwrap();
+
+    let result = client.rotate_key(&alice, &make_key(&env, 2), &x25519(&env));
+    assert_eq!(result, Err(Ok(KeyRegistryError::NoActiveKey)));
+}
+
+// ── Revocation ────────────────────────────────────────────────────────────────
+
+#[test]
+fn test_revoke_key_sets_timestamp() {
+    let (env, client) = setup();
+    let alice = Address::generate(&env);
+    env.mock_all_auths();
+
+    client
+        .register_key(&alice, &make_key(&env, 1), &x25519(&env))
+        .unwrap();
+    advance(&env, 500);
+    let revoke_time = env.ledger().timestamp();
+    client.revoke_key(&alice).unwrap();
+
+    let record = client.get_key(&alice).unwrap();
+    assert!(!record.is_active);
+    assert_eq!(record.revoked_at, revoke_time);
+}
+
+#[test]
+fn test_double_revoke_fails() {
+    let (env, client) = setup();
+    let alice = Address::generate(&env);
+    env.mock_all_auths();
+
+    client
+        .register_key(&alice, &make_key(&env, 1), &x25519(&env))
+        .unwrap();
+    client.revoke_key(&alice).unwrap();
+
+    let result = client.revoke_key(&alice);
+    assert_eq!(result, Err(Ok(KeyRegistryError::KeyAlreadyRevoked)));
+}
+
+#[test]
+fn test_revoke_without_key_fails() {
+    let (env, client) = setup();
+    let alice = Address::generate(&env);
+    env.mock_all_auths();
+
+    let result = client.revoke_key(&alice);
+    assert_eq!(result, Err(Ok(KeyRegistryError::KeyNotFound)));
+}
+
+// ── History ───────────────────────────────────────────────────────────────────
+
+#[test]
+fn test_key_history_grows_with_rotation() {
+    let (env, client) = setup();
+    let alice = Address::generate(&env);
+    env.mock_all_auths();
+
+    client
+        .register_key(&alice, &make_key(&env, 1), &x25519(&env))
+        .unwrap();
+    client
+        .rotate_key(&alice, &make_key(&env, 2), &x25519(&env))
+        .unwrap();
+    client
+        .rotate_key(&alice, &make_key(&env, 3), &x25519(&env))
+        .unwrap();
+
+    // register: 1 entry; rotate once: old+new = +2; rotate again: old+new = +2 → 5 total
+    let history = client.get_key_history(&alice);
+    assert_eq!(history.len(), 5);
+}
+
+#[test]
+fn test_key_history_contains_revoked_entry() {
+    let (env, client) = setup();
+    let alice = Address::generate(&env);
+    env.mock_all_auths();
+
+    client
+        .register_key(&alice, &make_key(&env, 1), &x25519(&env))
+        .unwrap();
+    client.revoke_key(&alice).unwrap();
+
+    let history = client.get_key_history(&alice);
+    // register + revoke update = 2 entries
+    assert_eq!(history.len(), 2);
+
+    let last = history.get(1).unwrap();
+    assert!(!last.is_active);
+    assert!(last.revoked_at > 0);
+}
+
+#[test]
+fn test_empty_history_for_unknown_address() {
+    let (env, client) = setup();
+    let stranger = Address::generate(&env);
+
+    let history = client.get_key_history(&stranger);
+    assert_eq!(history.len(), 0);
+}
+
+// ── has_active_key ────────────────────────────────────────────────────────────
+
+#[test]
+fn test_has_active_key_lifecycle() {
+    let (env, client) = setup();
+    let alice = Address::generate(&env);
+    env.mock_all_auths();
+
+    assert!(!client.has_active_key(&alice));
+
+    client
+        .register_key(&alice, &make_key(&env, 1), &x25519(&env))
+        .unwrap();
+    assert!(client.has_active_key(&alice));
+
+    client.revoke_key(&alice).unwrap();
+    assert!(!client.has_active_key(&alice));
+}
+
+// ── Key exchange integration flow ─────────────────────────────────────────────
+
+#[test]
+fn test_key_exchange_flow() {
+    let (env, client) = setup();
+    let alice = Address::generate(&env);
+    let bob = Address::generate(&env);
+    env.mock_all_auths();
+
+    // Both parties register their public keys.
+    client
+        .register_key(&alice, &make_key(&env, 0xAA), &x25519(&env))
+        .unwrap();
+    client
+        .register_key(&bob, &make_key(&env, 0xBB), &x25519(&env))
+        .unwrap();
+
+    // Each can retrieve the other's public key for ECDH.
+    let alice_key = client.get_key(&alice).unwrap();
+    let bob_key = client.get_key(&bob).unwrap();
+
+    assert!(alice_key.is_active);
+    assert!(bob_key.is_active);
+    assert_ne!(alice_key.public_key, bob_key.public_key);
+
+    // Alice rotates; Bob can now fetch Alice's new key.
+    advance(&env, 1000);
+    client
+        .rotate_key(&alice, &make_key(&env, 0xCC), &x25519(&env))
+        .unwrap();
+
+    let alice_new = client.get_key(&alice).unwrap();
+    assert_eq!(alice_new.public_key, make_key(&env, 0xCC));
+    assert_eq!(alice_new.version, 2);
+
+    // Old key still accessible in history for forward secrecy verification.
+    let history = client.get_key_history(&alice);
+    let old = history.get(0).unwrap();
+    assert_eq!(old.public_key, make_key(&env, 0xAA));
+}

--- a/contracts/contracts/encryption_key_registry/src/types.rs
+++ b/contracts/contracts/encryption_key_registry/src/types.rs
@@ -1,0 +1,24 @@
+use soroban_sdk::{contracttype, BytesN, Symbol};
+
+/// How long a key record lives in persistent storage (~180 days at 5s/ledger).
+pub const KEY_TTL_LEDGERS: u32 = 3_110_400;
+
+/// Maximum number of historical key records retained per address.
+pub const MAX_KEY_HISTORY: u32 = 50;
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct KeyRecord {
+    /// The raw 32-byte public key (e.g. X25519 or Ed25519).
+    pub public_key: BytesN<32>,
+    /// Application-defined label: e.g. `Symbol::new(env, "x25519")`.
+    pub key_type: Symbol,
+    /// Monotonically increasing version, starting at 1.
+    pub version: u32,
+    /// Ledger timestamp at registration time.
+    pub registered_at: u64,
+    /// Ledger timestamp at revocation time; 0 means still active.
+    pub revoked_at: u64,
+    /// Whether this record is the current active key.
+    pub is_active: bool,
+}


### PR DESCRIPTION
## Description

Implements the on-chain public key registry contract for end-to-end encryption on the Whspr Stellar platform. This contract manages user encryption public keys, tracking the full lifecycle of registration, rotation, and revocation with complete version history for forward secrecy.

## Related Issue

- Closes #371 

## Changes Made

- Added `contracts/contracts/encryption_key_registry/` as a new Soroban contract crate following existing workspace conventions
- Defined `KeyRecord` storage structure in `types.rs` with fields for public key, key type, version, registration timestamp, revocation timestamp, and active status
- Defined `DataKey` enum in `storage.rs` covering `ActiveKey`, `KeyVersion`, `KeyHistory`, and `Admin` slots using `persistent` storage with explicit TTL extension
- Implemented `register_key` — registers the first key for an address, rejects all-zero keys and duplicate active registrations
- Implemented `rotate_key` — atomically archives the old key and promotes the new one, incrementing the version counter
- Implemented `revoke_key` — marks the active key inactive with a `revoked_at` timestamp; allows re-registration afterward
- Implemented `get_key` — returns the current key record including revoked state so callers can inspect `is_active`
- Implemented `get_key_history` — returns the full ordered history for forward secrecy verification, capped at 50 entries
- Implemented `has_active_key` — convenience boolean check used by other contracts before sending messages
- Added event emission (`key_reg`, `key_rot`, `key_rev`) for all key state changes
- Added unit and integration tests covering full key lifecycle, edge cases, and a multi-party key exchange flow

## Acceptance Criteria

- [x] Each address can have exactly one active public key
- [x] Key history maintained for forward secrecy verification
- [x] Revoked keys flagged with revocation timestamp
- [x] Key rotation atomically replaces active key
- [x] Events emitted on all key state changes