### PR TITLE
feat: add notifications module and integrate with transactions service

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -26,9 +26,11 @@ import { WebhooksModule } from './webhooks/webhooks.module';
 import { ObservabilityModule } from './observability/observability.module';
 import { UserSettingsModule } from './user-settings/user-settings.module';
 import { AdminModule } from './admin/admin.module';
-import { AnalyticsModule } from './analytics/analytics.module';
 import { MembershipTierModule } from './membership-tier/membership-tier.module';
 import { CacheModule } from './cache/cache.module';
+import { RedisCacheModule } from './cache/redis-cache.module';
+import { StellarEventsModule } from './stellar-events/stellar-events.module';
+import { NotificationsModule } from './notifications/notifications.module';
 
 @Module({
   imports: [
@@ -65,6 +67,7 @@ import { CacheModule } from './cache/cache.module';
     WalletsModule,
     AnalyticsModule,
     TransactionsModule,
+    NotificationsModule,
     ScheduledJobsModule,
     WebhooksModule,
     ObservabilityModule,

--- a/src/messaging/dto/notification-events.dto.ts
+++ b/src/messaging/dto/notification-events.dto.ts
@@ -1,6 +1,12 @@
 import { IsString, IsOptional, IsEnum } from 'class-validator';
 
 export enum NotificationType {
+  NEW_MESSAGE = 'NEW_MESSAGE',
+  TRANSFER_RECEIVED = 'TRANSFER_RECEIVED',
+  GROUP_INVITE = 'GROUP_INVITE',
+  CONTACT_REQUEST = 'CONTACT_REQUEST',
+  PROPOSAL_VOTE = 'PROPOSAL_VOTE',
+  TRANSACTION_CONFIRMED = 'TRANSACTION_CONFIRMED',
   MESSAGE = 'message',
   FRIEND_REQUEST = 'friend_request',
   TRANSFER = 'transfer',

--- a/src/messaging/gateways/notifications.gateway.ts
+++ b/src/messaging/gateways/notifications.gateway.ts
@@ -98,6 +98,38 @@ export class NotificationsGateway implements OnGatewayConnection, OnGatewayDisco
     this.server.to(room).emit('transfer:update', event);
   }
 
+  async sendNotificationRead(
+    userId: string,
+    notificationId: string,
+    readAt: number,
+  ): Promise<void> {
+    const room = this.userRoom(userId);
+    const event = { notificationId, readAt, timestamp: Date.now() };
+    await this.eventReplayService.storeEvent(room, 'notification:read', event);
+    this.server.to(room).emit('notification:read', event);
+  }
+
+  async sendNotificationReadAll(userId: string): Promise<void> {
+    const room = this.userRoom(userId);
+    const event = { timestamp: Date.now() };
+    await this.eventReplayService.storeEvent(room, 'notification:read_all', event);
+    this.server.to(room).emit('notification:read_all', event);
+  }
+
+  async sendNotificationDeleted(userId: string, notificationId: string): Promise<void> {
+    const room = this.userRoom(userId);
+    const event = { notificationId, timestamp: Date.now() };
+    await this.eventReplayService.storeEvent(room, 'notification:deleted', event);
+    this.server.to(room).emit('notification:deleted', event);
+  }
+
+  async sendUnreadCountUpdate(userId: string, unreadCount: number): Promise<void> {
+    const room = this.userRoom(userId);
+    const event = { unreadCount, timestamp: Date.now() };
+    await this.eventReplayService.storeEvent(room, 'notification:unread_count', event);
+    this.server.to(room).emit('notification:unread_count', event);
+  }
+
   // ─── Helpers ────────────────────────────────────────────────────────────────
 
   private userRoom(userId: string): string {

--- a/src/migrations/1711234567898-NotificationsSchema.ts
+++ b/src/migrations/1711234567898-NotificationsSchema.ts
@@ -1,0 +1,53 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class NotificationsSchema1711234567898 implements MigrationInterface {
+  name = 'NotificationsSchema1711234567898';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TYPE "notification_type_enum" AS ENUM (
+        'NEW_MESSAGE',
+        'TRANSFER_RECEIVED',
+        'GROUP_INVITE',
+        'CONTACT_REQUEST',
+        'PROPOSAL_VOTE',
+        'TRANSACTION_CONFIRMED'
+      )
+    `);
+
+    await queryRunner.query(`
+      CREATE TABLE "notifications" (
+        "id" uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
+        "userId" uuid NOT NULL,
+        "type" "notification_type_enum" NOT NULL,
+        "title" varchar(160) NOT NULL,
+        "body" text NOT NULL,
+        "data" jsonb,
+        "isRead" boolean NOT NULL DEFAULT false,
+        "readAt" TIMESTAMP,
+        "createdAt" TIMESTAMP NOT NULL DEFAULT now(),
+        "deletedAt" TIMESTAMP
+      )
+    `);
+
+    await queryRunner.query(`CREATE INDEX "idx_notifications_type" ON "notifications"("type")`);
+    await queryRunner.query(
+      `CREATE INDEX "idx_notifications_user_created" ON "notifications"("userId", "createdAt")`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "idx_notifications_user_is_read" ON "notifications"("userId", "isRead")`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "idx_notifications_deleted_at" ON "notifications"("deletedAt")`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX "idx_notifications_deleted_at"`);
+    await queryRunner.query(`DROP INDEX "idx_notifications_user_is_read"`);
+    await queryRunner.query(`DROP INDEX "idx_notifications_user_created"`);
+    await queryRunner.query(`DROP INDEX "idx_notifications_type"`);
+    await queryRunner.query(`DROP TABLE "notifications"`);
+    await queryRunner.query(`DROP TYPE "notification_type_enum"`);
+  }
+}

--- a/src/notifications/dto/create-notification.dto.ts
+++ b/src/notifications/dto/create-notification.dto.ts
@@ -1,0 +1,9 @@
+import { InAppNotificationType } from '../entities/notification.entity';
+
+export interface CreateNotificationDto {
+  userId: string;
+  type: InAppNotificationType;
+  title: string;
+  body: string;
+  data?: Record<string, unknown>;
+}

--- a/src/notifications/dto/get-notifications-query.dto.ts
+++ b/src/notifications/dto/get-notifications-query.dto.ts
@@ -1,0 +1,11 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { IsEnum, IsOptional } from 'class-validator';
+import { PaginationDto } from '../../common/dto/pagination.dto';
+import { InAppNotificationType } from '../entities/notification.entity';
+
+export class GetNotificationsQueryDto extends PaginationDto {
+  @ApiPropertyOptional({ enum: InAppNotificationType })
+  @IsOptional()
+  @IsEnum(InAppNotificationType)
+  type?: InAppNotificationType;
+}

--- a/src/notifications/dto/notification-response.dto.ts
+++ b/src/notifications/dto/notification-response.dto.ts
@@ -1,0 +1,50 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { InAppNotificationType } from '../entities/notification.entity';
+
+export class NotificationResponseDto {
+  @ApiProperty()
+  id!: string;
+
+  @ApiProperty()
+  userId!: string;
+
+  @ApiProperty({ enum: InAppNotificationType })
+  type!: InAppNotificationType;
+
+  @ApiProperty()
+  title!: string;
+
+  @ApiProperty()
+  body!: string;
+
+  @ApiProperty({ required: false, type: Object, nullable: true })
+  data!: Record<string, unknown> | null;
+
+  @ApiProperty()
+  isRead!: boolean;
+
+  @ApiProperty({ required: false, nullable: true })
+  readAt!: Date | null;
+
+  @ApiProperty()
+  createdAt!: Date;
+}
+
+export class NotificationListResponseDto {
+  @ApiProperty({ type: [NotificationResponseDto] })
+  items!: NotificationResponseDto[];
+
+  @ApiProperty()
+  total!: number;
+
+  @ApiProperty()
+  page!: number;
+
+  @ApiProperty()
+  limit!: number;
+}
+
+export class UnreadCountResponseDto {
+  @ApiProperty()
+  unreadCount!: number;
+}

--- a/src/notifications/entities/notification.entity.ts
+++ b/src/notifications/entities/notification.entity.ts
@@ -1,0 +1,53 @@
+import {
+  Column,
+  CreateDateColumn,
+  DeleteDateColumn,
+  Entity,
+  Index,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+
+export enum InAppNotificationType {
+  NEW_MESSAGE = 'NEW_MESSAGE',
+  TRANSFER_RECEIVED = 'TRANSFER_RECEIVED',
+  GROUP_INVITE = 'GROUP_INVITE',
+  CONTACT_REQUEST = 'CONTACT_REQUEST',
+  PROPOSAL_VOTE = 'PROPOSAL_VOTE',
+  TRANSACTION_CONFIRMED = 'TRANSACTION_CONFIRMED',
+}
+
+@Entity('notifications')
+@Index('idx_notifications_user_created', ['userId', 'createdAt'])
+@Index('idx_notifications_user_is_read', ['userId', 'isRead'])
+export class Notification {
+  @PrimaryGeneratedColumn('uuid')
+  id!: string;
+
+  @Column({ type: 'uuid' })
+  userId!: string;
+
+  @Column({ type: 'enum', enum: InAppNotificationType })
+  @Index('idx_notifications_type')
+  type!: InAppNotificationType;
+
+  @Column({ type: 'varchar', length: 160 })
+  title!: string;
+
+  @Column({ type: 'text' })
+  body!: string;
+
+  @Column({ type: 'jsonb', nullable: true })
+  data!: Record<string, unknown> | null;
+
+  @Column({ type: 'boolean', default: false })
+  isRead!: boolean;
+
+  @Column({ type: 'timestamp', nullable: true })
+  readAt!: Date | null;
+
+  @CreateDateColumn({ type: 'timestamp' })
+  createdAt!: Date;
+
+  @DeleteDateColumn({ type: 'timestamp', nullable: true })
+  deletedAt!: Date | null;
+}

--- a/src/notifications/notifications.controller.ts
+++ b/src/notifications/notifications.controller.ts
@@ -1,0 +1,73 @@
+import {
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Param,
+  ParseUUIDPipe,
+  Patch,
+  Post,
+  Query,
+} from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { CurrentUser } from '../auth/decorators/current-user.decorator';
+import { GetNotificationsQueryDto } from './dto/get-notifications-query.dto';
+import {
+  NotificationListResponseDto,
+  NotificationResponseDto,
+  UnreadCountResponseDto,
+} from './dto/notification-response.dto';
+import { NotificationsService } from './notifications.service';
+
+@ApiTags('notifications')
+@ApiBearerAuth()
+@Controller('notifications')
+export class NotificationsController {
+  constructor(private readonly notificationsService: NotificationsService) {}
+
+  @Get()
+  @ApiOperation({ summary: 'Get paginated notifications for the current user' })
+  @ApiResponse({ status: 200, type: NotificationListResponseDto })
+  getNotifications(
+    @CurrentUser('id') userId: string,
+    @Query() query: GetNotificationsQueryDto,
+  ): Promise<NotificationListResponseDto> {
+    return this.notificationsService.getNotifications(userId, query);
+  }
+
+  @Patch(':id/read')
+  @ApiOperation({ summary: 'Mark a notification as read' })
+  @ApiResponse({ status: 200, type: NotificationResponseDto })
+  markRead(
+    @CurrentUser('id') userId: string,
+    @Param('id', ParseUUIDPipe) id: string,
+  ): Promise<NotificationResponseDto> {
+    return this.notificationsService.markRead(userId, id);
+  }
+
+  @Post('read-all')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Mark all notifications as read' })
+  @ApiResponse({ status: 200, schema: { properties: { marked: { type: 'number' } } } })
+  markAllRead(@CurrentUser('id') userId: string): Promise<{ marked: number }> {
+    return this.notificationsService.markAllRead(userId);
+  }
+
+  @Delete(':id')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOperation({ summary: 'Delete a notification' })
+  async deleteNotification(
+    @CurrentUser('id') userId: string,
+    @Param('id', ParseUUIDPipe) id: string,
+  ): Promise<void> {
+    await this.notificationsService.deleteNotification(userId, id);
+  }
+
+  @Get('unread-count')
+  @ApiOperation({ summary: 'Get unread notification count' })
+  @ApiResponse({ status: 200, type: UnreadCountResponseDto })
+  getUnreadCount(@CurrentUser('id') userId: string): Promise<UnreadCountResponseDto> {
+    return this.notificationsService.getUnreadCount(userId);
+  }
+}

--- a/src/notifications/notifications.module.ts
+++ b/src/notifications/notifications.module.ts
@@ -1,0 +1,15 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { MessagingModule } from '../messaging/messaging.module';
+import { Notification } from './entities/notification.entity';
+import { NotificationsController } from './notifications.controller';
+import { NotificationsRepository } from './notifications.repository';
+import { NotificationsService } from './notifications.service';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Notification]), MessagingModule],
+  controllers: [NotificationsController],
+  providers: [NotificationsRepository, NotificationsService],
+  exports: [NotificationsService],
+})
+export class NotificationsModule {}

