### PR TITLE
feat: implement address book module with CRUD operations for saved addresses

### DIFF
--- a/src/address-book/address-book.module.ts
+++ b/src/address-book/address-book.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { SavedAddressesController } from './saved-addresses.controller';
+import { SavedAddressesRepository } from './saved-addresses.repository';
+import { SavedAddressesService } from './saved-addresses.service';
+import { SavedAddress } from './entities/saved-address.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([SavedAddress])],
+  controllers: [SavedAddressesController],
+  providers: [SavedAddressesService, SavedAddressesRepository],
+  exports: [SavedAddressesService],
+})
+export class AddressBookModule {}

--- a/src/address-book/dto/saved-address.dto.ts
+++ b/src/address-book/dto/saved-address.dto.ts
@@ -1,0 +1,118 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { Transform } from 'class-transformer';
+import {
+  IsArray,
+  IsBoolean,
+  IsEnum,
+  IsOptional,
+  IsString,
+  MaxLength,
+  Matches,
+} from 'class-validator';
+import { WalletNetwork } from '../../wallets/entities/wallet.entity';
+
+const STELLAR_ADDRESS_REGEX = /^[GC][A-Z2-7]{55}$/;
+
+export class CreateSavedAddressDto {
+  @ApiProperty({ description: 'Stellar wallet address (56 chars, G... or C...)' })
+  @IsString()
+  @Matches(STELLAR_ADDRESS_REGEX, {
+    message: 'walletAddress must be a valid 56-char Stellar address starting with G or C',
+  })
+  walletAddress!: string;
+
+  @ApiProperty({ description: 'Payment alias, unique per user (case-insensitive)' })
+  @IsString()
+  @MaxLength(64)
+  alias!: string;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsString()
+  avatarUrl?: string;
+
+  @ApiPropertyOptional({ enum: WalletNetwork, default: WalletNetwork.STELLAR_MAINNET })
+  @IsOptional()
+  @IsEnum(WalletNetwork)
+  network?: WalletNetwork;
+
+  @ApiPropertyOptional({ type: [String] })
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  tags?: string[];
+}
+
+export class UpdateSavedAddressDto {
+  @ApiPropertyOptional({ description: 'Alias unique per user (case-insensitive)' })
+  @IsOptional()
+  @IsString()
+  @MaxLength(64)
+  alias?: string;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsString()
+  avatarUrl?: string;
+
+  @ApiPropertyOptional({ enum: WalletNetwork })
+  @IsOptional()
+  @IsEnum(WalletNetwork)
+  network?: WalletNetwork;
+
+  @ApiPropertyOptional({ type: [String] })
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  tags?: string[];
+}
+
+export class SearchSavedAddressesDto {
+  @ApiPropertyOptional({ description: 'Search by alias, address substring, or tag' })
+  @IsOptional()
+  @IsString()
+  q?: string;
+
+  @ApiPropertyOptional({ description: 'Filter by single tag' })
+  @IsOptional()
+  @IsString()
+  tag?: string;
+
+  @ApiPropertyOptional({ description: 'Autocomplete mode sorted by usage frequency', default: false })
+  @IsOptional()
+  @Transform(({ value }: { value: unknown }) => value === true || value === 'true')
+  @IsBoolean()
+  suggest?: boolean;
+}
+
+export class SavedAddressResponseDto {
+  @ApiProperty()
+  id!: string;
+
+  @ApiProperty()
+  userId!: string;
+
+  @ApiProperty()
+  walletAddress!: string;
+
+  @ApiProperty()
+  alias!: string;
+
+  @ApiPropertyOptional()
+  avatarUrl?: string | null;
+
+  @ApiProperty({ enum: WalletNetwork })
+  network!: WalletNetwork;
+
+  @ApiProperty({ type: [String] })
+  tags!: string[];
+
+  @ApiPropertyOptional()
+  lastUsedAt?: Date | null;
+
+  @ApiProperty()
+  usageCount!: number;
+
+  @ApiProperty()
+  createdAt!: Date;
+}

--- a/src/address-book/entities/saved-address.entity.ts
+++ b/src/address-book/entities/saved-address.entity.ts
@@ -1,0 +1,54 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  Index,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+import { User } from '../../users/entities/user.entity';
+import { WalletNetwork } from '../../wallets/entities/wallet.entity';
+
+@Entity('saved_addresses')
+export class SavedAddress {
+  @PrimaryGeneratedColumn('uuid')
+  id!: string;
+
+  @Column({ type: 'uuid' })
+  @Index('idx_saved_addresses_user_id')
+  userId!: string;
+
+  @ManyToOne(() => User, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'userId' })
+  user!: User;
+
+  @Column({ type: 'varchar', length: 56 })
+  @Index('idx_saved_addresses_wallet_address')
+  walletAddress!: string;
+
+  @Column({ type: 'varchar', length: 64 })
+  alias!: string;
+
+  @Column({ type: 'text', nullable: true })
+  avatarUrl!: string | null;
+
+  @Column({
+    type: 'enum',
+    enum: WalletNetwork,
+    default: WalletNetwork.STELLAR_MAINNET,
+  })
+  network!: WalletNetwork;
+
+  @Column({ type: 'text', array: true, default: '{}' })
+  tags!: string[];
+
+  @Column({ type: 'timestamp', nullable: true })
+  lastUsedAt!: Date | null;
+
+  @Column({ type: 'integer', default: 0 })
+  usageCount!: number;
+
+  @CreateDateColumn({ type: 'timestamp' })
+  createdAt!: Date;
+}

