### PR TITLE
feat: implement reactions feature with add, remove, and summary functionalities

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -31,6 +31,7 @@ import { CacheModule } from './cache/cache.module';
 import { RedisCacheModule } from './cache/redis-cache.module';
 import { StellarEventsModule } from './stellar-events/stellar-events.module';
 import { NotificationsModule } from './notifications/notifications.module';
+import { ReactionsModule } from './reactions/reactions.module';
 
 @Module({
   imports: [
@@ -68,6 +69,7 @@ import { NotificationsModule } from './notifications/notifications.module';
     AnalyticsModule,
     TransactionsModule,
     NotificationsModule,
+    ReactionsModule,
     ScheduledJobsModule,
     WebhooksModule,
     ObservabilityModule,

--- a/src/messaging/gateways/chat.gateway.ts
+++ b/src/messaging/gateways/chat.gateway.ts
@@ -256,6 +256,36 @@ export class ChatGateway implements OnGatewayConnection, OnGatewayDisconnect {
     this.server.to(roomId).emit('message:receipt', event);
   }
 
+  async sendReactionAdded(
+    conversationId: string,
+    event: {
+      messageId: string;
+      conversationId: string;
+      userId: string;
+      emoji: string;
+      timestamp: number;
+    },
+  ): Promise<void> {
+    const roomId = `conversation:${conversationId}`;
+    await this.eventReplayService.storeEvent(roomId, 'reaction:new', event);
+    this.server.to(roomId).emit('reaction:new', event);
+  }
+
+  async sendReactionRemoved(
+    conversationId: string,
+    event: {
+      messageId: string;
+      conversationId: string;
+      userId: string;
+      emoji: string;
+      timestamp: number;
+    },
+  ): Promise<void> {
+    const roomId = `conversation:${conversationId}`;
+    await this.eventReplayService.storeEvent(roomId, 'reaction:remove', event);
+    this.server.to(roomId).emit('reaction:remove', event);
+  }
+
   // ─── Helpers ────────────────────────────────────────────────────────────────
 
   private extractToken(client: Socket): string | null {

--- a/src/migrations/1711234567899-ReactionsSchema.ts
+++ b/src/migrations/1711234567899-ReactionsSchema.ts
@@ -1,0 +1,29 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class ReactionsSchema1711234567899 implements MigrationInterface {
+  name = 'ReactionsSchema1711234567899';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE "reactions" (
+        "id" uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
+        "messageId" uuid NOT NULL,
+        "userId" uuid NOT NULL,
+        "emoji" varchar(32) NOT NULL,
+        "createdAt" TIMESTAMP NOT NULL DEFAULT now(),
+        CONSTRAINT "uq_reactions_message_user_emoji" UNIQUE ("messageId", "userId", "emoji")
+      )
+    `);
+
+    await queryRunner.query(`CREATE INDEX "idx_reactions_message_id" ON "reactions"("messageId")`);
+    await queryRunner.query(
+      `CREATE INDEX "idx_reactions_message_emoji" ON "reactions"("messageId", "emoji")`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX "idx_reactions_message_emoji"`);
+    await queryRunner.query(`DROP INDEX "idx_reactions_message_id"`);
+    await queryRunner.query(`DROP TABLE "reactions"`);
+  }
+}

--- a/src/reactions/dto/add-reaction.dto.ts
+++ b/src/reactions/dto/add-reaction.dto.ts
@@ -1,0 +1,9 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsString, MaxLength } from 'class-validator';
+
+export class AddReactionDto {
+  @ApiProperty({ description: 'Emoji to react with', example: '🔥' })
+  @IsString()
+  @MaxLength(32)
+  emoji!: string;
+}

--- a/src/reactions/dto/reaction-summary.dto.ts
+++ b/src/reactions/dto/reaction-summary.dto.ts
@@ -1,0 +1,21 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class ReactionSummaryDto {
+  @ApiProperty({ example: '🔥' })
+  emoji!: string;
+
+  @ApiProperty({ example: 12 })
+  count!: number;
+
+  @ApiProperty({
+    type: [String],
+    description: 'A small sample of user IDs who reacted with this emoji',
+    example: ['user-a', 'user-b', 'user-c'],
+  })
+  sampleUsers!: string[];
+}
+
+export class MessageReactionsResponseDto {
+  @ApiProperty({ type: [ReactionSummaryDto] })
+  summary!: ReactionSummaryDto[];
+}

--- a/src/reactions/entities/reaction.entity.ts
+++ b/src/reactions/entities/reaction.entity.ts
@@ -1,0 +1,22 @@
+import { Column, CreateDateColumn, Entity, Index, PrimaryGeneratedColumn, Unique } from 'typeorm';
+
+@Entity('reactions')
+@Unique('uq_reactions_message_user_emoji', ['messageId', 'userId', 'emoji'])
+@Index('idx_reactions_message_id', ['messageId'])
+@Index('idx_reactions_message_emoji', ['messageId', 'emoji'])
+export class Reaction {
+  @PrimaryGeneratedColumn('uuid')
+  id!: string;
+
+  @Column({ type: 'uuid' })
+  messageId!: string;
+
+  @Column({ type: 'uuid' })
+  userId!: string;
+
+  @Column({ type: 'varchar', length: 32 })
+  emoji!: string;
+
+  @CreateDateColumn({ type: 'timestamp' })
+  createdAt!: Date;
+}

--- a/src/reactions/reactions.controller.ts
+++ b/src/reactions/reactions.controller.ts
@@ -1,0 +1,58 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Param,
+  ParseUUIDPipe,
+  Post,
+} from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiParam, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { CurrentUser } from '../auth/decorators/current-user.decorator';
+import { AddReactionDto } from './dto/add-reaction.dto';
+import { MessageReactionsResponseDto, ReactionSummaryDto } from './dto/reaction-summary.dto';
+import { ReactionsService } from './reactions.service';
+
+@ApiTags('reactions')
+@ApiBearerAuth()
+@Controller('messages/:id/reactions')
+export class ReactionsController {
+  constructor(private readonly reactionsService: ReactionsService) {}
+
+  @Post()
+  @ApiOperation({ summary: 'Add a reaction to a message' })
+  @ApiParam({ name: 'id', description: 'Message UUID' })
+  @ApiResponse({ status: 201, type: [ReactionSummaryDto] })
+  addReaction(
+    @Param('id', ParseUUIDPipe) messageId: string,
+    @CurrentUser('id') userId: string,
+    @Body() dto: AddReactionDto,
+  ): Promise<ReactionSummaryDto[]> {
+    return this.reactionsService.addReaction(messageId, userId, dto);
+  }
+
+  @Delete(':emoji')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOperation({ summary: 'Remove a reaction from a message' })
+  @ApiParam({ name: 'id', description: 'Message UUID' })
+  @ApiParam({ name: 'emoji', description: 'Emoji reaction to remove' })
+  async removeReaction(
+    @Param('id', ParseUUIDPipe) messageId: string,
+    @Param('emoji') emoji: string,
+    @CurrentUser('id') userId: string,
+  ): Promise<void> {
+    await this.reactionsService.removeReaction(messageId, userId, emoji);
+  }
+
+  @Get()
+  @ApiOperation({ summary: 'Get reaction summary for a message' })
+  @ApiParam({ name: 'id', description: 'Message UUID' })
+  @ApiResponse({ status: 200, type: MessageReactionsResponseDto })
+  getReactions(
+    @Param('id', ParseUUIDPipe) messageId: string,
+  ): Promise<MessageReactionsResponseDto> {
+    return this.reactionsService.getReactions(messageId);
+  }
+}

