### PR TITLE
feat: add username discovery module with user search and blocking functionality

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -53,6 +53,7 @@ import { MentionsModule } from './mentions/mentions.module';
 import { OnboardingModule } from './onboarding/onboarding.module';
 import { ConversationExportModule } from './conversation-export/conversation-export.module';
 import { AddressBookModule } from './address-book/address-book.module';
+import { UsernameDiscoveryModule } from './username-discovery/username-discovery.module';
 
 @Module({
   imports: [
@@ -109,6 +110,7 @@ import { AddressBookModule } from './address-book/address-book.module';
     MentionsModule,
     ConversationExportModule,
     AddressBookModule,
+    UsernameDiscoveryModule,
   ],
   controllers: [AppController],
   providers: [

--- a/src/migrations/1745200000000-DiscoveryUserBlocksSchema.ts
+++ b/src/migrations/1745200000000-DiscoveryUserBlocksSchema.ts
@@ -1,0 +1,39 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class DiscoveryUserBlocksSchema1745200000000 implements MigrationInterface {
+  name = 'DiscoveryUserBlocksSchema1745200000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE "discovery_user_blocks" (
+        "id" uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
+        "blockerId" uuid NOT NULL,
+        "blockedId" uuid NOT NULL,
+        "createdAt" TIMESTAMP NOT NULL DEFAULT now(),
+        CONSTRAINT "fk_discovery_user_blocks_blocker"
+          FOREIGN KEY ("blockerId") REFERENCES "users"("id") ON DELETE CASCADE,
+        CONSTRAINT "fk_discovery_user_blocks_blocked"
+          FOREIGN KEY ("blockedId") REFERENCES "users"("id") ON DELETE CASCADE,
+        CONSTRAINT "chk_discovery_user_blocks_not_self"
+          CHECK ("blockerId" <> "blockedId")
+      )
+    `);
+
+    await queryRunner.query(
+      `CREATE INDEX "idx_discovery_user_blocks_blocker_id" ON "discovery_user_blocks"("blockerId")`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "idx_discovery_user_blocks_blocked_id" ON "discovery_user_blocks"("blockedId")`,
+    );
+    await queryRunner.query(
+      `CREATE UNIQUE INDEX "uq_discovery_user_blocks_pair" ON "discovery_user_blocks"("blockerId", "blockedId")`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX "uq_discovery_user_blocks_pair"`);
+    await queryRunner.query(`DROP INDEX "idx_discovery_user_blocks_blocked_id"`);
+    await queryRunner.query(`DROP INDEX "idx_discovery_user_blocks_blocker_id"`);
+    await queryRunner.query(`DROP TABLE "discovery_user_blocks"`);
+  }
+}

--- a/src/username-discovery/dto/username-discovery.dto.ts
+++ b/src/username-discovery/dto/username-discovery.dto.ts
@@ -1,0 +1,83 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { Transform } from 'class-transformer';
+import { IsInt, IsOptional, IsString, Length, Max, Min } from 'class-validator';
+
+export class DiscoverUsersQueryDto {
+  @ApiProperty({ description: 'Username or display name query' })
+  @IsString()
+  @Length(1, 50)
+  @Transform(({ value }) => (typeof value === 'string' ? value.trim() : value))
+  q!: string;
+
+  @ApiPropertyOptional({ description: 'Max results to return', minimum: 1, maximum: 30 })
+  @IsOptional()
+  @Transform(({ value }) => (value === undefined ? undefined : Number(value)))
+  @IsInt()
+  @Min(1)
+  @Max(30)
+  limit?: number;
+}
+
+export class DiscoveryResultDto {
+  @ApiProperty()
+  id!: string;
+
+  @ApiProperty()
+  username!: string;
+
+  @ApiPropertyOptional()
+  displayName!: string | null;
+
+  @ApiPropertyOptional()
+  avatarUrl!: string | null;
+
+  @ApiPropertyOptional()
+  bio!: string | null;
+
+  @ApiProperty()
+  walletAddressMasked!: string;
+
+  @ApiProperty()
+  relevanceScore!: number;
+
+  @ApiProperty()
+  reputationScore!: number;
+
+  @ApiProperty()
+  mutualContactsCount!: number;
+}
+
+export class PublicProfileCardDto {
+  @ApiProperty()
+  id!: string;
+
+  @ApiProperty()
+  username!: string;
+
+  @ApiPropertyOptional()
+  displayName!: string | null;
+
+  @ApiPropertyOptional()
+  avatarUrl!: string | null;
+
+  @ApiPropertyOptional()
+  bio!: string | null;
+
+  @ApiProperty()
+  walletAddressMasked!: string;
+
+  @ApiProperty()
+  tier!: string;
+
+  @ApiProperty()
+  isVerified!: boolean;
+
+  @ApiProperty()
+  reputationScore!: number;
+
+  @ApiProperty()
+  mutualContactsCount!: number;
+
+  @ApiProperty()
+  deepLink!: string;
+}

--- a/src/username-discovery/entities/discovery-user-block.entity.ts
+++ b/src/username-discovery/entities/discovery-user-block.entity.ts
@@ -1,0 +1,26 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  Index,
+  PrimaryGeneratedColumn,
+  Unique,
+} from 'typeorm';
+
+@Entity('discovery_user_blocks')
+@Unique('uq_discovery_user_blocks_pair', ['blockerId', 'blockedId'])
+export class DiscoveryUserBlock {
+  @PrimaryGeneratedColumn('uuid')
+  id!: string;
+
+  @Column({ type: 'uuid' })
+  @Index('idx_discovery_user_blocks_blocker_id')
+  blockerId!: string;
+
+  @Column({ type: 'uuid' })
+  @Index('idx_discovery_user_blocks_blocked_id')
+  blockedId!: string;
+
+  @CreateDateColumn({ type: 'timestamp' })
+  createdAt!: Date;
+}

--- a/src/username-discovery/username-discovery.controller.ts
+++ b/src/username-discovery/username-discovery.controller.ts
@@ -1,0 +1,77 @@
+import { Controller, Get, Param, Query, Res } from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiOperation,
+  ApiParam,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
+import { Response } from 'express';
+import { CurrentUser } from '../auth/decorators/current-user.decorator';
+import {
+  DiscoverUsersQueryDto,
+  DiscoveryResultDto,
+  PublicProfileCardDto,
+} from './dto/username-discovery.dto';
+import { UsernameDiscoveryService } from './username-discovery.service';
+
+@ApiTags('discover')
+@ApiBearerAuth()
+@Controller('discover')
+export class UsernameDiscoveryController {
+  constructor(private readonly usernameDiscoveryService: UsernameDiscoveryService) {}
+
+  @Get()
+  @ApiOperation({ summary: 'Search users by username/displayName with privacy filters' })
+  @ApiResponse({ status: 200, type: [DiscoveryResultDto] })
+  discoverUsers(
+    @CurrentUser('id') userId: string,
+    @Query() query: DiscoverUsersQueryDto,
+  ): Promise<DiscoveryResultDto[]> {
+    return this.usernameDiscoveryService.discoverUsers(userId, query);
+  }
+
+  @Get('username/:username')
+  @ApiOperation({ summary: 'Find a discoverable user by exact username' })
+  @ApiParam({ name: 'username', description: 'Username to resolve' })
+  @ApiResponse({ status: 200, type: DiscoveryResultDto })
+  getByUsername(
+    @CurrentUser('id') userId: string,
+    @Param('username') username: string,
+  ): Promise<DiscoveryResultDto> {
+    return this.usernameDiscoveryService.getByUsername(userId, username);
+  }
+
+  @Get('wallet/:address')
+  @ApiOperation({ summary: 'Find a discoverable user by wallet address' })
+  @ApiParam({ name: 'address', description: 'Wallet address to resolve' })
+  @ApiResponse({ status: 200, type: DiscoveryResultDto })
+  getByWalletAddress(
+    @CurrentUser('id') userId: string,
+    @Param('address') walletAddress: string,
+  ): Promise<DiscoveryResultDto> {
+    return this.usernameDiscoveryService.getByWalletAddress(userId, walletAddress);
+  }
+
+  @Get(':username/card')
+  @ApiOperation({ summary: 'Get a public profile card (cached for 60 seconds)' })
+  @ApiResponse({ status: 200, type: PublicProfileCardDto })
+  getPublicCard(
+    @CurrentUser('id') userId: string,
+    @Param('username') username: string,
+  ): Promise<PublicProfileCardDto> {
+    return this.usernameDiscoveryService.getPublicCard(userId, username);
+  }
+
+  @Get(':username/qr')
+  @ApiOperation({ summary: 'Generate profile QR code with gasless://profile/:username deep link' })
+  async getProfileQr(
+    @Param('username') username: string,
+    @Res() res: Response,
+  ): Promise<void> {
+    const png = await this.usernameDiscoveryService.getProfileQr(username);
+    res.setHeader('Content-Type', 'image/png');
+    res.setHeader('Cache-Control', 'public, max-age=3600');
+    res.send(png);
+  }
+}

--- a/src/username-discovery/username-discovery.module.ts
+++ b/src/username-discovery/username-discovery.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { QrCodeModule } from '../qr-code/qr-code.module';
+import { DiscoveryUserBlock } from './entities/discovery-user-block.entity';
+import { UsernameDiscoveryController } from './username-discovery.controller';
+import { UsernameDiscoveryService } from './username-discovery.service';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([DiscoveryUserBlock]), QrCodeModule],
+  controllers: [UsernameDiscoveryController],
+  providers: [UsernameDiscoveryService],
+  exports: [UsernameDiscoveryService],
+})
+export class UsernameDiscoveryModule {}

--- a/src/username-discovery/username-discovery.service.spec.ts
+++ b/src/username-discovery/username-discovery.service.spec.ts
@@ -1,0 +1,123 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { TooManyRequestsException } from '@nestjs/common';
+import { DataSource } from 'typeorm';
+import { CacheService } from '../cache/cache.service';
+import { QrCodeService } from '../qr-code/qr-code.service';
+import { RedisService } from '../common/redis/redis.service';
+import { UsernameDiscoveryService } from './username-discovery.service';
+
+describe('UsernameDiscoveryService', () => {
+  let service: UsernameDiscoveryService;
+
+  const dataSourceMock = {
+    query: jest.fn(),
+  };
+
+  const cacheServiceMock = {
+    getOrSet: jest.fn(),
+  };
+
+  const qrCodeServiceMock = {
+    generateProfileQR: jest.fn(),
+  };
+
+  const redisClientMock = {
+    incr: jest.fn(),
+    expire: jest.fn(),
+  };
+
+  const redisServiceMock = {
+    getClient: jest.fn(() => redisClientMock),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        UsernameDiscoveryService,
+        { provide: DataSource, useValue: dataSourceMock },
+        { provide: CacheService, useValue: cacheServiceMock },
+        { provide: QrCodeService, useValue: qrCodeServiceMock },
+        { provide: RedisService, useValue: redisServiceMock },
+      ],
+    }).compile();
+
+    service = module.get(UsernameDiscoveryService);
+    jest.clearAllMocks();
+    redisClientMock.incr.mockResolvedValue(1);
+    redisClientMock.expire.mockResolvedValue(1);
+  });
+
+  it('discovers users and maps masked wallet plus ranking fields', async () => {
+    dataSourceMock.query
+      .mockResolvedValueOnce([{ walletAddress: 'GREQUESTERAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA' }])
+      .mockResolvedValueOnce([
+        {
+          id: 'u-1',
+          username: 'alice',
+          displayName: 'Alice',
+          avatarUrl: 'https://cdn/avatar.png',
+          bio: 'hello',
+          walletAddress: 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+          tier: 'silver',
+          isVerified: true,
+          reputationScore: '4.25',
+          mutualContactsCount: '3',
+          relevanceScore: '80',
+        },
+      ]);
+
+    const results = await service.discoverUsers('requester-id', { q: 'ali', limit: 10 });
+
+    expect(results).toHaveLength(1);
+    expect(results[0].username).toBe('alice');
+    expect(results[0].walletAddressMasked).toMatch(/\.\.\./);
+    expect(results[0].mutualContactsCount).toBe(3);
+    expect(results[0].reputationScore).toBe(4.25);
+  });
+
+  it('returns cached public profile card', async () => {
+    cacheServiceMock.getOrSet.mockImplementation(async (_key: string, _ttl: number, cb: () => Promise<any>) => cb());
+    dataSourceMock.query
+      .mockResolvedValueOnce([{ walletAddress: 'GREQUESTERAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA' }])
+      .mockResolvedValueOnce([
+        {
+          id: 'u-2',
+          username: 'bob',
+          displayName: 'Bob',
+          avatarUrl: null,
+          bio: 'bio',
+          walletAddress: 'GBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB',
+          tier: 'gold',
+          isVerified: false,
+          reputationScore: '0',
+          mutualContactsCount: '0',
+          relevanceScore: '100',
+        },
+      ]);
+
+    const card = await service.getPublicCard('requester-id', 'bob');
+
+    expect(cacheServiceMock.getOrSet).toHaveBeenCalled();
+    expect(card.username).toBe('bob');
+    expect(card.deepLink).toBe('gasless://profile/bob');
+    expect(card.walletAddressMasked).toMatch(/\.\.\./);
+  });
+
+  it('delegates profile QR generation to QR service', async () => {
+    const png = Buffer.from('png');
+    qrCodeServiceMock.generateProfileQR.mockResolvedValue(png);
+
+    const result = await service.getProfileQr('satoshi');
+
+    expect(result).toBe(png);
+    expect(qrCodeServiceMock.generateProfileQR).toHaveBeenCalledWith('satoshi');
+  });
+
+  it('enforces per-user search rate limit', async () => {
+    redisClientMock.incr.mockResolvedValue(31);
+
+    await expect(service.discoverUsers('requester-id', { q: 'al' })).rejects.toThrow(
+      TooManyRequestsException,
+    );
+  });
+});

--- a/src/username-discovery/username-discovery.service.ts
+++ b/src/username-discovery/username-discovery.service.ts
@@ -1,0 +1,289 @@
+import { Injectable, NotFoundException, TooManyRequestsException } from '@nestjs/common';
+import { InjectDataSource } from '@nestjs/typeorm';
+import { DataSource } from 'typeorm';
+import { CacheService } from '../cache/cache.service';
+import { QrCodeService } from '../qr-code/qr-code.service';
+import { RedisService } from '../common/redis/redis.service';
+import {
+  DiscoverUsersQueryDto,
+  DiscoveryResultDto,
+  PublicProfileCardDto,
+} from './dto/username-discovery.dto';
+
+const DISCOVERY_RATE_LIMIT = 30;
+const DISCOVERY_RATE_WINDOW_SECONDS = 60;
+const PUBLIC_CARD_CACHE_TTL_SECONDS = 60;
+
+type DiscoveryUserRow = {
+  id: string;
+  username: string;
+  displayName: string | null;
+  avatarUrl: string | null;
+  bio: string | null;
+  walletAddress: string;
+  tier: string;
+  isVerified: boolean;
+  reputationScore: string | number | null;
+  mutualContactsCount: string | number | null;
+  relevanceScore: string | number | null;
+};
+
+@Injectable()
+export class UsernameDiscoveryService {
+  constructor(
+    @InjectDataSource() private readonly dataSource: DataSource,
+    private readonly cacheService: CacheService,
+    private readonly qrCodeService: QrCodeService,
+    private readonly redisService: RedisService,
+  ) {}
+
+  async discoverUsers(
+    requesterId: string,
+    query: DiscoverUsersQueryDto,
+  ): Promise<DiscoveryResultDto[]> {
+    await this.enforceSearchRateLimit(requesterId);
+
+    const term = query.q.trim();
+    const limit = query.limit ?? 15;
+    const requesterWallet = await this.getWalletAddressByUserId(requesterId);
+
+    const rows = await this.dataSource.query(
+      `
+      SELECT
+        u.id,
+        u.username,
+        u."displayName",
+        u."avatarUrl",
+        u.bio,
+        u."walletAddress",
+        u.tier,
+        u."isVerified",
+        COALESCE(rs.score, 0) AS "reputationScore",
+        (
+          SELECT COUNT(DISTINCT LOWER(sa1."walletAddress"))
+          FROM saved_addresses sa1
+          INNER JOIN saved_addresses sa2
+            ON LOWER(sa1."walletAddress") = LOWER(sa2."walletAddress")
+          WHERE sa1."userId" = $4
+            AND sa2."userId" = u.id
+        ) AS "mutualContactsCount",
+        (
+          CASE
+            WHEN LOWER(u.username) = LOWER($3) THEN 100
+            WHEN LOWER(u.username) LIKE LOWER($3 || '%') THEN 80
+            WHEN LOWER(COALESCE(u."displayName", '')) LIKE LOWER($3 || '%') THEN 60
+            WHEN LOWER(COALESCE(u."displayName", '')) LIKE LOWER($1) THEN 40
+            WHEN LOWER(u.username) LIKE LOWER($1) THEN 30
+            ELSE 10
+          END
+        ) AS "relevanceScore"
+      FROM users u
+      LEFT JOIN reputation_scores rs
+        ON rs."userId" = u.id
+      LEFT JOIN user_settings us
+        ON us."userId" = u.id
+      WHERE u."isActive" = true
+        AND u.username IS NOT NULL
+        AND u.id <> $4
+        AND (u.username ILIKE $1 OR COALESCE(u."displayName", '') ILIKE $1)
+        AND NOT EXISTS (
+          SELECT 1
+          FROM discovery_user_blocks b
+          WHERE (b."blockerId" = u.id AND b."blockedId" = $4)
+             OR (b."blockerId" = $4 AND b."blockedId" = u.id)
+        )
+        AND LOWER(COALESCE(us."privacySettings"->>'lastSeenVisibility', 'everyone')) <> 'nobody'
+        AND (
+          LOWER(COALESCE(us."privacySettings"->>'lastSeenVisibility', 'everyone')) NOT IN ('contacts', 'contacts_only')
+          OR EXISTS (
+            SELECT 1
+            FROM saved_addresses sa
+            WHERE sa."userId" = u.id
+              AND LOWER(sa."walletAddress") = LOWER($2)
+          )
+        )
+      ORDER BY "relevanceScore" DESC, "mutualContactsCount" DESC, COALESCE(rs.score, 0) DESC
+      LIMIT $5
+      `,
+      [`%${term}%`, requesterWallet ?? '', term, requesterId, limit],
+    );
+
+    return rows.map((row: DiscoveryUserRow) => this.toDiscoveryResult(row));
+  }
+
+  async getByUsername(requesterId: string, username: string): Promise<DiscoveryResultDto> {
+    await this.enforceSearchRateLimit(requesterId);
+    const row = await this.findVisibleUserRow(requesterId, {
+      clause: 'LOWER(u.username) = LOWER($1)',
+      value: username.trim(),
+    });
+
+    if (!row) {
+      throw new NotFoundException('User not found');
+    }
+
+    return this.toDiscoveryResult(row);
+  }
+
+  async getByWalletAddress(requesterId: string, walletAddress: string): Promise<DiscoveryResultDto> {
+    await this.enforceSearchRateLimit(requesterId);
+    const row = await this.findVisibleUserRow(requesterId, {
+      clause: 'LOWER(u."walletAddress") = LOWER($1)',
+      value: walletAddress.trim(),
+    });
+
+    if (!row) {
+      throw new NotFoundException('User not found');
+    }
+
+    return this.toDiscoveryResult(row);
+  }
+
+  async getPublicCard(requesterId: string, username: string): Promise<PublicProfileCardDto> {
+    const cacheKey = `discovery:card:${requesterId}:${username.trim().toLowerCase()}`;
+
+    return this.cacheService.getOrSet(cacheKey, PUBLIC_CARD_CACHE_TTL_SECONDS, async () => {
+      const row = await this.findVisibleUserRow(requesterId, {
+        clause: 'LOWER(u.username) = LOWER($1)',
+        value: username.trim(),
+      });
+
+      if (!row) {
+        throw new NotFoundException('User not found');
+      }
+
+      return this.toPublicCard(row);
+    });
+  }
+
+  async getProfileQr(username: string): Promise<Buffer> {
+    return this.qrCodeService.generateProfileQR(username.trim());
+  }
+
+  private async findVisibleUserRow(
+    requesterId: string,
+    lookup: { clause: string; value: string },
+  ): Promise<DiscoveryUserRow | null> {
+    const requesterWallet = await this.getWalletAddressByUserId(requesterId);
+
+    const rows = await this.dataSource.query(
+      `
+      SELECT
+        u.id,
+        u.username,
+        u."displayName",
+        u."avatarUrl",
+        u.bio,
+        u."walletAddress",
+        u.tier,
+        u."isVerified",
+        COALESCE(rs.score, 0) AS "reputationScore",
+        (
+          SELECT COUNT(DISTINCT LOWER(sa1."walletAddress"))
+          FROM saved_addresses sa1
+          INNER JOIN saved_addresses sa2
+            ON LOWER(sa1."walletAddress") = LOWER(sa2."walletAddress")
+          WHERE sa1."userId" = $2
+            AND sa2."userId" = u.id
+        ) AS "mutualContactsCount",
+        100 AS "relevanceScore"
+      FROM users u
+      LEFT JOIN reputation_scores rs
+        ON rs."userId" = u.id
+      LEFT JOIN user_settings us
+        ON us."userId" = u.id
+      WHERE ${lookup.clause}
+        AND u."isActive" = true
+        AND u.username IS NOT NULL
+        AND u.id <> $2
+        AND NOT EXISTS (
+          SELECT 1
+          FROM discovery_user_blocks b
+          WHERE (b."blockerId" = u.id AND b."blockedId" = $2)
+             OR (b."blockerId" = $2 AND b."blockedId" = u.id)
+        )
+        AND LOWER(COALESCE(us."privacySettings"->>'lastSeenVisibility', 'everyone')) <> 'nobody'
+        AND (
+          LOWER(COALESCE(us."privacySettings"->>'lastSeenVisibility', 'everyone')) NOT IN ('contacts', 'contacts_only')
+          OR EXISTS (
+            SELECT 1
+            FROM saved_addresses sa
+            WHERE sa."userId" = u.id
+              AND LOWER(sa."walletAddress") = LOWER($3)
+          )
+        )
+      LIMIT 1
+      `,
+      [lookup.value, requesterId, requesterWallet ?? ''],
+    );
+
+    return rows[0] ?? null;
+  }
+
+  private async getWalletAddressByUserId(userId: string): Promise<string | null> {
+    const rows = await this.dataSource.query(
+      `SELECT "walletAddress" FROM users WHERE id = $1 LIMIT 1`,
+      [userId],
+    );
+    return rows[0]?.walletAddress ?? null;
+  }
+
+  private async enforceSearchRateLimit(userId: string): Promise<void> {
+    const key = `discovery:rate:${userId}`;
+
+    try {
+      const client = this.redisService.getClient();
+      const next = await client.incr(key);
+      if (next === 1) {
+        await client.expire(key, DISCOVERY_RATE_WINDOW_SECONDS);
+      }
+
+      if (next > DISCOVERY_RATE_LIMIT) {
+        throw new TooManyRequestsException('Discovery search rate limit exceeded');
+      }
+    } catch (error) {
+      if (error instanceof TooManyRequestsException) {
+        throw error;
+      }
+      // Degrade gracefully when Redis is unavailable.
+    }
+  }
+
+  private toDiscoveryResult(row: DiscoveryUserRow): DiscoveryResultDto {
+    return {
+      id: row.id,
+      username: row.username,
+      displayName: row.displayName,
+      avatarUrl: row.avatarUrl,
+      bio: row.bio,
+      walletAddressMasked: this.maskWalletAddress(row.walletAddress),
+      relevanceScore: Number(row.relevanceScore ?? 0),
+      reputationScore: Number(row.reputationScore ?? 0),
+      mutualContactsCount: Number(row.mutualContactsCount ?? 0),
+    };
+  }
+
+  private toPublicCard(row: DiscoveryUserRow): PublicProfileCardDto {
+    return {
+      id: row.id,
+      username: row.username,
+      displayName: row.displayName,
+      avatarUrl: row.avatarUrl,
+      bio: row.bio,
+      walletAddressMasked: this.maskWalletAddress(row.walletAddress),
+      tier: row.tier,
+      isVerified: row.isVerified,
+      reputationScore: Number(row.reputationScore ?? 0),
+      mutualContactsCount: Number(row.mutualContactsCount ?? 0),
+      deepLink: `gasless://profile/${encodeURIComponent(row.username)}`,
+    };
+  }
+
+  private maskWalletAddress(address: string): string {
+    const trimmed = address.trim();
+    if (trimmed.length <= 12) {
+      return trimmed;
+    }
+    return `${trimmed.slice(0, 6)}...${trimmed.slice(-4)}`;
+  }
+}