--- a/src/address-book/saved-addresses.controller.ts
+++ b/src/address-book/saved-addresses.controller.ts
@@ -1,0 +1,89 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Param,
+  Patch,
+  Post,
+  Query,
+} from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiOperation,
+  ApiParam,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
+import { CurrentUser } from '../auth/decorators/current-user.decorator';
+import { LocalizedParseUUIDPipe } from '../i18n/pipes/localized-parse-uuid.pipe';
+import {
+  CreateSavedAddressDto,
+  SavedAddressResponseDto,
+  SearchSavedAddressesDto,
+  UpdateSavedAddressDto,
+} from './dto/saved-address.dto';
+import { SavedAddress } from './entities/saved-address.entity';
+import { SavedAddressesService } from './saved-addresses.service';
+
+@ApiTags('address-book')
+@ApiBearerAuth()
+@Controller('address-book')
+export class SavedAddressesController {
+  constructor(private readonly savedAddressesService: SavedAddressesService) {}
+
+  @Post()
+  @ApiOperation({ summary: 'Save an external Stellar address with alias metadata' })
+  @ApiResponse({ status: 201, type: SavedAddressResponseDto })
+  addAddress(
+    @CurrentUser('id') userId: string,
+    @Body() dto: CreateSavedAddressDto,
+  ): Promise<SavedAddress> {
+    return this.savedAddressesService.addAddress(userId, dto);
+  }
+
+  @Get()
+  @ApiOperation({ summary: 'List saved addresses sorted by lastUsedAt DESC by default' })
+  @ApiResponse({ status: 200, type: [SavedAddressResponseDto] })
+  getAddresses(@CurrentUser('id') userId: string): Promise<SavedAddress[]> {
+    return this.savedAddressesService.getAddresses(userId);
+  }
+
+  @Get('search')
+  @ApiOperation({
+    summary:
+      'Search saved addresses by alias, address, or tag; supports suggest mode for transfer autocomplete',
+  })
+  @ApiResponse({ status: 200, type: [SavedAddressResponseDto] })
+  searchAddresses(
+    @CurrentUser('id') userId: string,
+    @Query() query: SearchSavedAddressesDto,
+  ): Promise<SavedAddress[]> {
+    return this.savedAddressesService.searchAddresses(userId, query);
+  }
+
+  @Patch(':id')
+  @ApiOperation({ summary: 'Update alias, avatar, network, or tags for a saved address' })
+  @ApiParam({ name: 'id', description: 'Saved address UUID' })
+  @ApiResponse({ status: 200, type: SavedAddressResponseDto })
+  updateAddress(
+    @CurrentUser('id') userId: string,
+    @Param('id', LocalizedParseUUIDPipe) id: string,
+    @Body() dto: UpdateSavedAddressDto,
+  ): Promise<SavedAddress> {
+    return this.savedAddressesService.updateAddress(userId, id, dto);
+  }
+
+  @Delete(':id')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOperation({ summary: 'Delete a saved address' })
+  @ApiParam({ name: 'id', description: 'Saved address UUID' })
+  async deleteAddress(
+    @CurrentUser('id') userId: string,
+    @Param('id', LocalizedParseUUIDPipe) id: string,
+  ): Promise<void> {
+    await this.savedAddressesService.deleteAddress(userId, id);
+  }
+}

