### PR TITLE
feat: add conversation export functionality

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -50,8 +50,8 @@ import { BlockchainTransactionsModule } from './blockchain-transactions/blockcha
 import { MessageForwardingModule } from './message-forwarding/message-forwarding.module';
 import { PollsModule } from './polls/polls.module';
 import { MentionsModule } from './mentions/mentions.module';
-import { PollsModule } from './polls/polls.module';
 import { OnboardingModule } from './onboarding/onboarding.module';
+import { ConversationExportModule } from './conversation-export/conversation-export.module';
 
 @Module({
   imports: [
@@ -106,6 +106,7 @@ import { OnboardingModule } from './onboarding/onboarding.module';
     MessageForwardingModule,
     PollsModule,
     MentionsModule,
+    ConversationExportModule,
   ],
   controllers: [AppController],
   providers: [

--- a/src/conversation-export/conversation-export.controller.ts
+++ b/src/conversation-export/conversation-export.controller.ts
@@ -1,0 +1,98 @@
+import {
+  Body,
+  Controller,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Param,
+  Post,
+} from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiOperation,
+  ApiParam,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
+import { CurrentUser } from '../auth/decorators/current-user.decorator';
+import { LocalizedParseUUIDPipe } from '../i18n/pipes/localized-parse-uuid.pipe';
+import {
+  ConversationExportDownloadResponseDto,
+  ConversationExportJobResponseDto,
+  ConversationExportStatusResponseDto,
+  RequestConversationExportDto,
+} from './dto/conversation-export.dto';
+import { ConversationExportService } from './conversation-export.service';
+
+@ApiTags('conversations')
+@ApiBearerAuth()
+@Controller('conversations')
+export class ConversationExportController {
+  constructor(private readonly conversationExportService: ConversationExportService) {}
+
+  @Post(':id/export')
+  @HttpCode(HttpStatus.CREATED)
+  @ApiOperation({ summary: 'Queue a conversation history export job' })
+  @ApiParam({ name: 'id', description: 'Conversation UUID' })
+  @ApiResponse({ status: 201, type: ConversationExportJobResponseDto })
+  async requestExport(
+    @CurrentUser('id') userId: string,
+    @Param('id', LocalizedParseUUIDPipe) conversationId: string,
+    @Body() body: RequestConversationExportDto,
+  ): Promise<ConversationExportJobResponseDto> {
+    const job = await this.conversationExportService.requestExport(
+      userId,
+      conversationId,
+      body?.format,
+    );
+
+    return {
+      jobId: job.id,
+      status: job.status,
+      format: job.format,
+      requestedAt: job.requestedAt.toISOString(),
+    };
+  }
+
+  @Get(':id/export/:jobId')
+  @ApiOperation({ summary: 'Get status for a conversation export job' })
+  @ApiParam({ name: 'id', description: 'Conversation UUID' })
+  @ApiParam({ name: 'jobId', description: 'Conversation export job UUID' })
+  @ApiResponse({ status: 200, type: ConversationExportStatusResponseDto })
+  async getExportStatus(
+    @CurrentUser('id') userId: string,
+    @Param('id', LocalizedParseUUIDPipe) conversationId: string,
+    @Param('jobId', LocalizedParseUUIDPipe) jobId: string,
+  ): Promise<ConversationExportStatusResponseDto> {
+    const job = await this.conversationExportService.getExportStatus(userId, conversationId, jobId);
+    return {
+      jobId: job.id,
+      status: job.status,
+      format: job.format,
+      fileUrl: job.fileUrl || undefined,
+      fileSize: job.fileSize || undefined,
+      completedAt: job.completedAt ? job.completedAt.toISOString() : undefined,
+      expiresAt: job.expiresAt ? job.expiresAt.toISOString() : undefined,
+    };
+  }
+
+  @Get(':id/export/:jobId/download')
+  @ApiOperation({ summary: 'Get pre-signed URL for a completed conversation export' })
+  @ApiParam({ name: 'id', description: 'Conversation UUID' })
+  @ApiParam({ name: 'jobId', description: 'Conversation export job UUID' })
+  @ApiResponse({ status: 200, type: ConversationExportDownloadResponseDto })
+  async downloadExport(
+    @CurrentUser('id') userId: string,
+    @Param('id', LocalizedParseUUIDPipe) conversationId: string,
+    @Param('jobId', LocalizedParseUUIDPipe) jobId: string,
+  ): Promise<ConversationExportDownloadResponseDto> {
+    const job = await this.conversationExportService.downloadExport(userId, conversationId, jobId);
+
+    return {
+      url: job.fileUrl!,
+      expiresAt: job.expiresAt!.toISOString(),
+      format: job.format,
+      fileSize: job.fileSize || undefined,
+    };
+  }
+}

--- a/src/conversation-export/conversation-export.module.ts
+++ b/src/conversation-export/conversation-export.module.ts
@@ -1,0 +1,28 @@
+import { Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Attachment } from '../attachments/entities/attachment.entity';
+import { ConversationParticipant } from '../conversations/entities/conversation-participant.entity';
+import { Conversation } from '../conversations/entities/conversation.entity';
+import { Message } from '../messages/entities/message.entity';
+import { ConversationExportController } from './conversation-export.controller';
+import { ConversationExportService } from './conversation-export.service';
+import { ConversationExportJob } from './entities/conversation-export-job.entity';
+import { ConversationExportGenerator } from './services/conversation-export.generator';
+
+@Module({
+  imports: [
+    ConfigModule,
+    TypeOrmModule.forFeature([
+      ConversationExportJob,
+      Conversation,
+      ConversationParticipant,
+      Message,
+      Attachment,
+    ]),
+  ],
+  controllers: [ConversationExportController],
+  providers: [ConversationExportService, ConversationExportGenerator],
+  exports: [ConversationExportService],
+})
+export class ConversationExportModule {}

--- a/src/conversation-export/conversation-export.service.spec.ts
+++ b/src/conversation-export/conversation-export.service.spec.ts
@@ -1,0 +1,376 @@
+import { ConflictException, ForbiddenException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Test } from '@nestjs/testing';
+import { Queue } from 'bullmq';
+import { Attachment } from '../attachments/entities/attachment.entity';
+import { ConversationParticipant } from '../conversations/entities/conversation-participant.entity';
+import { Conversation } from '../conversations/entities/conversation.entity';
+import { Message } from '../messages/entities/message.entity';
+import { ConversationExportService } from './conversation-export.service';
+import {
+  ConversationExportFormat,
+  ConversationExportJob,
+  ConversationExportStatus,
+} from './entities/conversation-export-job.entity';
+import {
+  ConversationExportGenerator,
+  ConversationExportMessage,
+} from './services/conversation-export.generator';
+
+const mockQueueAdd = jest.fn();
+const mockQueueClose = jest.fn();
+const mockWorkerClose = jest.fn();
+const mockS3Send = jest.fn();
+const mockGetSignedUrl = jest.fn();
+let capturedWorkerProcessor:
+  | ((job: { data: { jobId: string } }) => Promise<void>)
+  | null = null;
+
+jest.mock('bullmq', () => ({
+  Queue: jest.fn().mockImplementation(() => ({
+    add: mockQueueAdd,
+    close: mockQueueClose,
+  })),
+  Worker: jest.fn().mockImplementation((_name: string, processor: any) => {
+    capturedWorkerProcessor = processor;
+    return {
+      close: mockWorkerClose,
+    };
+  }),
+}));
+
+jest.mock('@aws-sdk/client-s3', () => ({
+  S3Client: jest.fn().mockImplementation(() => ({
+    send: mockS3Send,
+  })),
+  PutObjectCommand: jest.fn().mockImplementation((input: unknown) => input),
+  GetObjectCommand: jest.fn().mockImplementation((input: unknown) => input),
+}));
+
+jest.mock('@aws-sdk/s3-request-presigner', () => ({
+  getSignedUrl: (...args: unknown[]) => mockGetSignedUrl(...args),
+}));
+
+describe('ConversationExportService', () => {
+  let service: ConversationExportService;
+  let exportJobsRepository: any;
+  let conversationsRepository: any;
+  let participantsRepository: any;
+  let messagesRepository: any;
+  let attachmentsRepository: any;
+  let generator: jest.Mocked<ConversationExportGenerator>;
+
+  beforeEach(async () => {
+    capturedWorkerProcessor = null;
+
+    const moduleRef = await Test.createTestingModule({
+      providers: [
+        ConversationExportService,
+        {
+          provide: ConfigService,
+          useValue: {
+            get: jest.fn().mockImplementation((key: string, fallback?: unknown) => {
+              const config: Record<string, unknown> = {
+                STORAGE_BUCKET: 'test-bucket',
+              };
+              return config[key] ?? fallback;
+            }),
+          },
+        },
+        {
+          provide: getRepositoryToken(ConversationExportJob),
+          useValue: {
+            create: jest.fn(),
+            save: jest.fn(),
+            findOne: jest.fn(),
+            createQueryBuilder: jest.fn(),
+          },
+        },
+        {
+          provide: getRepositoryToken(Conversation),
+          useValue: {
+            findOne: jest.fn(),
+          },
+        },
+        {
+          provide: getRepositoryToken(ConversationParticipant),
+          useValue: {
+            exist: jest.fn(),
+          },
+        },
+        {
+          provide: getRepositoryToken(Message),
+          useValue: {
+            find: jest.fn(),
+          },
+        },
+        {
+          provide: getRepositoryToken(Attachment),
+          useValue: {
+            createQueryBuilder: jest.fn(),
+          },
+        },
+        {
+          provide: ConversationExportGenerator,
+          useValue: {
+            generate: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    service = moduleRef.get(ConversationExportService);
+    exportJobsRepository = moduleRef.get(getRepositoryToken(ConversationExportJob));
+    conversationsRepository = moduleRef.get(getRepositoryToken(Conversation));
+    participantsRepository = moduleRef.get(getRepositoryToken(ConversationParticipant));
+    messagesRepository = moduleRef.get(getRepositoryToken(Message));
+    attachmentsRepository = moduleRef.get(getRepositoryToken(Attachment));
+    generator = moduleRef.get(ConversationExportGenerator);
+
+    mockQueueAdd.mockReset();
+    mockQueueClose.mockReset();
+    mockWorkerClose.mockReset();
+    mockS3Send.mockReset();
+    mockGetSignedUrl.mockReset();
+
+    exportJobsRepository.create.mockReset();
+    exportJobsRepository.save.mockReset();
+    exportJobsRepository.findOne.mockReset();
+    exportJobsRepository.createQueryBuilder.mockReset();
+    conversationsRepository.findOne.mockReset();
+    participantsRepository.exist.mockReset();
+    messagesRepository.find.mockReset();
+    attachmentsRepository.createQueryBuilder.mockReset();
+    generator.generate.mockReset();
+  });
+
+  it('creates and queues a new export job', async () => {
+    conversationsRepository.findOne.mockResolvedValue({ id: 'conv-1' });
+    participantsRepository.exist.mockResolvedValue(true);
+    exportJobsRepository.createQueryBuilder.mockReturnValue({
+      where: jest.fn().mockReturnThis(),
+      andWhere: jest.fn().mockReturnThis(),
+      orderBy: jest.fn().mockReturnThis(),
+      getOne: jest.fn().mockResolvedValue(null),
+    });
+
+    const created = {
+      userId: 'user-1',
+      conversationId: 'conv-1',
+      format: ConversationExportFormat.JSON,
+      status: ConversationExportStatus.PENDING,
+    };
+    exportJobsRepository.create.mockReturnValue(created);
+    exportJobsRepository.save.mockResolvedValue({
+      ...created,
+      id: 'job-1',
+      requestedAt: new Date('2026-03-28T10:00:00.000Z'),
+    });
+
+    const result = await service.requestExport('user-1', 'conv-1', ConversationExportFormat.JSON);
+
+    expect(mockQueueAdd).toHaveBeenCalledWith(
+      'generate-conversation-export',
+      { jobId: 'job-1' },
+      { jobId: 'conversation-export:job-1', timeout: 300000 },
+    );
+    expect(result.id).toBe('job-1');
+  });
+
+  it('rejects when an active export already exists', async () => {
+    conversationsRepository.findOne.mockResolvedValue({ id: 'conv-1' });
+    participantsRepository.exist.mockResolvedValue(true);
+    exportJobsRepository.createQueryBuilder.mockReturnValue({
+      where: jest.fn().mockReturnThis(),
+      andWhere: jest.fn().mockReturnThis(),
+      orderBy: jest.fn().mockReturnThis(),
+      getOne: jest.fn().mockResolvedValue({ id: 'active-job' }),
+    });
+
+    await expect(
+      service.requestExport('user-1', 'conv-1', ConversationExportFormat.TXT),
+    ).rejects.toBeInstanceOf(ConflictException);
+  });
+
+  it('returns status for owned job and expires stale READY jobs', async () => {
+    exportJobsRepository.findOne.mockResolvedValue({
+      id: 'job-1',
+      userId: 'user-1',
+      conversationId: 'conv-1',
+      status: ConversationExportStatus.READY,
+      format: ConversationExportFormat.HTML,
+      fileUrl: 'https://signed',
+      expiresAt: new Date('2026-03-27T10:00:00.000Z'),
+    });
+    exportJobsRepository.save.mockImplementation(async (job: any) => job);
+
+    const result = await service.getExportStatus('user-1', 'conv-1', 'job-1');
+
+    expect(result.status).toBe(ConversationExportStatus.EXPIRED);
+    expect(result.fileUrl).toBeNull();
+  });
+
+  it('rejects status lookup when job ownership does not match', async () => {
+    exportJobsRepository.findOne.mockResolvedValue({
+      id: 'job-1',
+      userId: 'other',
+      conversationId: 'conv-1',
+    });
+
+    await expect(service.getExportStatus('user-1', 'conv-1', 'job-1')).rejects.toBeInstanceOf(
+      ForbiddenException,
+    );
+  });
+
+  it('returns download details for READY non-expired job', async () => {
+    const expiresAt = new Date('2099-03-28T10:00:00.000Z');
+    exportJobsRepository.findOne.mockResolvedValue({
+      id: 'job-1',
+      userId: 'user-1',
+      conversationId: 'conv-1',
+      status: ConversationExportStatus.READY,
+      format: ConversationExportFormat.JSON,
+      fileUrl: 'https://signed-url',
+      fileSize: 123,
+      expiresAt,
+    });
+
+    const result = await service.downloadExport('user-1', 'conv-1', 'job-1');
+
+    expect(result.fileUrl).toBe('https://signed-url');
+    expect(result.expiresAt).toBe(expiresAt);
+  });
+
+  it('worker processes export and uploads generated file', async () => {
+    expect(capturedWorkerProcessor).toBeTruthy();
+
+    exportJobsRepository.findOne.mockResolvedValue({
+      id: 'job-1',
+      userId: 'user-1',
+      conversationId: 'conv-1',
+      format: ConversationExportFormat.JSON,
+      status: ConversationExportStatus.PENDING,
+    });
+    exportJobsRepository.save.mockImplementation(async (job: any) => job);
+
+    const messages: ConversationExportMessage[] = [
+      {
+        id: 'msg-1',
+        senderId: 'user-1',
+        type: 'text',
+        content: 'hello',
+        createdAt: new Date('2026-03-28T10:00:00.000Z'),
+        attachments: [
+          {
+            id: 'att-1',
+            fileName: 'a.png',
+            mimeType: 'image/png',
+            fileSize: 42,
+            fileUrl: 'https://cdn/a.png',
+          },
+        ],
+      },
+    ];
+    messagesRepository.find.mockResolvedValue([
+      {
+        id: 'msg-1',
+        senderId: 'user-1',
+        type: 'text',
+        content: 'hello',
+        createdAt: new Date('2026-03-28T10:00:00.000Z'),
+      },
+    ]);
+    attachmentsRepository.createQueryBuilder.mockReturnValue({
+      where: jest.fn().mockReturnThis(),
+      orderBy: jest.fn().mockReturnThis(),
+      getMany: jest.fn().mockResolvedValue([
+        {
+          id: 'att-1',
+          messageId: 'msg-1',
+          fileName: 'a.png',
+          mimeType: 'image/png',
+          fileSize: 42,
+          fileUrl: 'https://cdn/a.png',
+          createdAt: new Date('2026-03-28T10:00:00.000Z'),
+        },
+      ]),
+    });
+    generator.generate.mockImplementation(() => Buffer.from(JSON.stringify(messages), 'utf8'));
+    mockS3Send.mockResolvedValue({});
+    mockGetSignedUrl.mockResolvedValue('https://signed-export-url');
+
+    await capturedWorkerProcessor!({ data: { jobId: 'job-1' } });
+
+    expect(generator.generate).toHaveBeenCalled();
+    expect(mockS3Send).toHaveBeenCalled();
+    expect(exportJobsRepository.save).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 'job-1',
+        status: ConversationExportStatus.READY,
+        fileUrl: 'https://signed-export-url',
+      }),
+    );
+  });
+
+  it('cleanup marks expired READY jobs as EXPIRED', async () => {
+    exportJobsRepository.createQueryBuilder.mockReturnValue({
+      where: jest.fn().mockReturnThis(),
+      andWhere: jest.fn().mockReturnThis(),
+      getMany: jest.fn().mockResolvedValue([
+        {
+          id: 'job-1',
+          status: ConversationExportStatus.READY,
+          fileUrl: 'https://signed',
+        },
+      ]),
+    });
+    exportJobsRepository.save.mockImplementation(async (job: any) => job);
+
+    const cleaned = await service.cleanupExpired();
+
+    expect(cleaned).toBe(1);
+    expect(exportJobsRepository.save).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 'job-1',
+        status: ConversationExportStatus.EXPIRED,
+        fileUrl: null,
+      }),
+    );
+  });
+
+  it('closes queue resources on module destroy', async () => {
+    await service.onModuleDestroy();
+
+    expect(mockWorkerClose).toHaveBeenCalled();
+    expect(mockQueueClose).toHaveBeenCalled();
+  });
+
+  it('sets default format when undefined', async () => {
+    conversationsRepository.findOne.mockResolvedValue({ id: 'conv-1' });
+    participantsRepository.exist.mockResolvedValue(true);
+    exportJobsRepository.createQueryBuilder.mockReturnValue({
+      where: jest.fn().mockReturnThis(),
+      andWhere: jest.fn().mockReturnThis(),
+      orderBy: jest.fn().mockReturnThis(),
+      getOne: jest.fn().mockResolvedValue(null),
+    });
+    exportJobsRepository.create.mockImplementation((payload: any) => payload);
+    exportJobsRepository.save.mockImplementation(async (payload: any) => ({
+      ...payload,
+      id: 'job-default',
+      requestedAt: new Date(),
+    }));
+
+    await service.requestExport('user-1', 'conv-1', undefined as unknown as ConversationExportFormat);
+
+    expect(exportJobsRepository.create).toHaveBeenCalledWith(
+      expect.objectContaining({ format: ConversationExportFormat.JSON }),
+    );
+  });
+
+  it('uses configured queue name and worker wiring', () => {
+    expect(Queue).toHaveBeenCalled();
+    expect(capturedWorkerProcessor).toBeTruthy();
+  });
+});

--- a/src/conversation-export/conversation-export.service.ts
+++ b/src/conversation-export/conversation-export.service.ts
@@ -1,0 +1,404 @@
+import {
+  BadRequestException,
+  ConflictException,
+  ForbiddenException,
+  Injectable,
+  Logger,
+  NotFoundException,
+  OnModuleDestroy,
+} from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { InjectRepository } from '@nestjs/typeorm';
+import {
+  GetObjectCommand,
+  PutObjectCommand,
+  S3Client,
+} from '@aws-sdk/client-s3';
+import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
+import { Queue, Worker } from 'bullmq';
+import { Repository } from 'typeorm';
+import { Attachment } from '../attachments/entities/attachment.entity';
+import { ConversationParticipant } from '../conversations/entities/conversation-participant.entity';
+import { Conversation } from '../conversations/entities/conversation.entity';
+import { Message } from '../messages/entities/message.entity';
+import {
+  ConversationExportFormat,
+  ConversationExportJob,
+  ConversationExportStatus,
+} from './entities/conversation-export-job.entity';
+import {
+  ConversationExportGenerator,
+  ConversationExportMessage,
+} from './services/conversation-export.generator';
+
+interface ExportWorkerJob {
+  jobId: string;
+}
+
+const CONVERSATION_EXPORT_QUEUE = 'conversation-exports';
+const EXPORT_JOB_NAME = 'generate-conversation-export';
+const EXPORT_URL_TTL_SECONDS = 48 * 60 * 60;
+const MAX_MESSAGES = 50000;
+
+@Injectable()
+export class ConversationExportService implements OnModuleDestroy {
+  private readonly logger = new Logger(ConversationExportService.name);
+  private readonly queue: Queue<ExportWorkerJob>;
+  private readonly worker: Worker<ExportWorkerJob>;
+  private readonly s3Client: S3Client;
+  private readonly bucket: string;
+
+  constructor(
+    private readonly configService: ConfigService,
+    @InjectRepository(ConversationExportJob)
+    private readonly exportJobsRepository: Repository<ConversationExportJob>,
+    @InjectRepository(Conversation)
+    private readonly conversationsRepository: Repository<Conversation>,
+    @InjectRepository(ConversationParticipant)
+    private readonly participantsRepository: Repository<ConversationParticipant>,
+    @InjectRepository(Message)
+    private readonly messagesRepository: Repository<Message>,
+    @InjectRepository(Attachment)
+    private readonly attachmentsRepository: Repository<Attachment>,
+    private readonly generator: ConversationExportGenerator,
+  ) {
+    const connection = {
+      host: this.configService.get<string>('REDIS_HOST', 'localhost'),
+      port: this.configService.get<number>('REDIS_PORT', 6379),
+      password: this.configService.get<string>('REDIS_PASSWORD') || undefined,
+      db: this.configService.get<number>('REDIS_DB', 0),
+      maxRetriesPerRequest: null as number | null,
+    };
+
+    this.queue = new Queue<ExportWorkerJob>(CONVERSATION_EXPORT_QUEUE, {
+      connection,
+      defaultJobOptions: {
+        attempts: 3,
+        backoff: { type: 'exponential', delay: 1000 },
+        removeOnComplete: false,
+        removeOnFail: false,
+      },
+    });
+    this.worker = new Worker<ExportWorkerJob>(
+      CONVERSATION_EXPORT_QUEUE,
+      async (job: { data: ExportWorkerJob }) => this.processExport(job.data.jobId),
+      { connection },
+    );
+
+    const region = this.configService.get<string>('STORAGE_REGION', 'auto');
+    const endpoint = this.configService.get<string>('STORAGE_ENDPOINT');
+    const accessKeyId =
+      this.configService.get<string>('STORAGE_ACCESS_KEY_ID') ||
+      this.configService.get<string>('S3_ACCESS_KEY_ID');
+    const secretAccessKey =
+      this.configService.get<string>('STORAGE_SECRET_ACCESS_KEY') ||
+      this.configService.get<string>('S3_SECRET_ACCESS_KEY');
+
+    this.s3Client = new S3Client({
+      region,
+      endpoint,
+      forcePathStyle: this.configService.get<string>('STORAGE_PROVIDER') === 'r2',
+      credentials:
+        accessKeyId && secretAccessKey
+          ? {
+              accessKeyId,
+              secretAccessKey,
+            }
+          : undefined,
+    });
+
+    this.bucket =
+      this.configService.get<string>('STORAGE_BUCKET') ||
+      this.configService.get<string>('S3_BUCKET') ||
+      '';
+  }
+
+  async onModuleDestroy(): Promise<void> {
+    await this.worker.close();
+    await this.queue.close();
+  }
+
+  async requestExport(
+    userId: string,
+    conversationId: string,
+    format?: ConversationExportFormat,
+  ): Promise<ConversationExportJob> {
+    await this.ensureUserCanAccessConversation(userId, conversationId);
+
+    const active = await this.findActiveJob(userId, conversationId);
+    if (active) {
+      throw new ConflictException('An active export job already exists for this conversation');
+    }
+
+    const job = this.exportJobsRepository.create({
+      userId,
+      conversationId,
+      format: format ?? ConversationExportFormat.JSON,
+      status: ConversationExportStatus.PENDING,
+      fileUrl: null,
+      fileKey: null,
+      fileSize: null,
+      completedAt: null,
+      expiresAt: null,
+    });
+
+    const saved = await this.exportJobsRepository.save(job);
+
+    await this.queue.add(
+      EXPORT_JOB_NAME,
+      { jobId: saved.id },
+      {
+        jobId: `conversation-export:${saved.id}`,
+        timeout: 5 * 60 * 1000,
+      },
+    );
+
+    return saved;
+  }
+
+  async getExportStatus(
+    userId: string,
+    conversationId: string,
+    jobId: string,
+  ): Promise<ConversationExportJob> {
+    const job = await this.getOwnedJobOrThrow(userId, conversationId, jobId);
+
+    if (
+      job.status === ConversationExportStatus.READY &&
+      job.expiresAt &&
+      job.expiresAt <= new Date()
+    ) {
+      job.status = ConversationExportStatus.EXPIRED;
+      job.fileUrl = null;
+      await this.exportJobsRepository.save(job);
+    }
+
+    return job;
+  }
+
+  async downloadExport(
+    userId: string,
+    conversationId: string,
+    jobId: string,
+  ): Promise<ConversationExportJob> {
+    const job = await this.getOwnedJobOrThrow(userId, conversationId, jobId);
+
+    if (job.status !== ConversationExportStatus.READY) {
+      throw new BadRequestException('Export is not ready yet');
+    }
+
+    if (!job.fileUrl || !job.expiresAt || job.expiresAt <= new Date()) {
+      job.status = ConversationExportStatus.EXPIRED;
+      job.fileUrl = null;
+      await this.exportJobsRepository.save(job);
+      throw new BadRequestException('Export link has expired. Request a new export');
+    }
+
+    return job;
+  }
+
+  async processExport(jobId: string): Promise<void> {
+    const exportJob = await this.exportJobsRepository.findOne({ where: { id: jobId } });
+    if (!exportJob) {
+      this.logger.warn(`Conversation export job not found: ${jobId}`);
+      return;
+    }
+
+    exportJob.status = ConversationExportStatus.PROCESSING;
+    await this.exportJobsRepository.save(exportJob);
+
+    try {
+      const messages = await this.fetchConversationMessages(exportJob.conversationId);
+      const payload = this.generator.generate(exportJob.conversationId, messages, exportJob.format);
+      const fileKey = this.buildFileKey(exportJob.userId, exportJob.conversationId, exportJob.id, exportJob.format);
+
+      await this.uploadFile(fileKey, payload, this.getMimeType(exportJob.format));
+      const signed = await this.createDownloadUrl(fileKey, EXPORT_URL_TTL_SECONDS);
+
+      exportJob.status = ConversationExportStatus.READY;
+      exportJob.fileKey = fileKey;
+      exportJob.fileUrl = signed.url;
+      exportJob.fileSize = payload.byteLength;
+      exportJob.completedAt = new Date();
+      exportJob.expiresAt = signed.expiresAt;
+      await this.exportJobsRepository.save(exportJob);
+    } catch (error) {
+      this.logger.error(`Failed processing conversation export ${jobId}: ${String(error)}`);
+      exportJob.status = ConversationExportStatus.EXPIRED;
+      exportJob.fileUrl = null;
+      exportJob.fileKey = null;
+      exportJob.fileSize = null;
+      exportJob.completedAt = new Date();
+      exportJob.expiresAt = new Date();
+      await this.exportJobsRepository.save(exportJob);
+      throw error;
+    }
+  }
+
+  async cleanupExpired(): Promise<number> {
+    const now = new Date();
+    const expiredReadyJobs = await this.exportJobsRepository
+      .createQueryBuilder('job')
+      .where('job.status = :ready', { ready: ConversationExportStatus.READY })
+      .andWhere('job.expiresAt IS NOT NULL')
+      .andWhere('job.expiresAt <= :now', { now })
+      .getMany();
+
+    for (const job of expiredReadyJobs) {
+      job.status = ConversationExportStatus.EXPIRED;
+      job.fileUrl = null;
+      await this.exportJobsRepository.save(job);
+    }
+
+    return expiredReadyJobs.length;
+  }
+
+  private async getOwnedJobOrThrow(
+    userId: string,
+    conversationId: string,
+    jobId: string,
+  ): Promise<ConversationExportJob> {
+    const job = await this.exportJobsRepository.findOne({ where: { id: jobId } });
+    if (!job) {
+      throw new NotFoundException('Export job not found');
+    }
+
+    if (job.userId !== userId || job.conversationId !== conversationId) {
+      throw new ForbiddenException('Export job does not belong to this user or conversation');
+    }
+
+    return job;
+  }
+
+  private async ensureUserCanAccessConversation(userId: string, conversationId: string): Promise<void> {
+    const conversation = await this.conversationsRepository.findOne({ where: { id: conversationId } });
+    if (!conversation) {
+      throw new NotFoundException('Conversation not found');
+    }
+
+    const isParticipant = await this.participantsRepository.exist({
+      where: { userId, conversationId },
+    });
+
+    if (!isParticipant) {
+      throw new ForbiddenException('You are not a participant in this conversation');
+    }
+  }
+
+  private async findActiveJob(userId: string, conversationId: string): Promise<ConversationExportJob | null> {
+    const now = new Date();
+    return this.exportJobsRepository
+      .createQueryBuilder('job')
+      .where('job.userId = :userId', { userId })
+      .andWhere('job.conversationId = :conversationId', { conversationId })
+      .andWhere(
+        '(job.status IN (:...activeStatuses) OR (job.status = :readyStatus AND job.expiresAt > :now))',
+        {
+          activeStatuses: [ConversationExportStatus.PENDING, ConversationExportStatus.PROCESSING],
+          readyStatus: ConversationExportStatus.READY,
+          now,
+        },
+      )
+      .orderBy('job.requestedAt', 'DESC')
+      .getOne();
+  }
+
+  private async fetchConversationMessages(conversationId: string): Promise<ConversationExportMessage[]> {
+    const messages: Message[] = await this.messagesRepository.find({
+      where: { conversationId },
+      order: { createdAt: 'ASC' },
+      take: MAX_MESSAGES,
+    });
+
+    if (messages.length === 0) {
+      return [];
+    }
+
+    const messageIds = messages.map((message: Message) => message.id);
+    const attachments: Attachment[] = await this.attachmentsRepository
+      .createQueryBuilder('attachment')
+      .where('attachment.messageId IN (:...messageIds)', { messageIds })
+      .orderBy('attachment.createdAt', 'ASC')
+      .getMany();
+
+    const byMessageId = new Map<string, Attachment[]>();
+    for (const attachment of attachments) {
+      const current = byMessageId.get(attachment.messageId) || [];
+      current.push(attachment);
+      byMessageId.set(attachment.messageId, current);
+    }
+
+    return messages.map((message: Message) => ({
+      id: message.id,
+      senderId: message.senderId,
+      type: message.type,
+      content: message.content,
+      createdAt: message.createdAt,
+      attachments: (byMessageId.get(message.id) || []).map((attachment: Attachment) => ({
+        id: attachment.id,
+        fileName: attachment.fileName,
+        mimeType: attachment.mimeType,
+        fileSize: attachment.fileSize,
+        fileUrl: attachment.fileUrl,
+      })),
+    }));
+  }
+
+  private buildFileKey(
+    userId: string,
+    conversationId: string,
+    exportJobId: string,
+    format: ConversationExportFormat,
+  ): string {
+    const ext = format.toLowerCase();
+    return `exports/conversations/${userId}/${conversationId}/${exportJobId}.${ext}`;
+  }
+
+  private getMimeType(format: ConversationExportFormat): string {
+    if (format === ConversationExportFormat.TXT) {
+      return 'text/plain; charset=utf-8';
+    }
+    if (format === ConversationExportFormat.HTML) {
+      return 'text/html; charset=utf-8';
+    }
+    return 'application/json; charset=utf-8';
+  }
+
+  private async uploadFile(fileKey: string, body: Buffer, contentType: string): Promise<void> {
+    if (!this.bucket) {
+      throw new BadRequestException('Storage bucket is not configured');
+    }
+
+    await this.s3Client.send(
+      new PutObjectCommand({
+        Bucket: this.bucket,
+        Key: fileKey,
+        Body: body,
+        ContentType: contentType,
+      }),
+    );
+  }
+
+  private async createDownloadUrl(
+    fileKey: string,
+    expiresInSeconds: number,
+  ): Promise<{ url: string; expiresAt: Date }> {
+    if (!this.bucket) {
+      throw new BadRequestException('Storage bucket is not configured');
+    }
+
+    const url = await getSignedUrl(
+      this.s3Client,
+      new GetObjectCommand({
+        Bucket: this.bucket,
+        Key: fileKey,
+      }),
+      { expiresIn: expiresInSeconds },
+    );
+
+    return {
+      url,
+      expiresAt: new Date(Date.now() + expiresInSeconds * 1000),
+    };
+  }
+}

--- a/src/conversation-export/dto/conversation-export.dto.ts
+++ b/src/conversation-export/dto/conversation-export.dto.ts
@@ -1,0 +1,64 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsEnum, IsOptional } from 'class-validator';
+import {
+  ConversationExportFormat,
+  ConversationExportStatus,
+} from '../entities/conversation-export-job.entity';
+
+export class RequestConversationExportDto {
+  @ApiPropertyOptional({ enum: ConversationExportFormat, default: ConversationExportFormat.JSON })
+  @IsOptional()
+  @IsEnum(ConversationExportFormat)
+  format?: ConversationExportFormat;
+}
+
+export class ConversationExportJobResponseDto {
+  @ApiProperty()
+  jobId!: string;
+
+  @ApiProperty({ enum: ConversationExportStatus })
+  status!: ConversationExportStatus;
+
+  @ApiProperty({ enum: ConversationExportFormat })
+  format!: ConversationExportFormat;
+
+  @ApiProperty()
+  requestedAt!: string;
+}
+
+export class ConversationExportStatusResponseDto {
+  @ApiProperty()
+  jobId!: string;
+
+  @ApiProperty({ enum: ConversationExportStatus })
+  status!: ConversationExportStatus;
+
+  @ApiProperty({ enum: ConversationExportFormat })
+  format!: ConversationExportFormat;
+
+  @ApiPropertyOptional()
+  fileUrl?: string;
+
+  @ApiPropertyOptional()
+  fileSize?: number;
+
+  @ApiPropertyOptional()
+  completedAt?: string;
+
+  @ApiPropertyOptional()
+  expiresAt?: string;
+}
+
+export class ConversationExportDownloadResponseDto {
+  @ApiProperty()
+  url!: string;
+
+  @ApiProperty()
+  expiresAt!: string;
+
+  @ApiProperty({ enum: ConversationExportFormat })
+  format!: ConversationExportFormat;
+
+  @ApiPropertyOptional()
+  fileSize?: number;
+}

--- a/src/conversation-export/entities/conversation-export-job.entity.ts
+++ b/src/conversation-export/entities/conversation-export-job.entity.ts
@@ -1,0 +1,71 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+  Index,
+} from 'typeorm';
+
+export enum ConversationExportFormat {
+  TXT = 'TXT',
+  JSON = 'JSON',
+  HTML = 'HTML',
+}
+
+export enum ConversationExportStatus {
+  PENDING = 'PENDING',
+  PROCESSING = 'PROCESSING',
+  READY = 'READY',
+  EXPIRED = 'EXPIRED',
+}
+
+@Entity('conversation_export_jobs')
+export class ConversationExportJob {
+  @PrimaryGeneratedColumn('uuid')
+  id!: string;
+
+  @Column({ type: 'uuid' })
+  @Index('idx_conversation_export_jobs_user_id')
+  userId!: string;
+
+  @Column({ type: 'uuid' })
+  @Index('idx_conversation_export_jobs_conversation_id')
+  conversationId!: string;
+
+  @Column({
+    type: 'enum',
+    enum: ConversationExportFormat,
+    default: ConversationExportFormat.JSON,
+  })
+  format!: ConversationExportFormat;
+
+  @Column({
+    type: 'enum',
+    enum: ConversationExportStatus,
+    default: ConversationExportStatus.PENDING,
+  })
+  @Index('idx_conversation_export_jobs_status')
+  status!: ConversationExportStatus;
+
+  @Column({ type: 'text', nullable: true })
+  fileUrl!: string | null;
+
+  @Column({ type: 'varchar', length: 512, nullable: true })
+  fileKey!: string | null;
+
+  @Column({ type: 'bigint', nullable: true })
+  fileSize!: number | null;
+
+  @CreateDateColumn({ type: 'timestamp' })
+  requestedAt!: Date;
+
+  @Column({ type: 'timestamp', nullable: true })
+  completedAt!: Date | null;
+
+  @Column({ type: 'timestamp', nullable: true })
+  expiresAt!: Date | null;
+
+  @UpdateDateColumn({ type: 'timestamp' })
+  updatedAt!: Date;
+}