--- a/src/reactions/reactions.module.ts
+++ b/src/reactions/reactions.module.ts
@@ -1,0 +1,16 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Message } from '../Conversation Module/src/conversations/entities/message.entity';
+import { MessagingModule } from '../messaging/messaging.module';
+import { Reaction } from './entities/reaction.entity';
+import { ReactionsController } from './reactions.controller';
+import { ReactionsRepository } from './reactions.repository';
+import { ReactionsService } from './reactions.service';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Reaction, Message]), MessagingModule],
+  controllers: [ReactionsController],
+  providers: [ReactionsRepository, ReactionsService],
+  exports: [ReactionsService],
+})
+export class ReactionsModule {}

--- a/src/reactions/reactions.repository.ts
+++ b/src/reactions/reactions.repository.ts
@@ -1,0 +1,79 @@
+import { Injectable } from '@nestjs/common';
+import { DataSource, Repository } from 'typeorm';
+import { Reaction } from './entities/reaction.entity';
+
+@Injectable()
+export class ReactionsRepository extends Repository<Reaction> {
+  constructor(private readonly dataSource: DataSource) {
+    super(Reaction, dataSource.createEntityManager());
+  }
+
+  async findOneByMessageUserEmoji(
+    messageId: string,
+    userId: string,
+    emoji: string,
+  ): Promise<Reaction | null> {
+    return this.findOne({ where: { messageId, userId, emoji } });
+  }
+
+  async addReaction(messageId: string, userId: string, emoji: string): Promise<Reaction> {
+    const existing = await this.findOneByMessageUserEmoji(messageId, userId, emoji);
+    if (existing) {
+      return existing;
+    }
+
+    const reaction = this.create({ messageId, userId, emoji });
+    return this.save(reaction);
+  }
+
+  async removeReaction(messageId: string, userId: string, emoji: string): Promise<number> {
+    const result = await this.delete({ messageId, userId, emoji });
+    return result.affected ?? 0;
+  }
+
+  async getReactions(messageId: string): Promise<Reaction[]> {
+    return this.find({
+      where: { messageId },
+      order: { createdAt: 'DESC' },
+    });
+  }
+
+  async getReactionSummary(messageId: string): Promise<
+    Array<{
+      emoji: string;
+      count: number;
+      sampleUsers: string[];
+    }>
+  > {
+    const rows = await this.createQueryBuilder('reaction')
+      .select('reaction.emoji', 'emoji')
+      .addSelect('COUNT(1)::int', 'count')
+      .addSelect('ARRAY_AGG(reaction.userId ORDER BY reaction.createdAt DESC)', 'users')
+      .where('reaction.messageId = :messageId', { messageId })
+      .groupBy('reaction.emoji')
+      .orderBy('COUNT(1)', 'DESC')
+      .addOrderBy('reaction.emoji', 'ASC')
+      .getRawMany<{ emoji: string; count: number | string; users: string[] | string | null }>();
+
+    return rows.map((row) => ({
+      emoji: row.emoji,
+      count: typeof row.count === 'string' ? parseInt(row.count, 10) : row.count,
+      sampleUsers: this.toUserArray(row.users).slice(0, 3),
+    }));
+  }
+
+  private toUserArray(value: string[] | string | null): string[] {
+    if (!value) return [];
+    if (Array.isArray(value)) return value;
+
+    const normalized = value.trim();
+    if (!normalized.startsWith('{') || !normalized.endsWith('}')) {
+      return normalized.length ? [normalized] : [];
+    }
+
+    const inner = normalized.slice(1, -1).trim();
+    if (!inner) return [];
+
+    return inner.split(',').map((part) => part.replace(/^"|"$/g, '').trim());
+  }
+}

