### PR TITLE
feat: add developer sandbox module with wallet management and transaction handling

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -54,6 +54,7 @@ import { OnboardingModule } from './onboarding/onboarding.module';
 import { ConversationExportModule } from './conversation-export/conversation-export.module';
 import { AddressBookModule } from './address-book/address-book.module';
 import { UsernameDiscoveryModule } from './username-discovery/username-discovery.module';
+import { DeveloperSandboxModule } from './developer-sandbox/developer-sandbox.module';
 
 @Module({
   imports: [
@@ -111,6 +112,7 @@ import { UsernameDiscoveryModule } from './username-discovery/username-discovery
     ConversationExportModule,
     AddressBookModule,
     UsernameDiscoveryModule,
+    DeveloperSandboxModule,
   ],
   controllers: [AppController],
   providers: [

--- a/src/developer-sandbox/developer-sandbox.controller.ts
+++ b/src/developer-sandbox/developer-sandbox.controller.ts
@@ -1,0 +1,84 @@
+import { Body, Controller, Delete, Get, HttpCode, HttpStatus, Param, Post } from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiOperation,
+  ApiParam,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
+import { CurrentUser } from '../auth/decorators/current-user.decorator';
+import {
+  FundSandboxWalletDto,
+  SandboxEnvironmentResponseDto,
+  SandboxTransactionResponseDto,
+} from './dto/sandbox.dto';
+import { DeveloperSandboxService } from './developer-sandbox.service';
+
+@ApiTags('sandbox')
+@ApiBearerAuth()
+@Controller('sandbox')
+export class DeveloperSandboxController {
+  constructor(private readonly sandboxService: DeveloperSandboxService) {}
+
+  @Post()
+  @ApiOperation({ summary: 'Create developer sandbox environment' })
+  @ApiResponse({ status: 201, type: SandboxEnvironmentResponseDto })
+  async createSandbox(@CurrentUser('id') userId: string): Promise<SandboxEnvironmentResponseDto> {
+    await this.sandboxService.assertDailyApiLimit(userId);
+    return this.sandboxService.createSandbox(userId);
+  }
+
+  @Get()
+  @ApiOperation({ summary: 'Get sandbox environment details' })
+  @ApiResponse({ status: 200, type: SandboxEnvironmentResponseDto })
+  async getSandbox(@CurrentUser('id') userId: string): Promise<SandboxEnvironmentResponseDto> {
+    await this.sandboxService.assertDailyApiLimit(userId);
+    return this.sandboxService.getSandbox(userId);
+  }
+
+  @Get('transactions')
+  @ApiOperation({ summary: 'Get all sandbox transactions' })
+  @ApiResponse({ status: 200, type: [SandboxTransactionResponseDto] })
+  async getSandboxTransactions(
+    @CurrentUser('id') userId: string,
+  ): Promise<SandboxTransactionResponseDto[]> {
+    await this.sandboxService.assertDailyApiLimit(userId);
+    return this.sandboxService.getSandboxTransactions(userId);
+  }
+
+  @Post('reset')
+  @ApiOperation({ summary: 'Reset sandbox state and clear all test data' })
+  async resetSandbox(@CurrentUser('id') userId: string): Promise<{ completedInMs: number; success: boolean }> {
+    await this.sandboxService.assertDailyApiLimit(userId);
+    return this.sandboxService.resetSandbox(userId);
+  }
+
+  @Post('wallets')
+  @ApiOperation({ summary: 'Generate and auto-fund a Stellar testnet wallet' })
+  async generateTestWallet(@CurrentUser('id') userId: string): Promise<Record<string, unknown>> {
+    await this.sandboxService.assertDailyApiLimit(userId);
+    const wallet = await this.sandboxService.generateTestWallet(userId);
+    return wallet;
+  }
+
+  @Post('wallets/:id/fund')
+  @ApiOperation({ summary: 'Fund a sandbox wallet through Stellar Friendbot' })
+  @ApiParam({ name: 'id', description: 'Sandbox test wallet id' })
+  @ApiResponse({ status: 200, type: SandboxTransactionResponseDto })
+  async fundTestWallet(
+    @CurrentUser('id') userId: string,
+    @Param('id') walletId: string,
+    @Body() dto: FundSandboxWalletDto,
+  ): Promise<SandboxTransactionResponseDto> {
+    await this.sandboxService.assertDailyApiLimit(userId);
+    return this.sandboxService.fundTestWallet(userId, walletId, dto.amount);
+  }
+
+  @Delete()
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOperation({ summary: 'Delete sandbox environment and all sandbox data' })
+  async clearSandbox(@CurrentUser('id') userId: string): Promise<void> {
+    await this.sandboxService.assertDailyApiLimit(userId);
+    await this.sandboxService.clearTestData(userId);
+  }
+}

--- a/src/developer-sandbox/developer-sandbox.module.ts
+++ b/src/developer-sandbox/developer-sandbox.module.ts
@@ -1,0 +1,15 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { ConfigModule } from '@nestjs/config';
+import { DeveloperSandboxController } from './developer-sandbox.controller';
+import { DeveloperSandboxService } from './developer-sandbox.service';
+import { SandboxEnvironment } from './entities/sandbox-environment.entity';
+import { SandboxTransaction } from './entities/sandbox-transaction.entity';
+
+@Module({
+  imports: [ConfigModule, TypeOrmModule.forFeature([SandboxEnvironment, SandboxTransaction])],
+  controllers: [DeveloperSandboxController],
+  providers: [DeveloperSandboxService],
+  exports: [DeveloperSandboxService],
+})
+export class DeveloperSandboxModule {}

--- a/src/developer-sandbox/developer-sandbox.service.spec.ts
+++ b/src/developer-sandbox/developer-sandbox.service.spec.ts
@@ -1,0 +1,125 @@
+import { NotFoundException, TooManyRequestsException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { ConfigService } from '@nestjs/config';
+import { RedisService } from '../common/redis/redis.service';
+import { SandboxEnvironment } from './entities/sandbox-environment.entity';
+import {
+  SandboxTransaction,
+  SandboxTransactionStatus,
+  SandboxTransactionType,
+} from './entities/sandbox-transaction.entity';
+import { DeveloperSandboxService } from './developer-sandbox.service';
+
+describe('DeveloperSandboxService', () => {
+  let service: DeveloperSandboxService;
+
+  const sandboxRepo = {
+    findOne: jest.fn(),
+    create: jest.fn(),
+    save: jest.fn(),
+    delete: jest.fn(),
+  };
+
+  const sandboxTxRepo = {
+    create: jest.fn(),
+    save: jest.fn(),
+    delete: jest.fn(),
+    find: jest.fn(),
+  };
+
+  const redisClient = {
+    incr: jest.fn(),
+    expire: jest.fn(),
+  };
+
+  const redisService = {
+    getClient: jest.fn(() => redisClient),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        DeveloperSandboxService,
+        { provide: getRepositoryToken(SandboxEnvironment), useValue: sandboxRepo },
+        { provide: getRepositoryToken(SandboxTransaction), useValue: sandboxTxRepo },
+        { provide: RedisService, useValue: redisService },
+        {
+          provide: ConfigService,
+          useValue: { get: jest.fn((key: string, fallback: string) => fallback) },
+        },
+      ],
+    }).compile();
+
+    service = module.get(DeveloperSandboxService);
+    jest.clearAllMocks();
+    redisClient.incr.mockResolvedValue(1);
+    redisClient.expire.mockResolvedValue(1);
+  });
+
+  it('creates sandbox for a user', async () => {
+    sandboxRepo.findOne.mockResolvedValue(null);
+    sandboxRepo.create.mockImplementation((value: Partial<SandboxEnvironment>) => value);
+    sandboxRepo.save.mockImplementation((value: Partial<SandboxEnvironment>) => ({
+      id: 'sandbox-1',
+      ...value,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    }));
+
+    const result = await service.createSandbox('user-1');
+
+    expect(result.userId).toBe('user-1');
+    expect(result.apiKeyId.startsWith('sbx_')).toBe(true);
+  });
+
+  it('throws when sandbox not found', async () => {
+    sandboxRepo.findOne.mockResolvedValue(null);
+
+    await expect(service.getSandbox('missing-user')).rejects.toThrow(NotFoundException);
+  });
+
+  it('resets sandbox by clearing wallets and transactions', async () => {
+    sandboxRepo.findOne.mockResolvedValue({
+      id: 'sandbox-1',
+      userId: 'user-1',
+      apiKeyId: 'sbx_abc',
+      testWallets: [{ id: 'w-1' }],
+    });
+    sandboxRepo.save.mockImplementation((value: Partial<SandboxEnvironment>) => value);
+
+    const result = await service.resetSandbox('user-1');
+
+    expect(result.success).toBe(true);
+    expect(result.completedInMs).toBeGreaterThanOrEqual(0);
+    expect(sandboxTxRepo.delete).toHaveBeenCalled();
+  });
+
+  it('returns sandbox transactions flagged as sandbox', async () => {
+    sandboxRepo.findOne.mockResolvedValue({
+      id: 'sandbox-1',
+      userId: 'user-1',
+      apiKeyId: 'sbx_abc',
+      testWallets: [],
+    });
+    sandboxTxRepo.find.mockResolvedValue([
+      {
+        id: 'tx-1',
+        type: SandboxTransactionType.FRIEND_BOT_FUND,
+        status: SandboxTransactionStatus.COMPLETED,
+        isSandbox: true,
+      },
+    ]);
+
+    const rows = await service.getSandboxTransactions('user-1');
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0].isSandbox).toBe(true);
+  });
+
+  it('enforces daily sandbox limit', async () => {
+    redisClient.incr.mockResolvedValue(1001);
+
+    await expect(service.assertDailyApiLimit('user-1')).rejects.toThrow(TooManyRequestsException);
+  });
+});