--- a/src/notifications/notifications.repository.ts
+++ b/src/notifications/notifications.repository.ts
@@ -1,0 +1,106 @@
+import { Injectable } from '@nestjs/common';
+import { DataSource, Repository } from 'typeorm';
+import { Notification, InAppNotificationType } from './entities/notification.entity';
+
+export interface NotificationQueryFilters {
+  userId: string;
+  page: number;
+  limit: number;
+  type?: InAppNotificationType;
+}
+
+@Injectable()
+export class NotificationsRepository extends Repository<Notification> {
+  constructor(private readonly dataSource: DataSource) {
+    super(Notification, dataSource.createEntityManager());
+  }
+
+  async createAndSave(input: {
+    userId: string;
+    type: InAppNotificationType;
+    title: string;
+    body: string;
+    data?: Record<string, unknown>;
+  }): Promise<Notification> {
+    const entity = this.create({
+      userId: input.userId,
+      type: input.type,
+      title: input.title,
+      body: input.body,
+      data: input.data ?? null,
+      isRead: false,
+      readAt: null,
+    });
+
+    return this.save(entity);
+  }
+
+  async findByIdForUser(id: string, userId: string): Promise<Notification | null> {
+    return this.findOne({ where: { id, userId } });
+  }
+
+  async getNotifications(filters: NotificationQueryFilters): Promise<{
+    items: Notification[];
+    total: number;
+    page: number;
+    limit: number;
+  }> {
+    const qb = this.createQueryBuilder('notification').where(
+      'notification.userId = :userId',
+      { userId: filters.userId },
+    );
+
+    if (filters.type) {
+      qb.andWhere('notification.type = :type', { type: filters.type });
+    }
+
+    qb.orderBy('notification.createdAt', 'DESC').addOrderBy('notification.id', 'DESC');
+    qb.skip((filters.page - 1) * filters.limit).take(filters.limit);
+
+    const [items, total] = await qb.getManyAndCount();
+
+    return {
+      items,
+      total,
+      page: filters.page,
+      limit: filters.limit,
+    };
+  }
+
+  async markRead(id: string, userId: string): Promise<number> {
+    const result = await this.createQueryBuilder()
+      .update(Notification)
+      .set({ isRead: true, readAt: () => 'NOW()' })
+      .where('id = :id', { id })
+      .andWhere('userId = :userId', { userId })
+      .andWhere('isRead = false')
+      .execute();
+
+    return result.affected ?? 0;
+  }
+
+  async markAllRead(userId: string): Promise<number> {
+    const result = await this.createQueryBuilder()
+      .update(Notification)
+      .set({ isRead: true, readAt: () => 'NOW()' })
+      .where('userId = :userId', { userId })
+      .andWhere('isRead = false')
+      .execute();
+
+    return result.affected ?? 0;
+  }
+
+  async countUnread(userId: string): Promise<number> {
+    return this.count({ where: { userId, isRead: false } });
+  }
+
+  async softDeleteForUser(id: string, userId: string): Promise<number> {
+    const result = await this.createQueryBuilder()
+      .softDelete()
+      .where('id = :id', { id })
+      .andWhere('userId = :userId', { userId })
+      .execute();
+
+    return result.affected ?? 0;
+  }
+}