--- a/src/reactions/reactions.service.ts
+++ b/src/reactions/reactions.service.ts
@@ -1,0 +1,83 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { ChatGateway } from '../messaging/gateways/chat.gateway';
+import { Message } from '../Conversation Module/src/conversations/entities/message.entity';
+import { AddReactionDto } from './dto/add-reaction.dto';
+import { MessageReactionsResponseDto, ReactionSummaryDto } from './dto/reaction-summary.dto';
+import { ReactionsRepository } from './reactions.repository';
+
+@Injectable()
+export class ReactionsService {
+  constructor(
+    private readonly reactionsRepository: ReactionsRepository,
+    private readonly chatGateway: ChatGateway,
+    @InjectRepository(Message)
+    private readonly messagesRepository: Repository<Message>,
+  ) {}
+
+  async addReaction(
+    messageId: string,
+    userId: string,
+    dto: AddReactionDto,
+  ): Promise<ReactionSummaryDto[]> {
+    const conversationId = await this.getConversationIdOrThrow(messageId);
+
+    const reaction = await this.reactionsRepository.addReaction(messageId, userId, dto.emoji);
+
+    await this.chatGateway.sendReactionAdded(conversationId, {
+      messageId,
+      conversationId,
+      userId,
+      emoji: reaction.emoji,
+      timestamp: Date.now(),
+    });
+
+    return this.getReactionSummary(messageId);
+  }
+
+  async removeReaction(messageId: string, userId: string, emoji: string): Promise<void> {
+    const conversationId = await this.getConversationIdOrThrow(messageId);
+
+    const removed = await this.reactionsRepository.removeReaction(messageId, userId, emoji);
+    if (removed === 0) {
+      throw new NotFoundException('Reaction not found');
+    }
+
+    await this.chatGateway.sendReactionRemoved(conversationId, {
+      messageId,
+      conversationId,
+      userId,
+      emoji,
+      timestamp: Date.now(),
+    });
+  }
+
+  async getReactions(messageId: string): Promise<MessageReactionsResponseDto> {
+    await this.getConversationIdOrThrow(messageId);
+    const summary = await this.getReactionSummary(messageId);
+    return { summary };
+  }
+
+  async getReactionSummary(messageId: string): Promise<ReactionSummaryDto[]> {
+    const groups = await this.reactionsRepository.getReactionSummary(messageId);
+    return groups.map((group) => ({
+      emoji: group.emoji,
+      count: group.count,
+      sampleUsers: group.sampleUsers,
+    }));
+  }
+
+  private async getConversationIdOrThrow(messageId: string): Promise<string> {
+    const message = await this.messagesRepository.findOne({
+      where: { id: messageId },
+      select: ['id', 'conversationId'],
+    });
+
+    if (!message) {
+      throw new NotFoundException('Message not found');
+    }
+
+    return message.conversationId;
+  }
+}


### PR DESCRIPTION
# PR Description

This PR implements the Reactions module for emoji reactions on messages with aggregation and real-time updates.

## Scope

- Adds Reaction entity with id, messageId, userId, emoji, createdAt
- Enforces one reaction per emoji per user per message
- Adds aggregation by emoji with count and sample users
- Adds real-time reaction add/remove events to conversation participants

## API Endpoints

- POST /messages/:id/reactions
- DELETE /messages/:id/reactions/:emoji
- GET /messages/:id/reactions

## Implementation Details

- Added `Reaction` entity and `reactions` migration with uniqueness and indexes
- Implemented `ReactionsRepository` with aggregation queries
- Implemented `ReactionsService` methods:
  - `addReaction`
  - `removeReaction`
  - `getReactions`
  - `getReactionSummary`
- Implemented `ReactionsController` with message-scoped routes
- Extended chat gateway to emit reaction events to conversation rooms

## Issue Link
closes #391 