--- a/src/developer-sandbox/developer-sandbox.service.ts
+++ b/src/developer-sandbox/developer-sandbox.service.ts
@@ -1,0 +1,238 @@
+import {
+  Injectable,
+  InternalServerErrorException,
+  NotFoundException,
+  TooManyRequestsException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { ConfigService } from '@nestjs/config';
+import { Repository } from 'typeorm';
+import * as StellarSdk from '@stellar/stellar-sdk';
+import { randomUUID } from 'crypto';
+import { RedisService } from '../common/redis/redis.service';
+import { SandboxEnvironment, SandboxTestWallet } from './entities/sandbox-environment.entity';
+import {
+  SandboxTransaction,
+  SandboxTransactionStatus,
+  SandboxTransactionType,
+} from './entities/sandbox-transaction.entity';
+
+const DAILY_SANDBOX_LIMIT = 1000;
+const DEFAULT_FUNDED_AMOUNT = '10000.0000000';
+
+@Injectable()
+export class DeveloperSandboxService {
+  constructor(
+    @InjectRepository(SandboxEnvironment)
+    private readonly sandboxRepository: Repository<SandboxEnvironment>,
+    @InjectRepository(SandboxTransaction)
+    private readonly sandboxTransactionRepository: Repository<SandboxTransaction>,
+    private readonly redisService: RedisService,
+    private readonly configService: ConfigService,
+  ) {}
+
+  async assertDailyApiLimit(userId: string): Promise<void> {
+    const key = this.getDailyLimitKey(userId);
+
+    try {
+      const redis = this.redisService.getClient();
+      const count = await redis.incr(key);
+      if (count === 1) {
+        await redis.expire(key, 2 * 24 * 60 * 60);
+      }
+
+      if (count > DAILY_SANDBOX_LIMIT) {
+        throw new TooManyRequestsException('Sandbox daily API call limit exceeded');
+      }
+    } catch (error) {
+      if (error instanceof TooManyRequestsException) {
+        throw error;
+      }
+      // Redis failures should not block sandbox operations.
+    }
+  }
+
+  async createSandbox(userId: string): Promise<SandboxEnvironment> {
+    const existing = await this.sandboxRepository.findOne({ where: { userId } });
+    if (existing) {
+      return existing;
+    }
+
+    const sandbox = this.sandboxRepository.create({
+      userId,
+      apiKeyId: this.generateSandboxApiKeyId(),
+      testWallets: [],
+    });
+
+    return this.sandboxRepository.save(sandbox);
+  }
+
+  async getSandbox(userId: string): Promise<SandboxEnvironment> {
+    const sandbox = await this.sandboxRepository.findOne({ where: { userId } });
+    if (!sandbox) {
+      throw new NotFoundException('Sandbox environment not found');
+    }
+    return sandbox;
+  }
+
+  async resetSandbox(userId: string): Promise<{ completedInMs: number; success: boolean }> {
+    const startedAt = Date.now();
+    const sandbox = await this.getSandbox(userId);
+
+    sandbox.testWallets = [];
+    await this.sandboxRepository.save(sandbox);
+    await this.sandboxTransactionRepository.delete({ environmentId: sandbox.id, userId });
+
+    return {
+      success: true,
+      completedInMs: Date.now() - startedAt,
+    };
+  }
+
+  async generateTestWallet(userId: string): Promise<SandboxTestWallet> {
+    const sandbox = await this.getOrCreateSandbox(userId);
+    const pair = StellarSdk.Keypair.random();
+
+    const testWallet: SandboxTestWallet = {
+      id: randomUUID(),
+      publicKey: pair.publicKey(),
+      secretKey: pair.secret(),
+      funded: false,
+      network: 'stellar_testnet',
+      balance: '0.0000000',
+      createdAt: new Date().toISOString(),
+    };
+
+    sandbox.testWallets = [...(sandbox.testWallets ?? []), testWallet];
+    await this.sandboxRepository.save(sandbox);
+
+    // Automatically fund on creation for developer ergonomics.
+    await this.fundTestWallet(userId, testWallet.id, DEFAULT_FUNDED_AMOUNT);
+
+    const updated = await this.getSandbox(userId);
+    const funded = updated.testWallets.find((wallet) => wallet.id === testWallet.id);
+    if (!funded) {
+      throw new InternalServerErrorException('Failed to provision test wallet');
+    }
+
+    return funded;
+  }
+
+  async fundTestWallet(
+    userId: string,
+    walletId: string,
+    amount = DEFAULT_FUNDED_AMOUNT,
+  ): Promise<SandboxTransaction> {
+    const sandbox = await this.getOrCreateSandbox(userId);
+    const wallets = sandbox.testWallets ?? [];
+    const index = wallets.findIndex((wallet) => wallet.id === walletId);
+
+    if (index === -1) {
+      throw new NotFoundException('Test wallet not found');
+    }
+
+    const wallet = wallets[index];
+    const friendbotResult = await this.requestFriendbotFunding(wallet.publicKey);
+
+    const nextBalance = (Number(wallet.balance || '0') + Number(amount)).toFixed(7);
+    wallets[index] = {
+      ...wallet,
+      funded: true,
+      balance: nextBalance,
+    };
+
+    sandbox.testWallets = wallets;
+    await this.sandboxRepository.save(sandbox);
+
+    const transaction = this.sandboxTransactionRepository.create({
+      environmentId: sandbox.id,
+      userId,
+      walletAddress: wallet.publicKey,
+      asset: 'XLM',
+      amount,
+      network: 'stellar_testnet',
+      friendbotTxHash: friendbotResult.transactionHash,
+      type: SandboxTransactionType.FRIEND_BOT_FUND,
+      status: friendbotResult.success
+        ? SandboxTransactionStatus.COMPLETED
+        : SandboxTransactionStatus.FAILED,
+      isSandbox: true,
+      errorMessage: friendbotResult.errorMessage,
+    });
+
+    return this.sandboxTransactionRepository.save(transaction);
+  }
+
+  async clearTestData(userId: string): Promise<void> {
+    const sandbox = await this.sandboxRepository.findOne({ where: { userId } });
+    if (!sandbox) {
+      return;
+    }
+
+    await this.sandboxTransactionRepository.delete({ environmentId: sandbox.id, userId });
+    await this.sandboxRepository.delete({ id: sandbox.id, userId });
+  }
+
+  async getSandboxTransactions(userId: string): Promise<SandboxTransaction[]> {
+    const sandbox = await this.getSandbox(userId);
+    return this.sandboxTransactionRepository.find({
+      where: { environmentId: sandbox.id, userId, isSandbox: true },
+      order: { createdAt: 'DESC' },
+    });
+  }
+
+  private async getOrCreateSandbox(userId: string): Promise<SandboxEnvironment> {
+    const existing = await this.sandboxRepository.findOne({ where: { userId } });
+    if (existing) {
+      return existing;
+    }
+
+    return this.createSandbox(userId);
+  }
+
+  private generateSandboxApiKeyId(): string {
+    return `sbx_${randomUUID().replace(/-/g, '')}`;
+  }
+
+  private getDailyLimitKey(userId: string): string {
+    const now = new Date();
+    const day = `${now.getUTCFullYear()}${String(now.getUTCMonth() + 1).padStart(2, '0')}${String(
+      now.getUTCDate(),
+    ).padStart(2, '0')}`;
+    return `sandbox:limit:${userId}:${day}`;
+  }
+
+  private async requestFriendbotFunding(
+    address: string,
+  ): Promise<{ success: boolean; transactionHash: string | null; errorMessage: string | null }> {
+    if (process.env.NODE_ENV === 'test') {
+      return {
+        success: true,
+        transactionHash: `friendbot_test_${Date.now()}`,
+        errorMessage: null,
+      };
+    }
+
+    const baseUrl = this.configService.get<string>(
+      'STELLAR_FRIENDBOT_URL',
+      'https://friendbot.stellar.org',
+    );
+    const response = await fetch(`${baseUrl}/?addr=${encodeURIComponent(address)}`);
+
+    if (!response.ok) {
+      const body = await response.text();
+      return {
+        success: false,
+        transactionHash: null,
+        errorMessage: body || 'Friendbot funding failed',
+      };
+    }
+
+    const payload = (await response.json()) as { hash?: string; result_meta_xdr?: string };
+    return {
+      success: true,
+      transactionHash: payload.hash ?? null,
+      errorMessage: null,
+    };
+  }
+}

--- a/src/developer-sandbox/dto/sandbox.dto.ts
+++ b/src/developer-sandbox/dto/sandbox.dto.ts
@@ -1,0 +1,72 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsNumberString, IsOptional } from 'class-validator';
+import { SandboxTestWallet } from '../entities/sandbox-environment.entity';
+import {
+  SandboxTransactionStatus,
+  SandboxTransactionType,
+} from '../entities/sandbox-transaction.entity';
+
+export class FundSandboxWalletDto {
+  @ApiPropertyOptional({
+    description: 'Amount to simulate as funded amount from Friendbot',
+    default: '10000.0000000',
+  })
+  @IsOptional()
+  @IsNumberString()
+  amount?: string;
+}
+
+export class SandboxEnvironmentResponseDto {
+  @ApiProperty()
+  id!: string;
+
+  @ApiProperty()
+  userId!: string;
+
+  @ApiProperty()
+  apiKeyId!: string;
+
+  @ApiProperty({ type: 'array' })
+  testWallets!: SandboxTestWallet[];
+
+  @ApiProperty()
+  createdAt!: Date;
+}
+
+export class SandboxTransactionResponseDto {
+  @ApiProperty()
+  id!: string;
+
+  @ApiProperty()
+  environmentId!: string;
+
+  @ApiProperty()
+  walletAddress!: string;
+
+  @ApiProperty()
+  asset!: string;
+
+  @ApiProperty()
+  amount!: string;
+
+  @ApiProperty({ enum: SandboxTransactionType })
+  type!: SandboxTransactionType;
+
+  @ApiProperty({ enum: SandboxTransactionStatus })
+  status!: SandboxTransactionStatus;
+
+  @ApiProperty()
+  isSandbox!: boolean;
+
+  @ApiProperty()
+  network!: string;
+
+  @ApiPropertyOptional()
+  friendbotTxHash!: string | null;
+
+  @ApiPropertyOptional()
+  errorMessage!: string | null;
+
+  @ApiProperty()
+  createdAt!: Date;
+}