--- a/src/address-book/saved-addresses.repository.ts
+++ b/src/address-book/saved-addresses.repository.ts
@@ -1,0 +1,78 @@
+import { Injectable } from '@nestjs/common';
+import { DataSource, Repository } from 'typeorm';
+import { SavedAddress } from './entities/saved-address.entity';
+
+@Injectable()
+export class SavedAddressesRepository extends Repository<SavedAddress> {
+  constructor(private readonly dataSource: DataSource) {
+    super(SavedAddress, dataSource.createEntityManager());
+  }
+
+  findByUserId(userId: string): Promise<SavedAddress[]> {
+    return this.createQueryBuilder('address')
+      .where('address.userId = :userId', { userId })
+      .orderBy('address.lastUsedAt', 'DESC', 'NULLS LAST')
+      .addOrderBy('address.createdAt', 'DESC')
+      .getMany();
+  }
+
+  searchByUser(userId: string, query?: string, tag?: string): Promise<SavedAddress[]> {
+    const qb = this.createQueryBuilder('address').where('address.userId = :userId', { userId });
+
+    if (query && query.trim().length > 0) {
+      const q = `%${query.trim().toLowerCase()}%`;
+      qb.andWhere(
+        '(LOWER(address.alias) LIKE :q OR LOWER(address.walletAddress) LIKE :q OR EXISTS (SELECT 1 FROM unnest(address.tags) AS t WHERE LOWER(t) LIKE :q))',
+        { q },
+      );
+    }
+
+    if (tag && tag.trim().length > 0) {
+      qb.andWhere('EXISTS (SELECT 1 FROM unnest(address.tags) AS t2 WHERE LOWER(t2) = :tag)', {
+        tag: tag.trim().toLowerCase(),
+      });
+    }
+
+    return qb
+      .orderBy('address.lastUsedAt', 'DESC', 'NULLS LAST')
+      .addOrderBy('address.createdAt', 'DESC')
+      .getMany();
+  }
+
+  searchForSuggestions(userId: string, query?: string, limit = 20): Promise<SavedAddress[]> {
+    const qb = this.createQueryBuilder('address').where('address.userId = :userId', { userId });
+
+    if (query && query.trim().length > 0) {
+      const q = `%${query.trim().toLowerCase()}%`;
+      qb.andWhere(
+        '(LOWER(address.alias) LIKE :q OR LOWER(address.walletAddress) LIKE :q OR EXISTS (SELECT 1 FROM unnest(address.tags) AS t WHERE LOWER(t) LIKE :q))',
+        { q },
+      );
+    }
+
+    return qb
+      .orderBy('address.usageCount', 'DESC')
+      .addOrderBy('address.lastUsedAt', 'DESC', 'NULLS LAST')
+      .addOrderBy('address.createdAt', 'DESC')
+      .limit(limit)
+      .getMany();
+  }
+
+  findByUserAndId(userId: string, id: string): Promise<SavedAddress | null> {
+    return this.findOne({ where: { userId, id } });
+  }
+
+  findByAliasCaseInsensitive(userId: string, alias: string): Promise<SavedAddress | null> {
+    return this.createQueryBuilder('address')
+      .where('address.userId = :userId', { userId })
+      .andWhere('LOWER(address.alias) = LOWER(:alias)', { alias })
+      .getOne();
+  }
+
+  findByAddressCaseInsensitive(userId: string, walletAddress: string): Promise<SavedAddress | null> {
+    return this.createQueryBuilder('address')
+      .where('address.userId = :userId', { userId })
+      .andWhere('LOWER(address.walletAddress) = LOWER(:walletAddress)', { walletAddress })
+      .getOne();
+  }
+}