--- a/src/conversation-export/services/conversation-export.generator.spec.ts
+++ b/src/conversation-export/services/conversation-export.generator.spec.ts
@@ -1,0 +1,52 @@
+import { ConversationExportFormat } from '../entities/conversation-export-job.entity';
+import {
+  ConversationExportGenerator,
+  ConversationExportMessage,
+} from './conversation-export.generator';
+
+describe('ConversationExportGenerator', () => {
+  const generator = new ConversationExportGenerator();
+
+  const messages: ConversationExportMessage[] = [
+    {
+      id: 'm1',
+      senderId: 'u1',
+      type: 'text',
+      content: 'Hello world',
+      createdAt: new Date('2026-03-28T12:00:00.000Z'),
+      attachments: [
+        {
+          id: 'a1',
+          fileName: 'photo.png',
+          mimeType: 'image/png',
+          fileSize: 1024,
+          fileUrl: 'https://cdn.example.com/photo.png',
+        },
+      ],
+    },
+  ];
+
+  it('generates TXT export in WhatsApp-style line format', () => {
+    const output = generator.generate('conv-1', messages, ConversationExportFormat.TXT).toString('utf8');
+
+    expect(output).toContain('[2026-03-28 12:00:00.000 UTC] u1: Hello world');
+    expect(output).toContain('[Attachment] photo.png (image/png) https://cdn.example.com/photo.png');
+  });
+
+  it('generates JSON export with metadata and message array', () => {
+    const output = generator.generate('conv-1', messages, ConversationExportFormat.JSON).toString('utf8');
+    const parsed = JSON.parse(output);
+
+    expect(parsed.conversationId).toBe('conv-1');
+    expect(parsed.messageCount).toBe(1);
+    expect(parsed.messages[0].attachments[0].fileUrl).toBe('https://cdn.example.com/photo.png');
+  });
+
+  it('generates HTML export with bubble layout and attachment links', () => {
+    const output = generator.generate('conv-1', messages, ConversationExportFormat.HTML).toString('utf8');
+
+    expect(output).toContain('<!doctype html>');
+    expect(output).toContain('class="bubble"');
+    expect(output).toContain('https://cdn.example.com/photo.png');
+  });
+});