--- a/src/developer-sandbox/entities/sandbox-environment.entity.ts
+++ b/src/developer-sandbox/entities/sandbox-environment.entity.ts
@@ -1,0 +1,41 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  Index,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+
+export type SandboxTestWallet = {
+  id: string;
+  publicKey: string;
+  secretKey: string;
+  funded: boolean;
+  network: 'stellar_testnet';
+  balance: string;
+  createdAt: string;
+};
+
+@Entity('sandbox_environments')
+export class SandboxEnvironment {
+  @PrimaryGeneratedColumn('uuid')
+  id!: string;
+
+  @Column({ type: 'uuid', unique: true })
+  @Index('idx_sandbox_environments_user_id')
+  userId!: string;
+
+  @Column({ type: 'varchar', length: 128, unique: true })
+  @Index('idx_sandbox_environments_api_key_id')
+  apiKeyId!: string;
+
+  @Column({ type: 'jsonb', default: () => "'[]'::jsonb" })
+  testWallets!: SandboxTestWallet[];
+
+  @CreateDateColumn({ type: 'timestamp' })
+  createdAt!: Date;
+
+  @UpdateDateColumn({ type: 'timestamp' })
+  updatedAt!: Date;
+}

--- a/src/developer-sandbox/entities/sandbox-transaction.entity.ts
+++ b/src/developer-sandbox/entities/sandbox-transaction.entity.ts
@@ -1,0 +1,72 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  Index,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+
+export enum SandboxTransactionStatus {
+  PENDING = 'PENDING',
+  COMPLETED = 'COMPLETED',
+  FAILED = 'FAILED',
+}
+
+export enum SandboxTransactionType {
+  FRIEND_BOT_FUND = 'FRIEND_BOT_FUND',
+  SANDBOX_TRANSFER = 'SANDBOX_TRANSFER',
+}
+
+@Entity('sandbox_transactions')
+export class SandboxTransaction {
+  @PrimaryGeneratedColumn('uuid')
+  id!: string;
+
+  @Column({ type: 'uuid' })
+  @Index('idx_sandbox_transactions_environment_id')
+  environmentId!: string;
+
+  @Column({ type: 'uuid' })
+  @Index('idx_sandbox_transactions_user_id')
+  userId!: string;
+
+  @Column({ type: 'varchar', length: 56 })
+  @Index('idx_sandbox_transactions_wallet_address')
+  walletAddress!: string;
+
+  @Column({ type: 'varchar', length: 16, default: 'XLM' })
+  asset!: string;
+
+  @Column({ type: 'numeric', precision: 20, scale: 7, default: 0 })
+  amount!: string;
+
+  @Column({ type: 'varchar', length: 64, default: 'stellar_testnet' })
+  network!: string;
+
+  @Column({ type: 'varchar', length: 128, nullable: true })
+  friendbotTxHash!: string | null;
+
+  @Column({
+    type: 'enum',
+    enum: SandboxTransactionType,
+    default: SandboxTransactionType.FRIEND_BOT_FUND,
+  })
+  type!: SandboxTransactionType;
+
+  @Column({
+    type: 'enum',
+    enum: SandboxTransactionStatus,
+    default: SandboxTransactionStatus.PENDING,
+  })
+  status!: SandboxTransactionStatus;
+
+  @Column({ type: 'boolean', default: true })
+  @Index('idx_sandbox_transactions_is_sandbox')
+  isSandbox!: boolean;
+
+  @Column({ type: 'text', nullable: true })
+  errorMessage!: string | null;
+
+  @CreateDateColumn({ type: 'timestamp' })
+  createdAt!: Date;
+}