--- a/test/username-discovery.e2e-spec.ts
+++ b/test/username-discovery.e2e-spec.ts
@@ -1,0 +1,190 @@
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import { JwtService } from '@nestjs/jwt';
+import { Test, TestingModule } from '@nestjs/testing';
+import request from 'supertest';
+import { DataSource } from 'typeorm';
+import { User, UserTier } from '../src/users/entities/user.entity';
+
+describe('UsernameDiscoveryController (e2e)', () => {
+  let app: INestApplication;
+  let dataSource: DataSource;
+  let jwtService: JwtService;
+  let requesterId: string;
+  let requesterWallet: string;
+  let token: string;
+
+  const userWallet = 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA';
+  const hiddenWallet = 'GBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB';
+  const blockedWallet = 'GCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC';
+
+  beforeAll(async () => {
+    process.env.NODE_ENV = process.env.NODE_ENV || 'test';
+    process.env.JWT_SECRET =
+      process.env.JWT_SECRET || 'test_jwt_secret_minimum_32_characters_long';
+
+    const { AppModule } = await import('../src/app.module');
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    app.useGlobalPipes(
+      new ValidationPipe({
+        whitelist: true,
+        forbidNonWhitelisted: true,
+        transform: true,
+      }),
+    );
+    await app.init();
+
+    dataSource = moduleFixture.get(DataSource);
+    jwtService = moduleFixture.get(JwtService);
+
+    const userRepo = dataSource.getRepository(User);
+    const requester = await userRepo.save(
+      userRepo.create({
+        walletAddress: 'GREQUESTERAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+        username: 'requester',
+        tier: UserTier.SILVER,
+        isActive: true,
+      }),
+    );
+    requesterId = requester.id;
+    requesterWallet = requester.walletAddress;
+    token = jwtService.sign({ sub: requester.id, walletAddress: requester.walletAddress });
+
+    const alice = await userRepo.save(
+      userRepo.create({
+        walletAddress: userWallet,
+        username: 'alice',
+        displayName: 'Alice A',
+        tier: UserTier.GOLD,
+        isActive: true,
+      }),
+    );
+
+    const hidden = await userRepo.save(
+      userRepo.create({
+        walletAddress: hiddenWallet,
+        username: 'hiddenone',
+        displayName: 'Hidden One',
+        tier: UserTier.SILVER,
+        isActive: true,
+      }),
+    );
+
+    const blocked = await userRepo.save(
+      userRepo.create({
+        walletAddress: blockedWallet,
+        username: 'blockedguy',
+        displayName: 'Blocked Guy',
+        tier: UserTier.SILVER,
+        isActive: true,
+      }),
+    );
+
+    await dataSource.query(
+      `
+      INSERT INTO user_settings ("userId", "notificationPreferences", "privacySettings", theme, language, timezone, "twoFactorEnabled")
+      VALUES
+        ($1, $4::jsonb, $5::jsonb, 'system', 'en', 'UTC', false),
+        ($2, $4::jsonb, $6::jsonb, 'system', 'en', 'UTC', false),
+        ($3, $4::jsonb, $5::jsonb, 'system', 'en', 'UTC', false)
+      ON CONFLICT ("userId") DO UPDATE
+      SET "privacySettings" = EXCLUDED."privacySettings"
+      `,
+      [
+        alice.id,
+        hidden.id,
+        blocked.id,
+        JSON.stringify({
+          messages: { push: true, email: false, inApp: true },
+          mentions: { push: true, email: true, inApp: true },
+          system: { push: false, email: true, inApp: true },
+        }),
+        JSON.stringify({
+          lastSeenVisibility: 'everyone',
+          readReceiptsEnabled: true,
+          onlineStatusVisible: true,
+        }),
+        JSON.stringify({
+          lastSeenVisibility: 'nobody',
+          readReceiptsEnabled: true,
+          onlineStatusVisible: true,
+        }),
+      ],
+    );
+
+    await dataSource.query(
+      `
+      INSERT INTO saved_addresses ("userId", "walletAddress", alias, network, tags, "usageCount")
+      VALUES ($1, $2, 'Requester', 'stellar_mainnet', '{}', 0)
+      `,
+      [alice.id, requesterWallet],
+    );
+
+    await dataSource.query(
+      `
+      INSERT INTO discovery_user_blocks ("blockerId", "blockedId")
+      VALUES ($1, $2)
+      `,
+      [requester.id, blocked.id],
+    );
+  });
+
+  afterAll(async () => {
+    if (dataSource) {
+      await dataSource.query(`DELETE FROM discovery_user_blocks`);
+      await dataSource.query(`DELETE FROM saved_addresses`);
+      await dataSource.query(`DELETE FROM user_settings`);
+      await dataSource.getRepository(User).delete({});
+    }
+
+    if (app) {
+      await app.close();
+    }
+  });
+
+  it('GET /discover?q returns visible users and excludes hidden/blocked users', async () => {
+    await request(app.getHttpServer())
+      .get('/api/discover?q=ali')
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200)
+      .expect((res) => {
+        expect(Array.isArray(res.body)).toBe(true);
+        expect(res.body.some((u: any) => u.username === 'alice')).toBe(true);
+        expect(res.body.some((u: any) => u.username === 'hiddenone')).toBe(false);
+        expect(res.body.some((u: any) => u.username === 'blockedguy')).toBe(false);
+      });
+  });
+
+  it('GET /discover/username/:username returns a masked wallet card summary', async () => {
+    await request(app.getHttpServer())
+      .get('/api/discover/username/alice')
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200)
+      .expect((res) => {
+        expect(res.body.username).toBe('alice');
+        expect(res.body.walletAddressMasked).toContain('...');
+      });
+  });
+
+  it('GET /discover/:username/card returns public card with deep link', async () => {
+    await request(app.getHttpServer())
+      .get('/api/discover/alice/card')
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200)
+      .expect((res) => {
+        expect(res.body.username).toBe('alice');
+        expect(res.body.deepLink).toBe('gasless://profile/alice');
+      });
+  });
+
+  it('GET /discover/:username/qr returns PNG response', async () => {
+    await request(app.getHttpServer())
+      .get('/api/discover/alice/qr')
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200)
+      .expect('Content-Type', /image\/png/);
+  });
+});


### PR DESCRIPTION
## Summary
Implements a new Username-Based Contact Discovery module with privacy-aware user search, public profile cards, and QR profile links.

## What Changed
- Added discovery endpoints for username search, username lookup, wallet lookup, public card, and profile QR.
- Enforced privacy and visibility rules, including hidden profiles and blocked-user filtering.
- Added per-user discovery rate limiting and 60s cached public profile cards.
- Added migration and tests (unit + e2e) for discovery behavior.

## Issue Link
Closes #588 