--- a/src/conversation-export/services/conversation-export.generator.ts
+++ b/src/conversation-export/services/conversation-export.generator.ts
@@ -1,0 +1,134 @@
+import { Injectable } from '@nestjs/common';
+import { ConversationExportFormat } from '../entities/conversation-export-job.entity';
+
+export interface ConversationExportMessage {
+  id: string;
+  senderId: string | null;
+  type: string;
+  content: string;
+  createdAt: Date;
+  attachments: Array<{
+    id: string;
+    fileName: string;
+    mimeType: string;
+    fileSize: number;
+    fileUrl: string;
+  }>;
+}
+
+@Injectable()
+export class ConversationExportGenerator {
+  generate(
+    conversationId: string,
+    messages: ConversationExportMessage[],
+    format: ConversationExportFormat,
+  ): Buffer {
+    if (format === ConversationExportFormat.TXT) {
+      return Buffer.from(this.renderTxt(messages), 'utf8');
+    }
+    if (format === ConversationExportFormat.HTML) {
+      return Buffer.from(this.renderHtml(conversationId, messages), 'utf8');
+    }
+    return Buffer.from(this.renderJson(conversationId, messages), 'utf8');
+  }
+
+  private renderTxt(messages: ConversationExportMessage[]): string {
+    const lines: string[] = [];
+    for (const message of messages) {
+      const ts = this.formatTimestamp(message.createdAt);
+      const sender = message.senderId ?? 'system';
+      lines.push(`[${ts}] ${sender}: ${message.content}`);
+      if (message.attachments.length > 0) {
+        for (const attachment of message.attachments) {
+          lines.push(`  [Attachment] ${attachment.fileName} (${attachment.mimeType}) ${attachment.fileUrl}`);
+        }
+      }
+    }
+    return lines.join('\n');
+  }
+
+  private renderJson(conversationId: string, messages: ConversationExportMessage[]): string {
+    return JSON.stringify(
+      {
+        conversationId,
+        exportedAt: new Date().toISOString(),
+        messageCount: messages.length,
+        messages: messages.map((message) => ({
+          id: message.id,
+          senderId: message.senderId,
+          type: message.type,
+          content: message.content,
+          createdAt: message.createdAt.toISOString(),
+          attachments: message.attachments.map((attachment) => ({
+            id: attachment.id,
+            fileName: attachment.fileName,
+            mimeType: attachment.mimeType,
+            fileSize: attachment.fileSize,
+            fileUrl: attachment.fileUrl,
+          })),
+        })),
+      },
+      null,
+      2,
+    );
+  }
+
+  private renderHtml(conversationId: string, messages: ConversationExportMessage[]): string {
+    const rows = messages
+      .map((message) => {
+        const sender = this.escapeHtml(message.senderId ?? 'system');
+        const content = this.escapeHtml(message.content);
+        const timestamp = this.formatTimestamp(message.createdAt);
+        const attachmentHtml =
+          message.attachments.length === 0
+            ? ''
+            : `<div class="attachments">${message.attachments
+                .map(
+                  (attachment) =>
+                    `<a href="${this.escapeHtml(attachment.fileUrl)}" target="_blank" rel="noopener noreferrer">${this.escapeHtml(attachment.fileName)}</a>`,
+                )
+                .join('<br/>')}</div>`;
+        return `<div class="bubble"><div class="meta">${sender} • ${timestamp}</div><div class="content">${content}</div>${attachmentHtml}</div>`;
+      })
+      .join('');
+
+    return `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Conversation Export</title>
+    <style>
+      body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; background: #f5f7fb; margin: 0; }
+      .wrap { max-width: 880px; margin: 0 auto; padding: 24px; }
+      h1 { font-size: 20px; margin: 0 0 20px; color: #1b2430; }
+      .bubble { background: #fff; border: 1px solid #dfe5ef; border-radius: 16px; padding: 12px 14px; margin-bottom: 10px; box-shadow: 0 1px 2px rgba(0,0,0,0.04); }
+      .meta { font-size: 12px; color: #607089; margin-bottom: 6px; }
+      .content { font-size: 14px; color: #18212f; white-space: pre-wrap; }
+      .attachments { margin-top: 8px; font-size: 13px; }
+      .attachments a { color: #1a73e8; text-decoration: none; }
+      .attachments a:hover { text-decoration: underline; }
+    </style>
+  </head>
+  <body>
+    <div class="wrap">
+      <h1>Conversation ${this.escapeHtml(conversationId)}</h1>
+      ${rows}
+    </div>
+  </body>
+</html>`;
+  }
+
+  private formatTimestamp(value: Date): string {
+    return value.toISOString().replace('T', ' ').replace('Z', ' UTC');
+  }
+
+  private escapeHtml(value: string): string {
+    return value
+      .replaceAll('&', '&amp;')
+      .replaceAll('<', '&lt;')
+      .replaceAll('>', '&gt;')
+      .replaceAll('"', '&quot;')
+      .replaceAll("'", '&#39;');
+  }
+}