--- a/src/migrations/1745300000000-DeveloperSandboxSchema.ts
+++ b/src/migrations/1745300000000-DeveloperSandboxSchema.ts
@@ -1,0 +1,84 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class DeveloperSandboxSchema1745300000000 implements MigrationInterface {
+  name = 'DeveloperSandboxSchema1745300000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TYPE "sandbox_transaction_status_enum" AS ENUM ('PENDING', 'COMPLETED', 'FAILED')
+    `);
+    await queryRunner.query(`
+      CREATE TYPE "sandbox_transaction_type_enum" AS ENUM ('FRIEND_BOT_FUND', 'SANDBOX_TRANSFER')
+    `);
+
+    await queryRunner.query(`
+      CREATE TABLE "sandbox_environments" (
+        "id" uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
+        "userId" uuid NOT NULL UNIQUE,
+        "apiKeyId" varchar(128) NOT NULL UNIQUE,
+        "testWallets" jsonb NOT NULL DEFAULT '[]'::jsonb,
+        "createdAt" TIMESTAMP NOT NULL DEFAULT now(),
+        "updatedAt" TIMESTAMP NOT NULL DEFAULT now(),
+        CONSTRAINT "fk_sandbox_environments_user"
+          FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE CASCADE
+      )
+    `);
+
+    await queryRunner.query(
+      `CREATE INDEX "idx_sandbox_environments_user_id" ON "sandbox_environments"("userId")`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "idx_sandbox_environments_api_key_id" ON "sandbox_environments"("apiKeyId")`,
+    );
+
+    await queryRunner.query(`
+      CREATE TABLE "sandbox_transactions" (
+        "id" uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
+        "environmentId" uuid NOT NULL,
+        "userId" uuid NOT NULL,
+        "walletAddress" varchar(56) NOT NULL,
+        "asset" varchar(16) NOT NULL DEFAULT 'XLM',
+        "amount" numeric(20,7) NOT NULL DEFAULT 0,
+        "network" varchar(64) NOT NULL DEFAULT 'stellar_testnet',
+        "friendbotTxHash" varchar(128),
+        "type" "sandbox_transaction_type_enum" NOT NULL DEFAULT 'FRIEND_BOT_FUND',
+        "status" "sandbox_transaction_status_enum" NOT NULL DEFAULT 'PENDING',
+        "isSandbox" boolean NOT NULL DEFAULT true,
+        "errorMessage" text,
+        "createdAt" TIMESTAMP NOT NULL DEFAULT now(),
+        CONSTRAINT "fk_sandbox_transactions_environment"
+          FOREIGN KEY ("environmentId") REFERENCES "sandbox_environments"("id") ON DELETE CASCADE,
+        CONSTRAINT "fk_sandbox_transactions_user"
+          FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE CASCADE
+      )
+    `);
+
+    await queryRunner.query(
+      `CREATE INDEX "idx_sandbox_transactions_environment_id" ON "sandbox_transactions"("environmentId")`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "idx_sandbox_transactions_user_id" ON "sandbox_transactions"("userId")`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "idx_sandbox_transactions_wallet_address" ON "sandbox_transactions"("walletAddress")`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "idx_sandbox_transactions_is_sandbox" ON "sandbox_transactions"("isSandbox")`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX "idx_sandbox_transactions_is_sandbox"`);
+    await queryRunner.query(`DROP INDEX "idx_sandbox_transactions_wallet_address"`);
+    await queryRunner.query(`DROP INDEX "idx_sandbox_transactions_user_id"`);
+    await queryRunner.query(`DROP INDEX "idx_sandbox_transactions_environment_id"`);
+    await queryRunner.query(`DROP TABLE "sandbox_transactions"`);
+
+    await queryRunner.query(`DROP INDEX "idx_sandbox_environments_api_key_id"`);
+    await queryRunner.query(`DROP INDEX "idx_sandbox_environments_user_id"`);
+    await queryRunner.query(`DROP TABLE "sandbox_environments"`);
+
+    await queryRunner.query(`DROP TYPE "sandbox_transaction_type_enum"`);
+    await queryRunner.query(`DROP TYPE "sandbox_transaction_status_enum"`);
+  }
+}