--- a/src/notifications/notifications.service.ts
+++ b/src/notifications/notifications.service.ts
@@ -1,0 +1,130 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { NotificationsGateway } from '../messaging/gateways/notifications.gateway';
+import { NotificationType } from '../messaging/dto/notification-events.dto';
+import { CreateNotificationDto } from './dto/create-notification.dto';
+import { GetNotificationsQueryDto } from './dto/get-notifications-query.dto';
+import {
+  NotificationListResponseDto,
+  NotificationResponseDto,
+  UnreadCountResponseDto,
+} from './dto/notification-response.dto';
+import { InAppNotificationType, Notification } from './entities/notification.entity';
+import { NotificationsRepository } from './notifications.repository';
+
+@Injectable()
+export class NotificationsService {
+  constructor(
+    private readonly notificationsRepository: NotificationsRepository,
+    private readonly notificationsGateway: NotificationsGateway,
+  ) {}
+
+  async createNotification(input: CreateNotificationDto): Promise<NotificationResponseDto> {
+    const notification = await this.notificationsRepository.createAndSave(input);
+
+    await this.notificationsGateway.sendNotification(input.userId, {
+      id: notification.id,
+      type: this.toGatewayType(input.type),
+      title: notification.title,
+      body: notification.body,
+      data: notification.data ?? undefined,
+    });
+
+    await this.emitUnreadCount(input.userId);
+
+    return this.toDto(notification);
+  }
+
+  async markRead(userId: string, id: string): Promise<NotificationResponseDto> {
+    const existing = await this.notificationsRepository.findByIdForUser(id, userId);
+    if (!existing) {
+      throw new NotFoundException('Notification not found');
+    }
+
+    if (!existing.isRead) {
+      await this.notificationsRepository.markRead(id, userId);
+    }
+
+    const updated = await this.notificationsRepository.findByIdForUser(id, userId);
+    if (!updated) {
+      throw new NotFoundException('Notification not found');
+    }
+
+    await this.notificationsGateway.sendNotificationRead(
+      userId,
+      updated.id,
+      updated.readAt?.getTime() ?? Date.now(),
+    );
+    await this.emitUnreadCount(userId);
+
+    return this.toDto(updated);
+  }
+
+  async markAllRead(userId: string): Promise<{ marked: number }> {
+    const marked = await this.notificationsRepository.markAllRead(userId);
+
+    await this.notificationsGateway.sendNotificationReadAll(userId);
+    await this.emitUnreadCount(userId);
+
+    return { marked };
+  }
+
+  async getNotifications(
+    userId: string,
+    query: GetNotificationsQueryDto,
+  ): Promise<NotificationListResponseDto> {
+    const page = query.page ?? 1;
+    const limit = query.limit ?? 10;
+
+    const result = await this.notificationsRepository.getNotifications({
+      userId,
+      page,
+      limit,
+      type: query.type,
+    });
+
+    return {
+      items: result.items.map((item) => this.toDto(item)),
+      total: result.total,
+      page: result.page,
+      limit: result.limit,
+    };
+  }
+
+  async deleteNotification(userId: string, id: string): Promise<void> {
+    const affected = await this.notificationsRepository.softDeleteForUser(id, userId);
+    if (affected === 0) {
+      throw new NotFoundException('Notification not found');
+    }
+
+    await this.notificationsGateway.sendNotificationDeleted(userId, id);
+    await this.emitUnreadCount(userId);
+  }
+
+  async getUnreadCount(userId: string): Promise<UnreadCountResponseDto> {
+    const unreadCount = await this.notificationsRepository.countUnread(userId);
+    return { unreadCount };
+  }
+
+  private async emitUnreadCount(userId: string): Promise<void> {
+    const unreadCount = await this.notificationsRepository.countUnread(userId);
+    await this.notificationsGateway.sendUnreadCountUpdate(userId, unreadCount);
+  }
+
+  private toDto(notification: Notification): NotificationResponseDto {
+    return {
+      id: notification.id,
+      userId: notification.userId,
+      type: notification.type,
+      title: notification.title,
+      body: notification.body,
+      data: notification.data,
+      isRead: notification.isRead,
+      readAt: notification.readAt,
+      createdAt: notification.createdAt,
+    };
+  }
+
+  private toGatewayType(type: InAppNotificationType): NotificationType {
+    return type as unknown as NotificationType;
+  }
+}