--- a/src/address-book/saved-addresses.service.spec.ts
+++ b/src/address-book/saved-addresses.service.spec.ts
@@ -1,0 +1,171 @@
+import {
+  BadRequestException,
+  ConflictException,
+  NotFoundException,
+} from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { WalletNetwork } from '../wallets/entities/wallet.entity';
+import { SavedAddressesService } from './saved-addresses.service';
+import { SavedAddressesRepository } from './saved-addresses.repository';
+
+describe('SavedAddressesService', () => {
+  let service: SavedAddressesService;
+  let repository: jest.Mocked<SavedAddressesRepository>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        SavedAddressesService,
+        {
+          provide: SavedAddressesRepository,
+          useValue: {
+            create: jest.fn(),
+            save: jest.fn(),
+            remove: jest.fn(),
+            findByUserId: jest.fn(),
+            searchByUser: jest.fn(),
+            searchForSuggestions: jest.fn(),
+            findByUserAndId: jest.fn(),
+            findByAliasCaseInsensitive: jest.fn(),
+            findByAddressCaseInsensitive: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get(SavedAddressesService);
+    repository = module.get(SavedAddressesRepository);
+  });
+
+  it('adds a valid saved address', async () => {
+    repository.findByAliasCaseInsensitive.mockResolvedValue(null);
+    repository.findByAddressCaseInsensitive.mockResolvedValue(null);
+    repository.create.mockReturnValue({ id: 'sa1' } as any);
+    repository.save.mockResolvedValue({ id: 'sa1', alias: 'Mom' } as any);
+
+    const result = await service.addAddress('user1', {
+      walletAddress: 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+      alias: 'Mom',
+      network: WalletNetwork.STELLAR_MAINNET,
+      tags: ['family'],
+    });
+
+    expect(result.id).toBe('sa1');
+    expect(repository.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        walletAddress: 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+        alias: 'Mom',
+      }),
+    );
+  });
+
+  it('rejects invalid stellar address format', async () => {
+    await expect(
+      service.addAddress('user1', {
+        walletAddress: 'bad-address',
+        alias: 'Mom',
+      } as any),
+    ).rejects.toBeInstanceOf(BadRequestException);
+  });
+
+  it('enforces alias uniqueness case-insensitively', async () => {
+    repository.findByAliasCaseInsensitive.mockResolvedValue({ id: 'existing' } as any);
+
+    await expect(
+      service.addAddress('user1', {
+        walletAddress: 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+        alias: 'mom',
+      } as any),
+    ).rejects.toBeInstanceOf(ConflictException);
+  });
+
+  it('updates saved address fields', async () => {
+    repository.findByUserAndId.mockResolvedValue({
+      id: 'sa1',
+      userId: 'user1',
+      alias: 'Old',
+      avatarUrl: null,
+      network: WalletNetwork.STELLAR_MAINNET,
+      tags: [],
+      usageCount: 0,
+      lastUsedAt: null,
+    } as any);
+    repository.findByAliasCaseInsensitive.mockResolvedValue(null);
+    repository.save.mockImplementation(async (v: any) => v);
+
+    const result = await service.updateAddress('user1', 'sa1', {
+      alias: 'New Alias',
+      tags: ['Friends', 'vip'],
+    });
+
+    expect(result.alias).toBe('New Alias');
+    expect(result.tags).toEqual(['friends', 'vip']);
+  });
+
+  it('deletes existing saved address', async () => {
+    repository.findByUserAndId.mockResolvedValue({ id: 'sa1' } as any);
+
+    await service.deleteAddress('user1', 'sa1');
+
+    expect(repository.remove).toHaveBeenCalled();
+  });
+
+  it('throws on delete when address does not exist', async () => {
+    repository.findByUserAndId.mockResolvedValue(null);
+
+    await expect(service.deleteAddress('user1', 'missing')).rejects.toBeInstanceOf(
+      NotFoundException,
+    );
+  });
+
+  it('searches in default mode by alias/address/tag', async () => {
+    repository.searchByUser.mockResolvedValue([{ id: 'sa1' } as any]);
+
+    const results = await service.searchAddresses('user1', { q: 'mom', tag: 'family' });
+
+    expect(results).toHaveLength(1);
+    expect(repository.searchByUser).toHaveBeenCalledWith('user1', 'mom', 'family');
+  });
+
+  it('returns suggestions sorted by usage in suggest mode', async () => {
+    repository.searchForSuggestions.mockResolvedValue([{ id: 'sa2', usageCount: 10 } as any]);
+
+    const results = await service.searchAddresses('user1', { q: 'ga', suggest: true });
+
+    expect(results[0].id).toBe('sa2');
+    expect(repository.searchForSuggestions).toHaveBeenCalledWith('user1', 'ga');
+  });
+
+  it('tracks usage by saved address id', async () => {
+    repository.findByUserAndId.mockResolvedValue({
+      id: 'sa1',
+      usageCount: 2,
+      lastUsedAt: null,
+    } as any);
+    repository.save.mockImplementation(async (v: any) => v);
+
+    await service.trackUsage('user1', 'sa1');
+
+    expect(repository.save).toHaveBeenCalledWith(
+      expect.objectContaining({ usageCount: 3 }),
+    );
+  });
+
+  it('tracks usage by wallet address when transaction confirms', async () => {
+    repository.findByAddressCaseInsensitive.mockResolvedValue({
+      id: 'sa1',
+      usageCount: 5,
+      lastUsedAt: null,
+    } as any);
+    repository.save.mockImplementation(async (v: any) => v);
+
+    await service.trackUsageByWalletAddress(
+      'user1',
+      'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+    );
+
+    expect(repository.save).toHaveBeenCalledWith(
+      expect.objectContaining({ usageCount: 6 }),
+    );
+  });
+});