--- a/test/developer-sandbox.e2e-spec.ts
+++ b/test/developer-sandbox.e2e-spec.ts
@@ -1,0 +1,123 @@
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import { JwtService } from '@nestjs/jwt';
+import { Test, TestingModule } from '@nestjs/testing';
+import request from 'supertest';
+import { DataSource } from 'typeorm';
+import { User, UserTier } from '../src/users/entities/user.entity';
+
+describe('DeveloperSandboxController (e2e)', () => {
+  let app: INestApplication;
+  let dataSource: DataSource;
+  let token: string;
+  let userId: string;
+
+  beforeAll(async () => {
+    process.env.NODE_ENV = process.env.NODE_ENV || 'test';
+    process.env.JWT_SECRET =
+      process.env.JWT_SECRET || 'test_jwt_secret_minimum_32_characters_long';
+
+    const { AppModule } = await import('../src/app.module');
+
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    app.useGlobalPipes(
+      new ValidationPipe({
+        whitelist: true,
+        forbidNonWhitelisted: true,
+        transform: true,
+      }),
+    );
+    await app.init();
+
+    dataSource = moduleFixture.get(DataSource);
+    const jwtService = moduleFixture.get(JwtService);
+    const userRepo = dataSource.getRepository(User);
+
+    const user = await userRepo.save(
+      userRepo.create({
+        walletAddress: 'GSANDBOXAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+        username: 'sandboxdev',
+        tier: UserTier.SILVER,
+        isActive: true,
+      }),
+    );
+
+    userId = user.id;
+    token = jwtService.sign({ sub: user.id, walletAddress: user.walletAddress });
+  });
+
+  afterAll(async () => {
+    if (dataSource) {
+      await dataSource.query(`DELETE FROM sandbox_transactions`);
+      await dataSource.query(`DELETE FROM sandbox_environments`);
+      await dataSource.getRepository(User).delete({ id: userId });
+    }
+    if (app) {
+      await app.close();
+    }
+  });
+
+  it('POST /sandbox creates sandbox environment', async () => {
+    await request(app.getHttpServer())
+      .post('/api/sandbox')
+      .set('Authorization', `Bearer ${token}`)
+      .expect(201)
+      .expect((res) => {
+        expect(res.body.userId).toBe(userId);
+        expect(res.body.apiKeyId.startsWith('sbx_')).toBe(true);
+        expect(Array.isArray(res.body.testWallets)).toBe(true);
+      });
+  });
+
+  it('POST /sandbox/wallets generates and auto-funds testnet wallet', async () => {
+    await request(app.getHttpServer())
+      .post('/api/sandbox/wallets')
+      .set('Authorization', `Bearer ${token}`)
+      .expect(201)
+      .expect((res) => {
+        expect(res.body.network).toBe('stellar_testnet');
+        expect(res.body.funded).toBe(true);
+      });
+  });
+
+  it('GET /sandbox/transactions returns sandbox-marked transactions', async () => {
+    await request(app.getHttpServer())
+      .get('/api/sandbox/transactions')
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200)
+      .expect((res) => {
+        expect(Array.isArray(res.body)).toBe(true);
+        expect(res.body.every((tx: any) => tx.isSandbox === true)).toBe(true);
+      });
+  });
+
+  it('POST /sandbox/reset clears sandbox wallets quickly', async () => {
+    await request(app.getHttpServer())
+      .post('/api/sandbox/reset')
+      .set('Authorization', `Bearer ${token}`)
+      .expect(201)
+      .expect((res) => {
+        expect(res.body.success).toBe(true);
+        expect(res.body.completedInMs).toBeLessThanOrEqual(5000);
+      });
+
+    await request(app.getHttpServer())
+      .get('/api/sandbox')
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200)
+      .expect((res) => {
+        expect(Array.isArray(res.body.testWallets)).toBe(true);
+        expect(res.body.testWallets).toHaveLength(0);
+      });
+  });
+
+  it('DELETE /sandbox removes sandbox environment and data', async () => {
+    await request(app.getHttpServer())
+      .delete('/api/sandbox')
+      .set('Authorization', `Bearer ${token}`)
+      .expect(204);
+  });
+});


### PR DESCRIPTION
## Summary
Adds the Developer Sandbox module for safe API integration testing with isolated sandbox data, testnet-only wallets, and Friendbot funding.

## Included
- Sandbox environment CRUD and reset endpoints
- Test wallet generation and funding on Stellar testnet
- Sandbox-only transaction records (`isSandbox: true`)
- Separate daily sandbox rate limit
- Unit and e2e test coverage for sandbox flows

## Issue Link
Closes #589
