### PR TITLE
Feat/poll

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -45,6 +45,7 @@ import { PinnedMessagesModule } from './pinned-messages/pinned-messages.module';
 import { Sep10Module } from './sep10/sep10.module';
 import { RampModule } from './ramp/ramp.module';
 import { QrCodeModule } from './qr-code/qr-code.module';
+import { PollsModule } from './polls/polls.module';
 
 @Module({
   imports: [
@@ -95,6 +96,7 @@ import { QrCodeModule } from './qr-code/qr-code.module';
     Sep10Module,
     RampModule,
     QrCodeModule,
+    PollsModule,
     ScheduledJobsModule,
     InChatTransfersModule,
     WebhooksModule,

--- a/src/messaging/gateways/chat.gateway.ts
+++ b/src/messaging/gateways/chat.gateway.ts
@@ -286,6 +286,12 @@ export class ChatGateway implements OnGatewayConnection, OnGatewayDisconnect {
     this.server.to(roomId).emit('reaction:remove', event);
   }
 
+  async sendPollUpdated(conversationId: string, payload: Record<string, unknown>): Promise<void> {
+    const roomId = `conversation:${conversationId}`;
+    await this.eventReplayService.storeEvent(roomId, 'poll:updated', payload);
+    this.server.to(roomId).emit('poll:updated', payload);
+  }
+
   emitMessagePinned(conversationId: string, payload: Record<string, unknown>): void {
     const roomId = `conversation:${conversationId}`;
     this.server.to(roomId).emit('message:pinned', payload);

--- a/src/migrations/1760000000000-PollsSchema.ts
+++ b/src/migrations/1760000000000-PollsSchema.ts
@@ -1,0 +1,65 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class PollsSchema1760000000000 implements MigrationInterface {
+  name = 'PollsSchema1760000000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE "polls" (
+        "id" uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
+        "conversationId" uuid NOT NULL,
+        "createdBy" uuid NOT NULL,
+        "question" varchar(300) NOT NULL,
+        "options" jsonb NOT NULL,
+        "allowMultiple" boolean NOT NULL DEFAULT false,
+        "isAnonymous" boolean NOT NULL DEFAULT false,
+        "expiresAt" TIMESTAMP NULL,
+        "isClosed" boolean NOT NULL DEFAULT false,
+        "createdAt" TIMESTAMP NOT NULL DEFAULT now(),
+        CONSTRAINT "fk_polls_conversation"
+          FOREIGN KEY ("conversationId") REFERENCES "conversations"("id") ON DELETE CASCADE,
+        CONSTRAINT "fk_polls_created_by"
+          FOREIGN KEY ("createdBy") REFERENCES "users"("id") ON DELETE CASCADE
+      )
+    `);
+    await queryRunner.query(`
+      CREATE INDEX "idx_polls_conversation_id" ON "polls"("conversationId")
+    `);
+    await queryRunner.query(`
+      CREATE INDEX "idx_polls_created_by" ON "polls"("createdBy")
+    `);
+    await queryRunner.query(`
+      CREATE INDEX "idx_polls_expires_at" ON "polls"("expiresAt")
+    `);
+    await queryRunner.query(`
+      CREATE INDEX "idx_polls_is_closed" ON "polls"("isClosed")
+    `);
+
+    await queryRunner.query(`
+      CREATE TABLE "poll_votes" (
+        "pollId" uuid NOT NULL,
+        "userId" uuid NOT NULL,
+        "optionIndexes" int[] NOT NULL,
+        "votedAt" TIMESTAMP NOT NULL DEFAULT now(),
+        CONSTRAINT "pk_poll_votes" PRIMARY KEY ("pollId", "userId"),
+        CONSTRAINT "fk_poll_votes_poll"
+          FOREIGN KEY ("pollId") REFERENCES "polls"("id") ON DELETE CASCADE,
+        CONSTRAINT "fk_poll_votes_user"
+          FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE CASCADE
+      )
+    `);
+    await queryRunner.query(`
+      CREATE INDEX "idx_poll_votes_user_id" ON "poll_votes"("userId")
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX "idx_poll_votes_user_id"`);
+    await queryRunner.query(`DROP TABLE "poll_votes"`);
+    await queryRunner.query(`DROP INDEX "idx_polls_is_closed"`);
+    await queryRunner.query(`DROP INDEX "idx_polls_expires_at"`);
+    await queryRunner.query(`DROP INDEX "idx_polls_created_by"`);
+    await queryRunner.query(`DROP INDEX "idx_polls_conversation_id"`);
+    await queryRunner.query(`DROP TABLE "polls"`);
+  }
+}

--- a/src/polls/dto/cast-vote.dto.ts
+++ b/src/polls/dto/cast-vote.dto.ts
@@ -1,0 +1,13 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import { ArrayMaxSize, ArrayMinSize, IsArray, IsInt } from 'class-validator';
+
+export class CastVoteDto {
+  @ApiProperty({ type: [Number], minItems: 1, maxItems: 10 })
+  @IsArray()
+  @ArrayMinSize(1)
+  @ArrayMaxSize(10)
+  @Type(() => Number)
+  @IsInt({ each: true })
+  optionIndexes!: number[];
+}

--- a/src/polls/dto/create-poll.dto.ts
+++ b/src/polls/dto/create-poll.dto.ts
@@ -1,0 +1,43 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import {
+  ArrayMaxSize,
+  ArrayMinSize,
+  IsArray,
+  IsBoolean,
+  IsDateString,
+  IsOptional,
+  IsString,
+  Length,
+} from 'class-validator';
+
+export class CreatePollDto {
+  @ApiProperty()
+  @IsString()
+  @Length(1, 300)
+  question!: string;
+
+  @ApiProperty({ type: [String], minItems: 2, maxItems: 10 })
+  @IsArray()
+  @ArrayMinSize(2)
+  @ArrayMaxSize(10)
+  @IsString({ each: true })
+  options!: string[];
+
+  @ApiPropertyOptional({ default: false })
+  @IsOptional()
+  @Type(() => Boolean)
+  @IsBoolean()
+  allowMultiple?: boolean;
+
+  @ApiPropertyOptional({ default: false })
+  @IsOptional()
+  @Type(() => Boolean)
+  @IsBoolean()
+  isAnonymous?: boolean;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsDateString()
+  expiresAt?: string;
+}

--- a/src/polls/dto/poll-response.dto.ts
+++ b/src/polls/dto/poll-response.dto.ts
@@ -1,0 +1,113 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+export class PollVoterDto {
+  @ApiProperty()
+  userId!: string;
+
+  @ApiPropertyOptional()
+  username!: string | null;
+
+  @ApiPropertyOptional()
+  displayName!: string | null;
+}
+
+export class PollOptionResultDto {
+  @ApiProperty()
+  index!: number;
+
+  @ApiProperty()
+  text!: string;
+
+  @ApiProperty()
+  voteCount!: number;
+
+  @ApiPropertyOptional({ type: [PollVoterDto] })
+  voters?: PollVoterDto[];
+}
+
+export class PollUserVoteDto {
+  @ApiProperty({ type: [Number] })
+  optionIndexes!: number[];
+
+  @ApiProperty()
+  votedAt!: Date;
+}
+
+export class PollResponseDto {
+  @ApiProperty()
+  id!: string;
+
+  @ApiProperty()
+  conversationId!: string;
+
+  @ApiProperty()
+  createdBy!: string;
+
+  @ApiProperty()
+  question!: string;
+
+  @ApiProperty({ type: [String] })
+  options!: string[];
+
+  @ApiProperty()
+  allowMultiple!: boolean;
+
+  @ApiProperty()
+  isAnonymous!: boolean;
+
+  @ApiPropertyOptional()
+  expiresAt!: Date | null;
+
+  @ApiProperty()
+  isClosed!: boolean;
+
+  @ApiProperty()
+  createdAt!: Date;
+
+  @ApiProperty()
+  totalVoters!: number;
+
+  @ApiProperty({ type: [PollOptionResultDto] })
+  results!: PollOptionResultDto[];
+
+  @ApiPropertyOptional({ type: PollUserVoteDto })
+  currentUserVote!: PollUserVoteDto | null;
+}
+
+export class PollRealtimePayloadDto {
+  @ApiProperty()
+  id!: string;
+
+  @ApiProperty()
+  conversationId!: string;
+
+  @ApiProperty()
+  createdBy!: string;
+
+  @ApiProperty()
+  question!: string;
+
+  @ApiProperty({ type: [String] })
+  options!: string[];
+
+  @ApiProperty()
+  allowMultiple!: boolean;
+
+  @ApiProperty()
+  isAnonymous!: boolean;
+
+  @ApiPropertyOptional()
+  expiresAt!: Date | null;
+
+  @ApiProperty()
+  isClosed!: boolean;
+
+  @ApiProperty()
+  createdAt!: Date;
+
+  @ApiProperty()
+  totalVoters!: number;
+
+  @ApiProperty({ type: [PollOptionResultDto] })
+  results!: PollOptionResultDto[];
+}

--- a/src/polls/entities/poll-vote.entity.ts
+++ b/src/polls/entities/poll-vote.entity.ts
@@ -1,0 +1,33 @@
+import {
+  Column,
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  PrimaryColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+import { Poll } from './poll.entity';
+import { User } from '../../users/entities/user.entity';
+
+@Entity('poll_votes')
+export class PollVote {
+  @PrimaryColumn({ type: 'uuid' })
+  pollId!: string;
+
+  @PrimaryColumn({ type: 'uuid' })
+  userId!: string;
+
+  @Column('int', { array: true })
+  optionIndexes!: number[];
+
+  @ManyToOne(() => Poll, (poll) => poll.votes, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'pollId' })
+  poll!: Poll;
+
+  @ManyToOne(() => User, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'userId' })
+  user!: User;
+
+  @UpdateDateColumn({ type: 'timestamp' })
+  votedAt!: Date;
+}

--- a/src/polls/entities/poll.entity.ts
+++ b/src/polls/entities/poll.entity.ts
@@ -1,0 +1,61 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  Index,
+  JoinColumn,
+  ManyToOne,
+  OneToMany,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+import { Conversation } from '../../conversations/entities/conversation.entity';
+import { User } from '../../users/entities/user.entity';
+import { PollVote } from './poll-vote.entity';
+
+@Entity('polls')
+export class Poll {
+  @PrimaryGeneratedColumn('uuid')
+  id!: string;
+
+  @Column({ type: 'uuid' })
+  @Index('idx_polls_conversation_id')
+  conversationId!: string;
+
+  @Column({ type: 'uuid' })
+  @Index('idx_polls_created_by')
+  createdBy!: string;
+
+  @Column({ type: 'varchar', length: 300 })
+  question!: string;
+
+  @Column({ type: 'jsonb' })
+  options!: string[];
+
+  @Column({ type: 'boolean', default: false })
+  allowMultiple!: boolean;
+
+  @Column({ type: 'boolean', default: false })
+  isAnonymous!: boolean;
+
+  @Column({ type: 'timestamp', nullable: true })
+  @Index('idx_polls_expires_at')
+  expiresAt!: Date | null;
+
+  @Column({ type: 'boolean', default: false })
+  @Index('idx_polls_is_closed')
+  isClosed!: boolean;
+
+  @ManyToOne(() => Conversation, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'conversationId' })
+  conversation!: Conversation;
+
+  @ManyToOne(() => User, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'createdBy' })
+  creator!: User;
+
+  @OneToMany(() => PollVote, (vote) => vote.poll)
+  votes!: PollVote[];
+
+  @CreateDateColumn({ type: 'timestamp' })
+  createdAt!: Date;
+}

--- a/src/polls/polls-expiry.job.spec.ts
+++ b/src/polls/polls-expiry.job.spec.ts
@@ -1,0 +1,61 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ChatGateway } from '../messaging/gateways/chat.gateway';
+import { PollsExpiryJob } from './polls-expiry.job';
+import { PollsService } from './polls.service';
+
+describe('PollsExpiryJob', () => {
+  let job: PollsExpiryJob;
+  let service: jest.Mocked<PollsService>;
+  let gateway: jest.Mocked<ChatGateway>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        PollsExpiryJob,
+        {
+          provide: PollsService,
+          useValue: {
+            closeExpiredPolls: jest.fn(),
+          },
+        },
+        {
+          provide: ChatGateway,
+          useValue: {
+            sendPollUpdated: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    job = module.get(PollsExpiryJob);
+    service = module.get(PollsService);
+    gateway = module.get(ChatGateway);
+  });
+
+  it('broadcasts updates for expired polls that were auto-closed', async () => {
+    service.closeExpiredPolls.mockResolvedValue([
+      {
+        id: '11111111-1111-1111-1111-111111111111',
+        conversationId: '22222222-2222-2222-2222-222222222222',
+        createdBy: '33333333-3333-3333-3333-333333333333',
+        question: 'Best option?',
+        options: ['A', 'B'],
+        allowMultiple: false,
+        isAnonymous: false,
+        expiresAt: null,
+        isClosed: true,
+        createdAt: new Date('2026-03-27T09:00:00.000Z'),
+        totalVoters: 1,
+        results: [],
+      },
+    ] as never);
+
+    await job.closeExpiredPolls();
+
+    expect(gateway.sendPollUpdated).toHaveBeenCalledTimes(1);
+    expect(gateway.sendPollUpdated).toHaveBeenCalledWith(
+      '22222222-2222-2222-2222-222222222222',
+      expect.objectContaining({ isClosed: true }),
+    );
+  });
+});

--- a/src/polls/polls-expiry.job.ts
+++ b/src/polls/polls-expiry.job.ts
@@ -1,0 +1,27 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron, CronExpression } from '@nestjs/schedule';
+import { ChatGateway } from '../messaging/gateways/chat.gateway';
+import { PollsService } from './polls.service';
+
+@Injectable()
+export class PollsExpiryJob {
+  private readonly logger = new Logger(PollsExpiryJob.name);
+
+  constructor(
+    private readonly pollsService: PollsService,
+    private readonly chatGateway: ChatGateway,
+  ) {}
+
+  @Cron(CronExpression.EVERY_MINUTE)
+  async closeExpiredPolls(): Promise<void> {
+    const expiredPolls = await this.pollsService.closeExpiredPolls();
+
+    for (const poll of expiredPolls) {
+      await this.chatGateway.sendPollUpdated(poll.conversationId, poll);
+    }
+
+    if (expiredPolls.length > 0) {
+      this.logger.log(`Closed ${expiredPolls.length} expired poll(s).`);
+    }
+  }
+}

--- a/src/polls/polls.controller.spec.ts
+++ b/src/polls/polls.controller.spec.ts
@@ -1,0 +1,79 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ChatGateway } from '../messaging/gateways/chat.gateway';
+import { PollsController } from './polls.controller';
+import { PollsService } from './polls.service';
+
+describe('PollsController', () => {
+  let controller: PollsController;
+  let service: jest.Mocked<PollsService>;
+  let gateway: jest.Mocked<ChatGateway>;
+
+  const pollResponse = {
+    id: '11111111-1111-1111-1111-111111111111',
+    conversationId: '22222222-2222-2222-2222-222222222222',
+    createdBy: '33333333-3333-3333-3333-333333333333',
+    question: 'Best option?',
+    options: ['A', 'B'],
+    allowMultiple: false,
+    isAnonymous: false,
+    expiresAt: null,
+    isClosed: false,
+    createdAt: new Date('2026-03-27T09:00:00.000Z'),
+    totalVoters: 1,
+    results: [],
+    currentUserVote: null,
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [PollsController],
+      providers: [
+        {
+          provide: PollsService,
+          useValue: {
+            createPoll: jest.fn(),
+            getPollsInConversation: jest.fn(),
+            getPollResults: jest.fn(),
+            castVote: jest.fn(),
+            retractVote: jest.fn(),
+            closePoll: jest.fn(),
+            getPollRealtimePayload: jest.fn(),
+          },
+        },
+        {
+          provide: ChatGateway,
+          useValue: {
+            sendPollUpdated: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    controller = module.get(PollsController);
+    service = module.get(PollsService);
+    gateway = module.get(ChatGateway);
+  });
+
+  it('emits a websocket update when a vote is cast', async () => {
+    service.castVote.mockResolvedValue(pollResponse as never);
+    service.getPollRealtimePayload.mockResolvedValue(pollResponse as never);
+
+    const result = await controller.castVote(
+      '44444444-4444-4444-4444-444444444444',
+      pollResponse.id,
+      { optionIndexes: [0] },
+    );
+
+    expect(result).toBe(pollResponse);
+    expect(gateway.sendPollUpdated).toHaveBeenCalledWith(pollResponse.conversationId, pollResponse);
+  });
+
+  it('emits a websocket update when a vote is retracted', async () => {
+    service.retractVote.mockResolvedValue(pollResponse as never);
+    service.getPollRealtimePayload.mockResolvedValue(pollResponse as never);
+
+    await controller.retractVote('44444444-4444-4444-4444-444444444444', pollResponse.id);
+
+    expect(gateway.sendPollUpdated).toHaveBeenCalledWith(pollResponse.conversationId, pollResponse);
+  });
+});

--- a/src/polls/polls.controller.ts
+++ b/src/polls/polls.controller.ts
@@ -1,0 +1,101 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Param,
+  ParseUUIDPipe,
+  Post,
+} from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { CurrentUser } from '../auth/decorators/current-user.decorator';
+import { ChatGateway } from '../messaging/gateways/chat.gateway';
+import { CastVoteDto } from './dto/cast-vote.dto';
+import { CreatePollDto } from './dto/create-poll.dto';
+import { PollResponseDto } from './dto/poll-response.dto';
+import { PollsService } from './polls.service';
+
+@ApiTags('polls')
+@ApiBearerAuth()
+@Controller()
+export class PollsController {
+  constructor(
+    private readonly pollsService: PollsService,
+    private readonly chatGateway: ChatGateway,
+  ) {}
+
+  @Post('conversations/:id/polls')
+  @HttpCode(HttpStatus.CREATED)
+  @ApiOperation({ summary: 'Create a poll in a conversation' })
+  @ApiResponse({ status: 201, type: PollResponseDto })
+  createPoll(
+    @CurrentUser('id') userId: string,
+    @Param('id', ParseUUIDPipe) conversationId: string,
+    @Body() dto: CreatePollDto,
+  ): Promise<PollResponseDto> {
+    return this.pollsService.createPoll(userId, conversationId, dto);
+  }
+
+  @Get('conversations/:id/polls')
+  @ApiOperation({ summary: 'List polls in a conversation' })
+  @ApiResponse({ status: 200, type: [PollResponseDto] })
+  getPollsInConversation(
+    @CurrentUser('id') userId: string,
+    @Param('id', ParseUUIDPipe) conversationId: string,
+  ): Promise<PollResponseDto[]> {
+    return this.pollsService.getPollsInConversation(userId, conversationId);
+  }
+
+  @Get('polls/:id')
+  @ApiOperation({ summary: 'Get a poll with results' })
+  @ApiResponse({ status: 200, type: PollResponseDto })
+  getPoll(
+    @CurrentUser('id') userId: string,
+    @Param('id', ParseUUIDPipe) pollId: string,
+  ): Promise<PollResponseDto> {
+    return this.pollsService.getPollResults(userId, pollId);
+  }
+
+  @Post('polls/:id/vote')
+  @HttpCode(HttpStatus.CREATED)
+  @ApiOperation({ summary: 'Cast or update a vote for a poll' })
+  @ApiResponse({ status: 201, type: PollResponseDto })
+  async castVote(
+    @CurrentUser('id') userId: string,
+    @Param('id', ParseUUIDPipe) pollId: string,
+    @Body() dto: CastVoteDto,
+  ): Promise<PollResponseDto> {
+    const response = await this.pollsService.castVote(userId, pollId, dto);
+    const payload = await this.pollsService.getPollRealtimePayload(pollId);
+    await this.chatGateway.sendPollUpdated(response.conversationId, payload);
+    return response;
+  }
+
+  @Delete('polls/:id/vote')
+  @ApiOperation({ summary: 'Retract a vote from a poll' })
+  @ApiResponse({ status: 200, type: PollResponseDto })
+  async retractVote(
+    @CurrentUser('id') userId: string,
+    @Param('id', ParseUUIDPipe) pollId: string,
+  ): Promise<PollResponseDto> {
+    const response = await this.pollsService.retractVote(userId, pollId);
+    const payload = await this.pollsService.getPollRealtimePayload(pollId);
+    await this.chatGateway.sendPollUpdated(response.conversationId, payload);
+    return response;
+  }
+
+  @Post('polls/:id/close')
+  @ApiOperation({ summary: 'Close a poll' })
+  @ApiResponse({ status: 201, type: PollResponseDto })
+  async closePoll(
+    @CurrentUser('id') userId: string,
+    @Param('id', ParseUUIDPipe) pollId: string,
+  ): Promise<PollResponseDto> {
+    const response = await this.pollsService.closePoll(userId, pollId);
+    const payload = await this.pollsService.getPollRealtimePayload(pollId);
+    await this.chatGateway.sendPollUpdated(response.conversationId, payload);
+    return response;
+  }
+}

--- a/src/polls/polls.module.ts
+++ b/src/polls/polls.module.ts
@@ -1,0 +1,23 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Conversation } from '../conversations/entities/conversation.entity';
+import { ConversationParticipant } from '../conversations/entities/conversation-participant.entity';
+import { MessagingModule } from '../messaging/messaging.module';
+import { User } from '../users/entities/user.entity';
+import { PollVote } from './entities/poll-vote.entity';
+import { Poll } from './entities/poll.entity';
+import { PollsController } from './polls.controller';
+import { PollsExpiryJob } from './polls-expiry.job';
+import { PollsRepository } from './polls.repository';
+import { PollsService } from './polls.service';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([Poll, PollVote, Conversation, ConversationParticipant, User]),
+    MessagingModule,
+  ],
+  controllers: [PollsController],
+  providers: [PollsRepository, PollsService, PollsExpiryJob],
+  exports: [PollsService],
+})
+export class PollsModule {}

--- a/src/polls/polls.repository.ts
+++ b/src/polls/polls.repository.ts
@@ -1,0 +1,119 @@
+import { Injectable } from '@nestjs/common';
+import { DataSource, Repository } from 'typeorm';
+import { Poll } from './entities/poll.entity';
+import { PollVote } from './entities/poll-vote.entity';
+
+type PollVoteAggregationRow = {
+  optionIndex: number;
+  voteCount: number;
+  voterIds: string[];
+};
+
+@Injectable()
+export class PollsRepository extends Repository<Poll> {
+  private readonly votesRepository: Repository<PollVote>;
+
+  constructor(private readonly dataSource: DataSource) {
+    super(Poll, dataSource.createEntityManager());
+    this.votesRepository = dataSource.getRepository(PollVote);
+  }
+
+  findVoteByPollAndUser(pollId: string, userId: string): Promise<PollVote | null> {
+    return this.votesRepository.findOne({
+      where: { pollId, userId },
+    });
+  }
+
+  findVotesByPoll(pollId: string): Promise<PollVote[]> {
+    return this.votesRepository.find({
+      where: { pollId },
+      order: { votedAt: 'DESC' },
+    });
+  }
+
+  saveVote(vote: PollVote): Promise<PollVote> {
+    return this.votesRepository.save(vote);
+  }
+
+  createVote(partial: Partial<PollVote>): PollVote {
+    return this.votesRepository.create(partial);
+  }
+
+  async deleteVote(pollId: string, userId: string): Promise<number> {
+    const result = await this.votesRepository.delete({ pollId, userId });
+    return result.affected ?? 0;
+  }
+
+  async getVoteAggregation(pollId: string): Promise<PollVoteAggregationRow[]> {
+    const rows = await this.dataSource.query(
+      `
+        SELECT
+          expanded.option_index AS "optionIndex",
+          COUNT(*)::int AS "voteCount",
+          ARRAY_AGG(expanded."userId" ORDER BY expanded."votedAt" DESC) AS "voterIds"
+        FROM (
+          SELECT
+            "userId",
+            "votedAt",
+            unnest("optionIndexes") AS option_index
+          FROM "poll_votes"
+          WHERE "pollId" = $1
+        ) expanded
+        GROUP BY expanded.option_index
+        ORDER BY expanded.option_index ASC
+      `,
+      [pollId],
+    );
+
+    return rows.map((row: Record<string, unknown>) => ({
+      optionIndex: this.toNumber(row.optionIndex),
+      voteCount: this.toNumber(row.voteCount),
+      voterIds: this.toArray(row.voterIds),
+    }));
+  }
+
+  findConversationPolls(conversationId: string): Promise<Poll[]> {
+    return this.find({
+      where: { conversationId },
+      order: { createdAt: 'DESC' },
+    });
+  }
+
+  findExpiredOpenPolls(referenceTime: Date): Promise<Poll[]> {
+    return this.createQueryBuilder('poll')
+      .where('poll.isClosed = :isClosed', { isClosed: false })
+      .andWhere('poll.expiresAt IS NOT NULL')
+      .andWhere('poll.expiresAt <= :referenceTime', { referenceTime })
+      .getMany();
+  }
+
+  private toNumber(value: unknown): number {
+    if (typeof value === 'number') {
+      return value;
+    }
+
+    return parseInt(String(value), 10);
+  }
+
+  private toArray(value: unknown): string[] {
+    if (!value) {
+      return [];
+    }
+
+    if (Array.isArray(value)) {
+      return value.map((entry) => String(entry));
+    }
+
+    const normalized = String(value).trim();
+    if (!normalized.startsWith('{') || !normalized.endsWith('}')) {
+      return normalized.length ? [normalized] : [];
+    }
+
+    const inner = normalized.slice(1, -1).trim();
+    if (!inner) {
+      return [];
+    }
+
+    return inner.split(',').map((part) => part.replace(/^"|"$/g, '').trim());
+  }
+}

--- a/src/polls/polls.service.spec.ts
+++ b/src/polls/polls.service.spec.ts
@@ -1,0 +1,272 @@
+import {
+  BadRequestException,
+  ForbiddenException,
+  NotFoundException,
+} from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Conversation } from '../conversations/entities/conversation.entity';
+import { ConversationParticipant } from '../conversations/entities/conversation-participant.entity';
+import { User } from '../users/entities/user.entity';
+import { PollsService } from './polls.service';
+import { PollsRepository } from './polls.repository';
+import { Poll } from './entities/poll.entity';
+import { PollVote } from './entities/poll-vote.entity';
+
+describe('PollsService', () => {
+  let service: PollsService;
+  let pollsRepository: jest.Mocked<PollsRepository>;
+  let conversationsRepository: jest.Mocked<Repository<Conversation>>;
+  let participantsRepository: jest.Mocked<Repository<ConversationParticipant>>;
+  let usersRepository: jest.Mocked<Repository<User>>;
+
+  const now = new Date('2026-03-27T10:00:00.000Z');
+  const pollId = '11111111-1111-1111-1111-111111111111';
+  const conversationId = '22222222-2222-2222-2222-222222222222';
+  const creatorId = '33333333-3333-3333-3333-333333333333';
+  const voterId = '44444444-4444-4444-4444-444444444444';
+
+  const basePoll: Poll = {
+    id: pollId,
+    conversationId,
+    createdBy: creatorId,
+    question: 'Best option?',
+    options: ['Alpha', 'Beta', 'Gamma'],
+    allowMultiple: false,
+    isAnonymous: false,
+    expiresAt: new Date('2026-03-28T10:00:00.000Z'),
+    isClosed: false,
+    conversation: {} as Conversation,
+    creator: {} as User,
+    votes: [],
+    createdAt: new Date('2026-03-27T09:00:00.000Z'),
+  };
+
+  beforeEach(async () => {
+    jest.useFakeTimers().setSystemTime(now);
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        PollsService,
+        {
+          provide: PollsRepository,
+          useValue: {
+            create: jest.fn(),
+            save: jest.fn(),
+            findOne: jest.fn(),
+            findVoteByPollAndUser: jest.fn(),
+            findVotesByPoll: jest.fn(),
+            saveVote: jest.fn(),
+            createVote: jest.fn(),
+            deleteVote: jest.fn(),
+            getVoteAggregation: jest.fn(),
+            findConversationPolls: jest.fn(),
+            findExpiredOpenPolls: jest.fn(),
+          },
+        },
+        {
+          provide: getRepositoryToken(Conversation),
+          useValue: { findOne: jest.fn() },
+        },
+        {
+          provide: getRepositoryToken(ConversationParticipant),
+          useValue: { exist: jest.fn() },
+        },
+        {
+          provide: getRepositoryToken(User),
+          useValue: { find: jest.fn() },
+        },
+      ],
+    }).compile();
+
+    service = module.get(PollsService);
+    pollsRepository = module.get(PollsRepository);
+    conversationsRepository = module.get(getRepositoryToken(Conversation));
+    participantsRepository = module.get(getRepositoryToken(ConversationParticipant));
+    usersRepository = module.get(getRepositoryToken(User));
+
+    conversationsRepository.findOne.mockResolvedValue({ id: conversationId } as Conversation);
+    participantsRepository.exist.mockResolvedValue(true);
+    pollsRepository.findOne.mockResolvedValue({ ...basePoll });
+    pollsRepository.findVotesByPoll.mockResolvedValue([]);
+    pollsRepository.getVoteAggregation.mockResolvedValue([]);
+    usersRepository.find.mockResolvedValue([]);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('creates a poll with normalized options', async () => {
+    const createdPoll = { ...basePoll, options: ['Alpha', 'Beta'] };
+    pollsRepository.create.mockReturnValue(createdPoll);
+    pollsRepository.save.mockResolvedValue(createdPoll);
+
+    const result = await service.createPoll(creatorId, conversationId, {
+      question: ' Favorite? ',
+      options: [' Alpha ', 'Beta'],
+      allowMultiple: true,
+      isAnonymous: true,
+      expiresAt: '2026-03-28T12:00:00.000Z',
+    });
+
+    expect(pollsRepository.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        question: 'Favorite?',
+        options: ['Alpha', 'Beta'],
+        allowMultiple: true,
+        isAnonymous: true,
+      }),
+    );
+    expect(result.question).toBe('Favorite?');
+  });
+
+  it('rejects duplicate poll options', async () => {
+    await expect(
+      service.createPoll(creatorId, conversationId, {
+        question: 'Favorite?',
+        options: ['Alpha', 'alpha'],
+      }),
+    ).rejects.toThrow(BadRequestException);
+  });
+
+  it('casts a vote and includes named voters for non-anonymous polls', async () => {
+    const vote: PollVote = {
+      pollId,
+      userId: voterId,
+      optionIndexes: [1],
+      votedAt: now,
+      poll: basePoll,
+      user: {} as User,
+    };
+
+    pollsRepository.findVoteByPollAndUser.mockResolvedValue(null);
+    pollsRepository.createVote.mockReturnValue(vote);
+    pollsRepository.saveVote.mockResolvedValue(vote);
+    pollsRepository.findVotesByPoll.mockResolvedValue([vote]);
+    pollsRepository.getVoteAggregation.mockResolvedValue([
+      { optionIndex: 1, voteCount: 1, voterIds: [voterId] },
+    ]);
+    usersRepository.find.mockResolvedValue([
+      { id: voterId, username: 'voter', displayName: 'Voter Name' } as User,
+    ]);
+
+    const result = await service.castVote(voterId, pollId, { optionIndexes: [1] });
+
+    expect(pollsRepository.saveVote).toHaveBeenCalled();
+    expect(result.totalVoters).toBe(1);
+    expect(result.results[1].voters).toEqual([
+      { userId: voterId, username: 'voter', displayName: 'Voter Name' },
+    ]);
+    expect(result.currentUserVote?.optionIndexes).toEqual([1]);
+  });
+
+  it('hides individual voters for anonymous polls', async () => {
+    const anonymousPoll = { ...basePoll, isAnonymous: true, allowMultiple: true };
+    const vote: PollVote = {
+      pollId,
+      userId: voterId,
+      optionIndexes: [0, 2],
+      votedAt: now,
+      poll: anonymousPoll,
+      user: {} as User,
+    };
+
+    pollsRepository.findOne.mockResolvedValue(anonymousPoll);
+    pollsRepository.findVoteByPollAndUser.mockResolvedValue(null);
+    pollsRepository.createVote.mockReturnValue(vote);
+    pollsRepository.saveVote.mockResolvedValue(vote);
+    pollsRepository.findVotesByPoll.mockResolvedValue([vote]);
+    pollsRepository.getVoteAggregation.mockResolvedValue([
+      { optionIndex: 0, voteCount: 1, voterIds: [voterId] },
+      { optionIndex: 2, voteCount: 1, voterIds: [voterId] },
+    ]);
+
+    const result = await service.castVote(voterId, pollId, { optionIndexes: [0, 2] });
+
+    expect(usersRepository.find).not.toHaveBeenCalled();
+    expect(result.results[0].voters).toBeUndefined();
+    expect(result.results[2].voters).toBeUndefined();
+  });
+
+  it('rejects multi-select votes for single-choice polls', async () => {
+    await expect(service.castVote(voterId, pollId, { optionIndexes: [0, 1] })).rejects.toThrow(
+      BadRequestException,
+    );
+  });
+
+  it('retracts a vote before poll closure', async () => {
+    pollsRepository.deleteVote.mockResolvedValue(1);
+
+    const result = await service.retractVote(voterId, pollId);
+
+    expect(pollsRepository.deleteVote).toHaveBeenCalledWith(pollId, voterId);
+    expect(result.id).toBe(pollId);
+  });
+
+  it('prevents non-creators from closing a poll', async () => {
+    await expect(service.closePoll(voterId, pollId)).rejects.toThrow(ForbiddenException);
+  });
+
+  it('auto-closes expired polls when accessed', async () => {
+    const expiredPoll = { ...basePoll, expiresAt: new Date('2026-03-27T09:00:00.000Z') };
+    pollsRepository.findOne.mockResolvedValue(expiredPoll);
+    pollsRepository.save.mockResolvedValue({ ...expiredPoll, isClosed: true });
+
+    await expect(service.getPoll(creatorId, pollId)).resolves.toMatchObject({ isClosed: true });
+    expect(pollsRepository.save).toHaveBeenCalledWith(expect.objectContaining({ isClosed: true }));
+  });
+
+  it('refuses to vote on expired polls', async () => {
+    const expiredPoll = { ...basePoll, expiresAt: new Date('2026-03-27T09:00:00.000Z') };
+    pollsRepository.findOne.mockResolvedValue(expiredPoll);
+    pollsRepository.save.mockResolvedValue({ ...expiredPoll, isClosed: true });
+
+    await expect(service.castVote(voterId, pollId, { optionIndexes: [0] })).rejects.toThrow(
+      BadRequestException,
+    );
+  });
+
+  it('returns conversation polls with current user votes', async () => {
+    const vote: PollVote = {
+      pollId,
+      userId: creatorId,
+      optionIndexes: [0],
+      votedAt: now,
+      poll: basePoll,
+      user: {} as User,
+    };
+
+    pollsRepository.findConversationPolls.mockResolvedValue([{ ...basePoll }]);
+    pollsRepository.findVotesByPoll.mockResolvedValue([vote]);
+    pollsRepository.getVoteAggregation.mockResolvedValue([
+      { optionIndex: 0, voteCount: 1, voterIds: [creatorId] },
+    ]);
+    usersRepository.find.mockResolvedValue([
+      { id: creatorId, username: 'owner', displayName: 'Owner' } as User,
+    ]);
+
+    const result = await service.getPollsInConversation(creatorId, conversationId);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].currentUserVote?.optionIndexes).toEqual([0]);
+  });
+
+  it('closes expired polls in bulk for the scheduled job', async () => {
+    const expiredPoll = { ...basePoll, expiresAt: new Date('2026-03-27T09:00:00.000Z') };
+    pollsRepository.findExpiredOpenPolls.mockResolvedValue([expiredPoll]);
+    pollsRepository.save.mockResolvedValue([{ ...expiredPoll, isClosed: true }] as never);
+
+    const result = await service.closeExpiredPolls(now);
+
+    expect(pollsRepository.save).toHaveBeenCalledWith([expect.objectContaining({ isClosed: true })]);
+    expect(result[0]).toMatchObject({ id: pollId, isClosed: true });
+  });
+
+  it('throws when the poll does not exist', async () => {
+    pollsRepository.findOne.mockResolvedValue(null);
+
+    await expect(service.getPoll(creatorId, pollId)).rejects.toThrow(NotFoundException);
+  });
+});

--- a/src/polls/polls.service.ts
+++ b/src/polls/polls.service.ts
@@ -1,0 +1,355 @@
+import {
+  BadRequestException,
+  ForbiddenException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { In, Repository } from 'typeorm';
+import { Conversation } from '../conversations/entities/conversation.entity';
+import { ConversationParticipant } from '../conversations/entities/conversation-participant.entity';
+import { User } from '../users/entities/user.entity';
+import { CastVoteDto } from './dto/cast-vote.dto';
+import {
+  PollOptionResultDto,
+  PollRealtimePayloadDto,
+  PollResponseDto,
+  PollVoterDto,
+} from './dto/poll-response.dto';
+import { CreatePollDto } from './dto/create-poll.dto';
+import { Poll } from './entities/poll.entity';
+import { PollVote } from './entities/poll-vote.entity';
+import { PollsRepository } from './polls.repository';
+
+@Injectable()
+export class PollsService {
+  constructor(
+    private readonly pollsRepository: PollsRepository,
+    @InjectRepository(Conversation)
+    private readonly conversationsRepository: Repository<Conversation>,
+    @InjectRepository(ConversationParticipant)
+    private readonly participantsRepository: Repository<ConversationParticipant>,
+    @InjectRepository(User)
+    private readonly usersRepository: Repository<User>,
+  ) {}
+
+  async createPoll(
+    userId: string,
+    conversationId: string,
+    dto: CreatePollDto,
+  ): Promise<PollResponseDto> {
+    await this.getConversationOrThrow(conversationId);
+    await this.assertParticipant(conversationId, userId);
+
+    const poll = this.pollsRepository.create({
+      conversationId,
+      createdBy: userId,
+      question: dto.question.trim(),
+      options: this.normalizeOptions(dto.options),
+      allowMultiple: dto.allowMultiple ?? false,
+      isAnonymous: dto.isAnonymous ?? false,
+      expiresAt: this.parseExpiresAt(dto.expiresAt),
+      isClosed: false,
+    });
+
+    const savedPoll = await this.pollsRepository.save(poll);
+    return this.buildPollResponse(savedPoll, userId);
+  }
+
+  async castVote(userId: string, pollId: string, dto: CastVoteDto): Promise<PollResponseDto> {
+    const poll = await this.getAuthorizedPoll(userId, pollId);
+    await this.assertPollOpen(poll);
+
+    const optionIndexes = this.normalizeVoteOptionIndexes(dto.optionIndexes, poll);
+    const vote =
+      (await this.pollsRepository.findVoteByPollAndUser(poll.id, userId)) ??
+      this.pollsRepository.createVote({ pollId: poll.id, userId });
+
+    vote.optionIndexes = optionIndexes;
+    vote.votedAt = new Date();
+    await this.pollsRepository.saveVote(vote);
+
+    return this.buildPollResponse(poll, userId);
+  }
+
+  async retractVote(userId: string, pollId: string): Promise<PollResponseDto> {
+    const poll = await this.getAuthorizedPoll(userId, pollId);
+    await this.assertPollOpen(poll);
+
+    const removed = await this.pollsRepository.deleteVote(poll.id, userId);
+    if (!removed) {
+      throw new NotFoundException('Vote not found.');
+    }
+
+    return this.buildPollResponse(poll, userId);
+  }
+
+  async closePoll(userId: string, pollId: string): Promise<PollResponseDto> {
+    const poll = await this.getAuthorizedPoll(userId, pollId);
+    if (poll.createdBy !== userId) {
+      throw new ForbiddenException('Only the poll creator can close this poll.');
+    }
+
+    if (!poll.isClosed) {
+      poll.isClosed = true;
+      await this.pollsRepository.save(poll);
+    }
+
+    return this.buildPollResponse(poll, userId);
+  }
+
+  async getPoll(userId: string, pollId: string): Promise<PollResponseDto> {
+    const poll = await this.getAuthorizedPoll(userId, pollId);
+    return this.buildPollResponse(poll, userId);
+  }
+
+  getPollResults(userId: string, pollId: string): Promise<PollResponseDto> {
+    return this.getPoll(userId, pollId);
+  }
+
+  async getPollRealtimePayload(pollId: string): Promise<PollRealtimePayloadDto> {
+    const poll = await this.getPollOrThrow(pollId);
+    await this.closePollIfExpired(poll);
+    return this.buildRealtimePayload(poll);
+  }
+
+  async getPollsInConversation(userId: string, conversationId: string): Promise<PollResponseDto[]> {
+    await this.getConversationOrThrow(conversationId);
+    await this.assertParticipant(conversationId, userId);
+
+    const polls = await this.pollsRepository.findConversationPolls(conversationId);
+    for (const poll of polls) {
+      await this.closePollIfExpired(poll);
+    }
+
+    return Promise.all(polls.map((poll) => this.buildPollResponse(poll, userId)));
+  }
+
+  async closeExpiredPolls(referenceTime = new Date()): Promise<PollRealtimePayloadDto[]> {
+    const expiredPolls = await this.pollsRepository.findExpiredOpenPolls(referenceTime);
+    if (expiredPolls.length === 0) {
+      return [];
+    }
+
+    for (const poll of expiredPolls) {
+      poll.isClosed = true;
+    }
+
+    await this.pollsRepository.save(expiredPolls);
+    return Promise.all(expiredPolls.map((poll) => this.buildRealtimePayload(poll)));
+  }
+
+  private async buildPollResponse(poll: Poll, currentUserId: string): Promise<PollResponseDto> {
+    const [aggregation, votes] = await Promise.all([
+      this.pollsRepository.getVoteAggregation(poll.id),
+      this.pollsRepository.findVotesByPoll(poll.id),
+    ]);
+
+    const votersByOption = await this.getVotersByOption(poll, aggregation);
+    const currentUserVote = votes.find((vote) => vote.userId === currentUserId) ?? null;
+
+    return {
+      id: poll.id,
+      conversationId: poll.conversationId,
+      createdBy: poll.createdBy,
+      question: poll.question,
+      options: poll.options,
+      allowMultiple: poll.allowMultiple,
+      isAnonymous: poll.isAnonymous,
+      expiresAt: poll.expiresAt,
+      isClosed: poll.isClosed,
+      createdAt: poll.createdAt,
+      totalVoters: votes.length,
+      results: poll.options.map((option, index) =>
+        this.toOptionResult(index, option, aggregation, votersByOption),
+      ),
+      currentUserVote: currentUserVote
+        ? {
+            optionIndexes: [...currentUserVote.optionIndexes].sort((left, right) => left - right),
+            votedAt: currentUserVote.votedAt,
+          }
+        : null,
+    };
+  }
+
+  private async buildRealtimePayload(poll: Poll): Promise<PollRealtimePayloadDto> {
+    const [aggregation, votes] = await Promise.all([
+      this.pollsRepository.getVoteAggregation(poll.id),
+      this.pollsRepository.findVotesByPoll(poll.id),
+    ]);
+
+    const votersByOption = await this.getVotersByOption(poll, aggregation);
+
+    return {
+      id: poll.id,
+      conversationId: poll.conversationId,
+      createdBy: poll.createdBy,
+      question: poll.question,
+      options: poll.options,
+      allowMultiple: poll.allowMultiple,
+      isAnonymous: poll.isAnonymous,
+      expiresAt: poll.expiresAt,
+      isClosed: poll.isClosed,
+      createdAt: poll.createdAt,
+      totalVoters: votes.length,
+      results: poll.options.map((option, index) =>
+        this.toOptionResult(index, option, aggregation, votersByOption),
+      ),
+    };
+  }
+
+  private async getVotersByOption(
+    poll: Poll,
+    aggregation: Array<{ optionIndex: number; voteCount: number; voterIds: string[] }>,
+  ): Promise<Map<number, PollVoterDto[]>> {
+    if (poll.isAnonymous) {
+      return new Map();
+    }
+
+    const voterIds = [...new Set(aggregation.flatMap((row) => row.voterIds))];
+    if (voterIds.length === 0) {
+      return new Map();
+    }
+
+    const users = await this.usersRepository.find({
+      where: { id: In(voterIds) },
+      select: ['id', 'username', 'displayName'],
+    });
+    const usersById = new Map(users.map((user) => [user.id, user]));
+
+    return new Map(
+      aggregation.map((row) => [
+        row.optionIndex,
+        row.voterIds
+          .map((userId) => usersById.get(userId))
+          .filter((user): user is User => Boolean(user))
+          .map((user) => ({
+            userId: user.id,
+            username: user.username,
+            displayName: user.displayName,
+          })),
+      ]),
+    );
+  }
+
+  private toOptionResult(
+    index: number,
+    text: string,
+    aggregation: Array<{ optionIndex: number; voteCount: number; voterIds: string[] }>,
+    votersByOption: Map<number, PollVoterDto[]>,
+  ): PollOptionResultDto {
+    const match = aggregation.find((row) => row.optionIndex === index);
+
+    return {
+      index,
+      text,
+      voteCount: match?.voteCount ?? 0,
+      voters: votersByOption.get(index),
+    };
+  }
+
+  private async getAuthorizedPoll(userId: string, pollId: string): Promise<Poll> {
+    const poll = await this.getPollOrThrow(pollId);
+    await this.assertParticipant(poll.conversationId, userId);
+    await this.closePollIfExpired(poll);
+    return poll;
+  }
+
+  private async getPollOrThrow(pollId: string): Promise<Poll> {
+    const poll = await this.pollsRepository.findOne({
+      where: { id: pollId },
+    });
+
+    if (!poll) {
+      throw new NotFoundException('Poll not found.');
+    }
+
+    return poll;
+  }
+
+  private async getConversationOrThrow(conversationId: string): Promise<Conversation> {
+    const conversation = await this.conversationsRepository.findOne({
+      where: { id: conversationId },
+    });
+
+    if (!conversation) {
+      throw new NotFoundException('Conversation not found.');
+    }
+
+    return conversation;
+  }
+
+  private async assertParticipant(conversationId: string, userId: string): Promise<void> {
+    const isParticipant = await this.participantsRepository.exist({
+      where: { conversationId, userId },
+    });
+
+    if (!isParticipant) {
+      throw new ForbiddenException('Not a participant in this conversation.');
+    }
+  }
+
+  private async closePollIfExpired(poll: Poll): Promise<void> {
+    if (!poll.isClosed && poll.expiresAt && poll.expiresAt.getTime() <= Date.now()) {
+      poll.isClosed = true;
+      await this.pollsRepository.save(poll);
+    }
+  }
+
+  private async assertPollOpen(poll: Poll): Promise<void> {
+    await this.closePollIfExpired(poll);
+    if (poll.isClosed) {
+      throw new BadRequestException('Poll is closed.');
+    }
+  }
+
+  private normalizeOptions(options: string[]): string[] {
+    const normalized = options.map((option) => option.trim()).filter((option) => option.length > 0);
+    if (normalized.length < 2 || normalized.length > 10) {
+      throw new BadRequestException('Poll options must contain between 2 and 10 choices.');
+    }
+
+    const uniqueOptions = new Set(normalized.map((option) => option.toLowerCase()));
+    if (uniqueOptions.size !== normalized.length) {
+      throw new BadRequestException('Poll options must be unique.');
+    }
+
+    return normalized;
+  }
+
+  private parseExpiresAt(rawExpiresAt?: string): Date | null {
+    if (!rawExpiresAt) {
+      return null;
+    }
+
+    const expiresAt = new Date(rawExpiresAt);
+    if (Number.isNaN(expiresAt.getTime())) {
+      throw new BadRequestException('Poll expiration date is invalid.');
+    }
+
+    if (expiresAt.getTime() <= Date.now()) {
+      throw new BadRequestException('Poll expiration date must be in the future.');
+    }
+
+    return expiresAt;
+  }
+
+  private normalizeVoteOptionIndexes(optionIndexes: number[], poll: Poll): number[] {
+    const uniqueIndexes = [...new Set(optionIndexes)].sort((left, right) => left - right);
+    if (uniqueIndexes.length === 0) {
+      throw new BadRequestException('At least one option must be selected.');
+    }
+
+    if (!poll.allowMultiple && uniqueIndexes.length > 1) {
+      throw new BadRequestException('This poll only allows one option per vote.');
+    }
+
+    for (const optionIndex of uniqueIndexes) {
+      if (optionIndex < 0 || optionIndex >= poll.options.length) {
+        throw new BadRequestException('Selected option is invalid.');
+      }
+    }
+
+    return uniqueIndexes;
+  }
+}

--- a/test/polls.e2e-spec.ts
+++ b/test/polls.e2e-spec.ts
@@ -1,0 +1,170 @@
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import request from 'supertest';
+import { ChatGateway } from '../src/messaging/gateways/chat.gateway';
+import { PollsController } from '../src/polls/polls.controller';
+import { PollsService } from '../src/polls/polls.service';
+
+describe('PollsController (e2e)', () => {
+  let app: INestApplication;
+  let service: jest.Mocked<PollsService>;
+  let gateway: jest.Mocked<ChatGateway>;
+
+  const pollId = '11111111-1111-1111-1111-111111111111';
+  const conversationId = '22222222-2222-2222-2222-222222222222';
+  const userId = '33333333-3333-3333-3333-333333333333';
+  const pollResponse = {
+    id: pollId,
+    conversationId,
+    createdBy: userId,
+    question: 'Best option?',
+    options: ['Alpha', 'Beta'],
+    allowMultiple: false,
+    isAnonymous: false,
+    expiresAt: null,
+    isClosed: false,
+    createdAt: '2026-03-27T09:00:00.000Z',
+    totalVoters: 1,
+    results: [
+      {
+        index: 0,
+        text: 'Alpha',
+        voteCount: 1,
+        voters: [{ userId, username: 'owner', displayName: 'Owner' }],
+      },
+      {
+        index: 1,
+        text: 'Beta',
+        voteCount: 0,
+      },
+    ],
+    currentUserVote: {
+      optionIndexes: [0],
+      votedAt: '2026-03-27T09:30:00.000Z',
+    },
+  };
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      controllers: [PollsController],
+      providers: [
+        {
+          provide: PollsService,
+          useValue: {
+            createPoll: jest.fn().mockResolvedValue(pollResponse),
+            getPollsInConversation: jest.fn().mockResolvedValue([pollResponse]),
+            getPollResults: jest.fn().mockResolvedValue(pollResponse),
+            castVote: jest.fn().mockResolvedValue(pollResponse),
+            retractVote: jest.fn().mockResolvedValue(pollResponse),
+            closePoll: jest.fn().mockResolvedValue({ ...pollResponse, isClosed: true }),
+            getPollRealtimePayload: jest.fn().mockResolvedValue({
+              ...pollResponse,
+              currentUserVote: undefined,
+            }),
+          },
+        },
+        {
+          provide: ChatGateway,
+          useValue: {
+            sendPollUpdated: jest.fn().mockResolvedValue(undefined),
+          },
+        },
+      ],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    app.setGlobalPrefix('api');
+    app.use((req: any, _res: any, next: () => void) => {
+      req.user = { id: userId };
+      next();
+    });
+    app.useGlobalPipes(
+      new ValidationPipe({
+        whitelist: true,
+        forbidNonWhitelisted: true,
+        transform: true,
+      }),
+    );
+    await app.init();
+
+    service = moduleFixture.get(PollsService);
+    gateway = moduleFixture.get(ChatGateway);
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('creates a poll', async () => {
+    await request(app.getHttpServer())
+      .post(`/api/conversations/${conversationId}/polls`)
+      .send({
+        question: 'Best option?',
+        options: ['Alpha', 'Beta'],
+        isAnonymous: false,
+      })
+      .expect(201)
+      .expect((res) => {
+        expect(res.body.id).toBe(pollId);
+        expect(res.body.options).toEqual(['Alpha', 'Beta']);
+      });
+  });
+
+  it('validates option count on poll creation', async () => {
+    await request(app.getHttpServer())
+      .post(`/api/conversations/${conversationId}/polls`)
+      .send({
+        question: 'Too short',
+        options: ['Only one'],
+      })
+      .expect(400);
+  });
+
+  it('lists polls in a conversation', async () => {
+    await request(app.getHttpServer())
+      .get(`/api/conversations/${conversationId}/polls`)
+      .expect(200)
+      .expect((res) => {
+        expect(res.body).toHaveLength(1);
+        expect(res.body[0].id).toBe(pollId);
+      });
+  });
+
+  it('gets a single poll', async () => {
+    await request(app.getHttpServer())
+      .get(`/api/polls/${pollId}`)
+      .expect(200)
+      .expect((res) => {
+        expect(res.body.question).toBe('Best option?');
+      });
+  });
+
+  it('casts a vote and emits a websocket update', async () => {
+    await request(app.getHttpServer())
+      .post(`/api/polls/${pollId}/vote`)
+      .send({ optionIndexes: [0] })
+      .expect(201)
+      .expect((res) => {
+        expect(res.body.currentUserVote.optionIndexes).toEqual([0]);
+      });
+
+    expect(service.castVote).toHaveBeenCalledWith(userId, pollId, { optionIndexes: [0] });
+    expect(gateway.sendPollUpdated).toHaveBeenCalled();
+  });
+
+  it('retracts a vote and emits a websocket update', async () => {
+    await request(app.getHttpServer()).delete(`/api/polls/${pollId}/vote`).expect(200);
+
+    expect(service.retractVote).toHaveBeenCalledWith(userId, pollId);
+    expect(gateway.sendPollUpdated).toHaveBeenCalled();
+  });
+
+  it('closes a poll', async () => {
+    await request(app.getHttpServer())
+      .post(`/api/polls/${pollId}/close`)
+      .expect(201)
+      .expect((res) => {
+        expect(res.body.isClosed).toBe(true);
+      });
+  });
+});


### PR DESCRIPTION
Implemented a new polls module with entities, repository aggregation, service logic, controller routes, realtime fanout, expiry cleanup, and tests. The core behavior lives in [polls.service.ts](app://-/index.html?hostId=local), where poll creation, vote casting/retraction, creator-only closing, anonymous result shaping, participant checks, and auto-closing of expired polls are handled. Vote aggregation is pushed into [polls.repository.ts](app://-/index.html?hostId=local) with a Postgres unnest query over optionIndexes, and the HTTP layer is in [polls.controller.ts](app://-/index.html?hostId=local) with the requested endpoints plus poll:updated websocket emission via the chat gateway.

I also added the scheduled expiry job in [polls-expiry.job.ts](app://-/index.html?hostId=local), the schema migration in [1760000000000-PollsSchema.ts](app://-/index.html?hostId=local), and focused unit/e2e coverage in [polls.service.spec.ts](app://-/index.html?hostId=local), [polls.controller.spec.ts](app://-/index.html?hostId=local), [polls-expiry.job.spec.ts](app://-/index.html?hostId=local), and [polls.e2e-spec.ts](app://-/index.html?hostId=local).

Closes #538 
Closes #556
Closes #537 
Closes #554 