--- a/src/address-book/saved-addresses.service.ts
+++ b/src/address-book/saved-addresses.service.ts
@@ -1,0 +1,172 @@
+import {
+  BadRequestException,
+  ConflictException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import {
+  CreateSavedAddressDto,
+  SearchSavedAddressesDto,
+  UpdateSavedAddressDto,
+} from './dto/saved-address.dto';
+import { SavedAddress } from './entities/saved-address.entity';
+import { SavedAddressesRepository } from './saved-addresses.repository';
+import { WalletNetwork } from '../wallets/entities/wallet.entity';
+
+const STELLAR_ADDRESS_REGEX = /^[GC][A-Z2-7]{55}$/;
+
+@Injectable()
+export class SavedAddressesService {
+  constructor(private readonly savedAddressesRepository: SavedAddressesRepository) {}
+
+  async addAddress(userId: string, dto: CreateSavedAddressDto): Promise<SavedAddress> {
+    const normalizedAddress = dto.walletAddress.trim().toUpperCase();
+    this.assertValidStellarAddress(normalizedAddress);
+
+    const alias = dto.alias.trim();
+    await this.assertAliasUnique(userId, alias);
+
+    const existingAddress = await this.savedAddressesRepository.findByAddressCaseInsensitive(
+      userId,
+      normalizedAddress,
+    );
+    if (existingAddress) {
+      throw new ConflictException('This wallet address is already saved');
+    }
+
+    const entity = this.savedAddressesRepository.create({
+      userId,
+      walletAddress: normalizedAddress,
+      alias,
+      avatarUrl: dto.avatarUrl?.trim() || null,
+      network: dto.network ?? WalletNetwork.STELLAR_MAINNET,
+      tags: this.normalizeTags(dto.tags),
+      usageCount: 0,
+      lastUsedAt: null,
+    });
+
+    return this.savedAddressesRepository.save(entity);
+  }
+
+  async updateAddress(userId: string, id: string, dto: UpdateSavedAddressDto): Promise<SavedAddress> {
+    const existing = await this.savedAddressesRepository.findByUserAndId(userId, id);
+    if (!existing) {
+      throw new NotFoundException('Saved address not found');
+    }
+
+    if (dto.alias && dto.alias.trim().length > 0) {
+      const alias = dto.alias.trim();
+      const aliasOwner = await this.savedAddressesRepository.findByAliasCaseInsensitive(userId, alias);
+      if (aliasOwner && aliasOwner.id !== id) {
+        throw new ConflictException('Alias already exists for this user');
+      }
+      existing.alias = alias;
+    }
+
+    if (dto.avatarUrl !== undefined) {
+      existing.avatarUrl = dto.avatarUrl?.trim() || null;
+    }
+
+    if (dto.network) {
+      existing.network = dto.network;
+    }
+
+    if (dto.tags !== undefined) {
+      existing.tags = this.normalizeTags(dto.tags);
+    }
+
+    return this.savedAddressesRepository.save(existing);
+  }
+
+  async deleteAddress(userId: string, id: string): Promise<void> {
+    const existing = await this.savedAddressesRepository.findByUserAndId(userId, id);
+    if (!existing) {
+      throw new NotFoundException('Saved address not found');
+    }
+
+    await this.savedAddressesRepository.remove(existing);
+  }
+
+  async getAddresses(userId: string): Promise<SavedAddress[]> {
+    return this.savedAddressesRepository.findByUserId(userId);
+  }
+
+  async searchAddresses(userId: string, query: SearchSavedAddressesDto): Promise<SavedAddress[]> {
+    if (query.suggest) {
+      return this.savedAddressesRepository.searchForSuggestions(userId, query.q);
+    }
+
+    return this.savedAddressesRepository.searchByUser(userId, query.q, query.tag);
+  }
+
+  async resolveAlias(userId: string, aliasOrAddress: string): Promise<SavedAddress | null> {
+    const value = aliasOrAddress.trim();
+    if (!value) {
+      return null;
+    }
+
+    const byAlias = await this.savedAddressesRepository.findByAliasCaseInsensitive(userId, value);
+    if (byAlias) {
+      return byAlias;
+    }
+
+    return this.savedAddressesRepository.findByAddressCaseInsensitive(userId, value);
+  }
+
+  async trackUsage(userId: string, savedAddressId: string): Promise<void> {
+    const existing = await this.savedAddressesRepository.findByUserAndId(userId, savedAddressId);
+    if (!existing) {
+      return;
+    }
+
+    existing.usageCount += 1;
+    existing.lastUsedAt = new Date();
+    await this.savedAddressesRepository.save(existing);
+  }
+
+  async trackUsageByWalletAddress(userId: string, walletAddress: string): Promise<void> {
+    const existing = await this.savedAddressesRepository.findByAddressCaseInsensitive(
+      userId,
+      walletAddress.trim(),
+    );
+
+    if (!existing) {
+      return;
+    }
+
+    existing.usageCount += 1;
+    existing.lastUsedAt = new Date();
+    await this.savedAddressesRepository.save(existing);
+  }
+
+  private assertValidStellarAddress(walletAddress: string): void {
+    if (!STELLAR_ADDRESS_REGEX.test(walletAddress)) {
+      throw new BadRequestException(
+        'walletAddress must be a valid 56-char Stellar address starting with G or C',
+      );
+    }
+  }
+
+  private async assertAliasUnique(userId: string, alias: string): Promise<void> {
+    const existingAlias = await this.savedAddressesRepository.findByAliasCaseInsensitive(
+      userId,
+      alias,
+    );
+    if (existingAlias) {
+      throw new ConflictException('Alias already exists for this user');
+    }
+  }
+
+  private normalizeTags(tags?: string[]): string[] {
+    if (!tags || tags.length === 0) {
+      return [];
+    }
+
+    const normalized = tags
+      .map((tag) => tag.trim())
+      .filter((tag) => tag.length > 0)
+      .map((tag) => tag.toLowerCase());
+
+    return Array.from(new Set(normalized));
+  }
+}

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -52,6 +52,7 @@ import { PollsModule } from './polls/polls.module';
 import { MentionsModule } from './mentions/mentions.module';
 import { OnboardingModule } from './onboarding/onboarding.module';
 import { ConversationExportModule } from './conversation-export/conversation-export.module';
+import { AddressBookModule } from './address-book/address-book.module';
 
 @Module({
   imports: [
@@ -107,6 +108,7 @@ import { ConversationExportModule } from './conversation-export/conversation-exp
     PollsModule,
     MentionsModule,
     ConversationExportModule,
+    AddressBookModule,
   ],
   controllers: [AppController],
   providers: [

--- a/src/in-chat-transfers/in-chat-transfers.module.ts
+++ b/src/in-chat-transfers/in-chat-transfers.module.ts
@@ -1,5 +1,6 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
+import { AddressBookModule } from '../address-book/address-book.module';
 import { Conversation } from '../conversations/entities/conversation.entity';
 import { ConversationParticipant } from '../conversations/entities/conversation-participant.entity';
 import { Message } from '../messages/entities/message.entity';
@@ -23,6 +24,7 @@ import { TransfersGateway } from './transfers.gateway';
       Wallet,
     ]),
     UsersModule,
+    AddressBookModule,
   ],
   controllers: [InChatTransfersController],
   providers: [InChatTransfersService, SorobanTransfersService, TransfersGateway],

--- a/src/in-chat-transfers/in-chat-transfers.service.spec.ts
+++ b/src/in-chat-transfers/in-chat-transfers.service.spec.ts
@@ -13,6 +13,7 @@ import {
 } from './entities/in-chat-transfer.entity';
 import { Wallet } from '../wallets/entities/wallet.entity';
 import { UsersRepository } from '../users/users.repository';
+import { SavedAddressesService } from '../address-book/saved-addresses.service';
 import { SorobanTransfersService } from './soroban-transfers.service';
 import { InChatTransfersService } from './in-chat-transfers.service';
 
@@ -35,6 +36,7 @@ describe('InChatTransfersService', () => {
   let walletsRepository: MockRepository<Wallet>;
   let usersRepository: jest.Mocked<UsersRepository>;
   let sorobanTransfersService: jest.Mocked<SorobanTransfersService>;
+  let savedAddressesService: jest.Mocked<SavedAddressesService>;
 
   const senderId = '00000000-0000-0000-0000-000000000001';
   const recipientId = '00000000-0000-0000-0000-000000000002';
@@ -89,12 +91,19 @@ describe('InChatTransfersService', () => {
             submitTransfer: jest.fn(),
           },
         },
+        {
+          provide: SavedAddressesService,
+          useValue: {
+            trackUsageByWalletAddress: jest.fn(),
+          },
+        },
       ],
     }).compile();
 
     service = module.get(InChatTransfersService);
     usersRepository = module.get(UsersRepository);
     sorobanTransfersService = module.get(SorobanTransfersService);