--- a/src/transactions/services/transactions.service.ts
+++ b/src/transactions/services/transactions.service.ts
@@ -9,6 +9,8 @@ import { Repository } from 'typeorm';
 import { NotificationType } from '../../messaging/dto/notification-events.dto';
 import { ChatGateway } from '../../messaging/gateways/chat.gateway';
 import { NotificationsGateway } from '../../messaging/gateways/notifications.gateway';
+import { InAppNotificationType } from '../../notifications/entities/notification.entity';
+import { NotificationsService } from '../../notifications/notifications.service';
 import { Wallet, WalletNetwork } from '../../wallets/entities/wallet.entity';
 import { ListTransactionsQueryDto } from '../dto/list-transactions-query.dto';
 import {
@@ -46,6 +48,7 @@ export class TransactionsService {
     private readonly transactionsRepository: TransactionsRepository,
     private readonly sorobanTransactionsService: SorobanTransactionsService,
     private readonly notificationsGateway: NotificationsGateway,
+    private readonly notificationsService: NotificationsService,
     private readonly chatGateway: ChatGateway,
     @InjectRepository(Wallet)
     private readonly walletsRepository: Repository<Wallet>,
@@ -248,10 +251,41 @@ export class TransactionsService {
 
     if (senderId) {
       await this.notificationsGateway.sendTransferUpdate(senderId, transferPayload);
+
+      if (transaction.status === TransactionStatus.CONFIRMED) {
+        await this.notificationsService.createNotification({
+          userId: senderId,
+          type: InAppNotificationType.TRANSACTION_CONFIRMED,
+          title: 'Transaction confirmed',
+          body: 'Your transaction was confirmed on chain.',
+          data: {
+            transactionId: transaction.id,
+            txHash: transaction.txHash,
+            amount: transaction.amount,
+            tokenId: transaction.tokenId,
+          },
+        });
+      }
     }
 
     if (recipientId && recipientId !== senderId) {
       await this.notificationsGateway.sendTransferUpdate(recipientId, transferPayload);
+
+      if (transaction.status === TransactionStatus.CONFIRMED) {
+        await this.notificationsService.createNotification({
+          userId: recipientId,
+          type: InAppNotificationType.TRANSFER_RECEIVED,
+          title: 'Transfer received',
+          body: 'You received a confirmed transfer.',
+          data: {
+            transactionId: transaction.id,
+            txHash: transaction.txHash,
+            amount: transaction.amount,
+            tokenId: transaction.tokenId,
+            fromAddress: transaction.fromAddress,
+          },
+        });
+      }
     }
 
     if (

--- a/src/transactions/transactions.module.ts
+++ b/src/transactions/transactions.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { MessagingModule } from '../messaging/messaging.module';
+import { NotificationsModule } from '../notifications/notifications.module';
 import { Wallet } from '../wallets/entities/wallet.entity';
 import { TransactionsController } from './controllers/transactions.controller';
 import { Transaction } from './entities/transaction.entity';
@@ -9,7 +10,7 @@ import { SorobanTransactionsService } from './services/soroban-transactions.serv
 import { TransactionsService } from './services/transactions.service';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Transaction, Wallet]), MessagingModule],
+  imports: [TypeOrmModule.forFeature([Transaction, Wallet]), MessagingModule, NotificationsModule],
   controllers: [TransactionsController],
   providers: [TransactionsRepository, SorobanTransactionsService, TransactionsService],
   exports: [TransactionsService],


### PR DESCRIPTION
# PR Description

Adds an in-app Notifications module with persistence, unread tracking, filtering, and real-time WebSocket delivery.

This PR introduces a Notification entity, repository, service, and controller to support listing, reading, and deleting user notifications. It also adds unread-count updates and reactive WebSocket events so clients can stay in sync after create/read/delete actions.

Included API routes:
- GET /notifications
- PATCH /notifications/:id/read
- POST /notifications/read-all
- DELETE /notifications/:id
- GET /notifications/unread-count

## PR Link
closes #401 