--- a/src/migrations/1745000000000-ConversationExportJobsSchema.ts
+++ b/src/migrations/1745000000000-ConversationExportJobsSchema.ts
@@ -1,0 +1,49 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class ConversationExportJobsSchema1745000000000 implements MigrationInterface {
+  name = 'ConversationExportJobsSchema1745000000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE "conversation_export_jobs" (
+        "id" uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
+        "userId" uuid NOT NULL,
+        "conversationId" uuid NOT NULL,
+        "format" varchar(16) NOT NULL,
+        "status" varchar(16) NOT NULL DEFAULT 'PENDING',
+        "fileUrl" text,
+        "fileKey" varchar(512),
+        "fileSize" bigint,
+        "requestedAt" TIMESTAMP NOT NULL DEFAULT now(),
+        "completedAt" TIMESTAMP,
+        "expiresAt" TIMESTAMP,
+        "updatedAt" TIMESTAMP NOT NULL DEFAULT now(),
+        CONSTRAINT "fk_conversation_export_jobs_user"
+          FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE CASCADE,
+        CONSTRAINT "fk_conversation_export_jobs_conversation"
+          FOREIGN KEY ("conversationId") REFERENCES "conversations"("id") ON DELETE CASCADE
+      )
+    `);
+
+    await queryRunner.query(
+      `CREATE INDEX "idx_conversation_export_jobs_user_id" ON "conversation_export_jobs"("userId")`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "idx_conversation_export_jobs_conversation_id" ON "conversation_export_jobs"("conversationId")`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "idx_conversation_export_jobs_status" ON "conversation_export_jobs"("status")`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "idx_conversation_export_jobs_requested_at" ON "conversation_export_jobs"("requestedAt")`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX "idx_conversation_export_jobs_requested_at"`);
+    await queryRunner.query(`DROP INDEX "idx_conversation_export_jobs_status"`);
+    await queryRunner.query(`DROP INDEX "idx_conversation_export_jobs_conversation_id"`);
+    await queryRunner.query(`DROP INDEX "idx_conversation_export_jobs_user_id"`);
+    await queryRunner.query(`DROP TABLE "conversation_export_jobs"`);
+  }
+}


### PR DESCRIPTION
## Summary
Adds a new Conversation Export module so users can export conversation history in TXT, JSON, or HTML format.

## What Changed
- Added Conversation Export API endpoints:
  - `POST /conversations/:id/export`
  - `GET /conversations/:id/export/:jobId`
  - `GET /conversations/:id/export/:jobId/download`
- Implemented queued export processing with BullMQ.
- Added export job persistence (`conversation_export_jobs`) with status and expiry tracking.
- Added output generators for TXT (timestamped plain text), JSON (structured payload), and HTML (styled chat layout).
- Added S3/R2 upload and 48-hour pre-signed download URLs.
- Added unit tests for service flow and format generation.

## Issue Link
- Closes #580 