+    savedAddressesService = module.get(SavedAddressesService);
 
     jest.clearAllMocks();
   });
@@ -216,6 +225,10 @@ describe('InChatTransfersService', () => {
 
     expect(result.status).toBe(TransferStatus.COMPLETED);
     expect(result.sorobanTxHash).toBe('soroban_hash_1');
+    expect(savedAddressesService.trackUsageByWalletAddress).toHaveBeenCalledWith(
+      senderId,
+      'GALICE',
+    );
     expect(messagesRepository.save).toHaveBeenCalledWith(
       expect.objectContaining({
         conversationId,

--- a/src/in-chat-transfers/in-chat-transfers.service.ts
+++ b/src/in-chat-transfers/in-chat-transfers.service.ts
@@ -12,6 +12,7 @@ import {
 } from './entities/in-chat-transfer.entity';
 import { UsersRepository } from '../users/users.repository';
 import { Wallet } from '../wallets/entities/wallet.entity';
+import { SavedAddressesService } from '../address-book/saved-addresses.service';
 import { InitiateTransferDto } from './dto/initiate-transfer.dto';
 import { TransferPreviewDto } from './dto/transfer-preview.dto';
 import { TransferResponseDto } from './dto/transfer-response.dto';
@@ -51,6 +52,7 @@ export class InChatTransfersService {
     private readonly walletsRepository: Repository<Wallet>,
     private readonly usersRepository: UsersRepository,
     private readonly sorobanTransfersService: SorobanTransfersService,
+    private readonly savedAddressesService: SavedAddressesService,
   ) {}
 
   parseTransferCommand(raw: string): ParsedTransferCommand {
@@ -227,6 +229,12 @@ export class InChatTransfersService {
       transfer.messageId = message.id;
       transfer.transactionId = transaction.id;
       await this.transfersRepository.save(transfer);
+
+      await Promise.all(
+        recipientUsers.map((recipient) =>
+          this.savedAddressesService.trackUsageByWalletAddress(senderId, recipient.walletAddress),
+        ),
+      );
 
       return {
         transferId: transfer.id,

--- a/src/migrations/1745100000000-SavedAddressesSchema.ts
+++ b/src/migrations/1745100000000-SavedAddressesSchema.ts
@@ -1,0 +1,45 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class SavedAddressesSchema1745100000000 implements MigrationInterface {
+  name = 'SavedAddressesSchema1745100000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE "saved_addresses" (
+        "id" uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
+        "userId" uuid NOT NULL,
+        "walletAddress" varchar(56) NOT NULL,
+        "alias" varchar(64) NOT NULL,
+        "avatarUrl" text,
+        "network" varchar(32) NOT NULL DEFAULT 'stellar_mainnet',
+        "tags" text[] NOT NULL DEFAULT '{}',
+        "lastUsedAt" TIMESTAMP,
+        "usageCount" integer NOT NULL DEFAULT 0,
+        "createdAt" TIMESTAMP NOT NULL DEFAULT now(),
+        CONSTRAINT "fk_saved_addresses_user"
+          FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE CASCADE
+      )
+    `);
+
+    await queryRunner.query(
+      `CREATE INDEX "idx_saved_addresses_user_id" ON "saved_addresses"("userId")`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "idx_saved_addresses_wallet_address" ON "saved_addresses"("walletAddress")`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "idx_saved_addresses_last_used_at" ON "saved_addresses"("lastUsedAt")`,
+    );
+    await queryRunner.query(
+      `CREATE UNIQUE INDEX "uq_saved_addresses_user_alias_ci" ON "saved_addresses"("userId", LOWER("alias"))`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX "uq_saved_addresses_user_alias_ci"`);
+    await queryRunner.query(`DROP INDEX "idx_saved_addresses_last_used_at"`);
+    await queryRunner.query(`DROP INDEX "idx_saved_addresses_wallet_address"`);
+    await queryRunner.query(`DROP INDEX "idx_saved_addresses_user_id"`);
+    await queryRunner.query(`DROP TABLE "saved_addresses"`);
+  }
+}

--- a/src/transactions/services/transactions.service.ts
+++ b/src/transactions/services/transactions.service.ts
@@ -12,6 +12,7 @@ import { NotificationsGateway } from '../../messaging/gateways/notifications.gat
 import { InAppNotificationType } from '../../notifications/entities/notification.entity';
 import { NotificationsService } from '../../notifications/notifications.service';
 import { Wallet, WalletNetwork } from '../../wallets/entities/wallet.entity';
+import { SavedAddressesService } from '../../address-book/saved-addresses.service';
 import { ListTransactionsQueryDto } from '../dto/list-transactions-query.dto';
 import {
   TransactionListResponseDto,
@@ -52,6 +53,7 @@ export class TransactionsService {
     private readonly chatGateway: ChatGateway,
     @InjectRepository(Wallet)
     private readonly walletsRepository: Repository<Wallet>,
+    private readonly savedAddressesService: SavedAddressesService,
   ) {}
 
   async createTransaction(input: CreateTransactionInput): Promise<TransactionResponseDto> {
@@ -253,6 +255,8 @@ export class TransactionsService {
       await this.notificationsGateway.sendTransferUpdate(senderId, transferPayload);
 
       if (transaction.status === TransactionStatus.CONFIRMED) {
+        await this.savedAddressesService.trackUsageByWalletAddress(senderId, transaction.toAddress);
+
         await this.notificationsService.createNotification({
           userId: senderId,
           type: InAppNotificationType.TRANSACTION_CONFIRMED,

--- a/src/transactions/transactions.module.ts
+++ b/src/transactions/transactions.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
 import { TypeOrmModule } from '@nestjs/typeorm';
+import { AddressBookModule } from '../address-book/address-book.module';
 import { MessagingModule } from '../messaging/messaging.module';
 import { NotificationsModule } from '../notifications/notifications.module';
 import { Wallet } from '../wallets/entities/wallet.entity';
@@ -19,6 +20,7 @@ import { TransactionsService } from './services/transactions.service';
     TypeOrmModule.forFeature([Transaction, Wallet]),
     MessagingModule,
     NotificationsModule,
+    AddressBookModule,
   ],
   controllers: [TransactionsController, ReceiptController],
   providers: [

--- a/test/address-book.e2e-spec.ts
+++ b/test/address-book.e2e-spec.ts
@@ -1,0 +1,145 @@
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import { JwtService } from '@nestjs/jwt';
+import { Test, TestingModule } from '@nestjs/testing';
+import request from 'supertest';
+import { DataSource } from 'typeorm';
+import { User, UserTier } from '../src/users/entities/user.entity';
+import { SavedAddress } from '../src/address-book/entities/saved-address.entity';
+
+describe('AddressBookController (e2e)', () => {
+  let app: INestApplication;
+  let dataSource: DataSource;
+  let jwtService: JwtService;
+  let userId: string;
+  let token: string;
+
+  const walletA = 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA';
+  const walletB = 'CBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB';
+
+  beforeAll(async () => {
+    process.env.NODE_ENV = process.env.NODE_ENV || 'test';
+    process.env.JWT_SECRET =
+      process.env.JWT_SECRET || 'test_jwt_secret_minimum_32_characters_long';
+
+    const { AppModule } = await import('../src/app.module');
+
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    app.useGlobalPipes(
+      new ValidationPipe({
+        whitelist: true,
+        forbidNonWhitelisted: true,
+        transform: true,
+      }),
+    );
+    await app.init();
+
+    dataSource = moduleFixture.get(DataSource);
+    jwtService = moduleFixture.get(JwtService);
+
+    const users = dataSource.getRepository(User);
+    const user = await users.save(
+      users.create({
+        walletAddress: 'GZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ',
+        tier: UserTier.FREE,
+        isActive: true,
+      }),
+    );
+
+    userId = user.id;
+    token = jwtService.sign({ sub: user.id, walletAddress: user.walletAddress });
+  });
+
+  afterAll(async () => {
+    if (dataSource) {
+      await dataSource.getRepository(SavedAddress).delete({});
+      await dataSource.getRepository(User).delete({});
+    }
+    if (app) {
+      await app.close();
+    }
+  });
+
+  it('POST /address-book creates entry with valid stellar address', async () => {
+    await request(app.getHttpServer())
+      .post('/api/address-book')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ walletAddress: walletA, alias: 'Mom', tags: ['family'] })
+      .expect(201)
+      .expect((res) => {
+        expect(res.body.alias).toBe('Mom');
+        expect(res.body.walletAddress).toBe(walletA);
+      });
+  });
+
+  it('POST /address-book rejects invalid stellar address', async () => {
+    await request(app.getHttpServer())
+      .post('/api/address-book')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ walletAddress: 'bad', alias: 'Invalid' })
+      .expect(400);
+  });
+
+  it('GET /address-book/search finds by alias/address/tag', async () => {
+    await request(app.getHttpServer())
+      .post('/api/address-book')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ walletAddress: walletB, alias: 'Vendor', tags: ['merchant'] })
+      .expect(201);
+
+    await request(app.getHttpServer())
+      .get('/api/address-book/search?q=ven')
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200)
+      .expect((res) => {
+        expect(Array.isArray(res.body)).toBe(true);
+        expect(res.body.some((v: any) => v.alias === 'Vendor')).toBe(true);
+      });
+
+    await request(app.getHttpServer())
+      .get('/api/address-book/search?tag=merchant')
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200)
+      .expect((res) => {
+        expect(res.body.some((v: any) => v.alias === 'Vendor')).toBe(true);
+      });
+  });
+
+  it('GET /address-book/search?suggest=true returns autocomplete list', async () => {
+    await request(app.getHttpServer())
+      .get('/api/address-book/search?suggest=true&q=g')
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200)
+      .expect((res) => {
+        expect(Array.isArray(res.body)).toBe(true);
+      });
+  });
+
+  it('PATCH + DELETE /address-book/:id updates then removes entry', async () => {
+    const created = await request(app.getHttpServer())
+      .post('/api/address-book')
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        walletAddress: 'GCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC',
+        alias: 'Temp',
+      })
+      .expect(201);
+
+    await request(app.getHttpServer())
+      .patch(`/api/address-book/${created.body.id}`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ alias: 'Updated Temp', tags: ['updated'] })
+      .expect(200)
+      .expect((res) => {
+        expect(res.body.alias).toBe('Updated Temp');
+      });
+
+    await request(app.getHttpServer())
+      .delete(`/api/address-book/${created.body.id}`)
+      .set('Authorization', `Bearer ${token}`)
+      .expect(204);
+  });
+});


### PR DESCRIPTION
## Summary
Implements Address Book + Payment Alias so users can save, label, search, and reuse external Stellar wallet addresses for faster transfers.

## What Changed
- Added SavedAddress entity + migration with alias uniqueness per user (case-insensitive).
- Added Address Book APIs:
  - POST /address-book
  - GET /address-book
  - PATCH /address-book/:id
  - DELETE /address-book/:id
  - GET /address-book/search
- Added service/repository logic for add, update, delete, list, search, alias resolution, and usage tracking.
- Added Stellar address validation for 56-char G.../C... format.
- Added suggestion mode for transfer autocomplete, sorted by usage frequency.
- Wired usage tracking into confirmed transfer flows.
- Added unit and e2e tests for the module.

## Issue Link
- Closes #585 
