### PR TITLE
Feat : Smart Notification Digest Module

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -64,6 +64,7 @@ import { DeveloperSandboxModule } from './developer-sandbox/developer-sandbox.mo
 import { StoriesModule } from './stories/stories.module';
 import { PaymentsModule } from './payments/payments.module';
 import { LinkPreviewsModule } from './link-previews/link-previews.module';
+import { NotificationDigestModule } from './notification-digest/notification-digest.module';
 
 @Module({
   imports: [
@@ -131,6 +132,7 @@ import { LinkPreviewsModule } from './link-previews/link-previews.module';
     StoriesModule,
     PaymentsModule,
     LinkPreviewsModule,
+    NotificationDigestModule,
   ],
 
   controllers: [AppController],

--- a/src/mail/mail.service.ts
+++ b/src/mail/mail.service.ts
@@ -42,4 +42,47 @@ export class MailService {
       this.logger.error(`Failed to send confirmation to ${email}`, err);
     }
   }
+
+  /**
+   * Sends a grouped notification digest email summary.
+   */
+  async sendDigestEmail(
+    email: string,
+    grouped: Record<string, unknown[]>,
+    totalCount: number,
+  ): Promise<void> {
+    try {
+      const rows = Object.entries(grouped)
+        .map(
+          ([type, items]) =>
+            `<tr><td style="padding:4px 8px">${type.replace(/_/g, ' ')}</td>` +
+            `<td style="padding:4px 8px;text-align:center"><strong>${items.length}</strong></td></tr>`,
+        )
+        .join('');
+
+      await this.transporter.sendMail({
+        from: `"Gasless Gossip" <${this.config.get('MAIL_FROM', 'noreply@gaslessgossip.com')}>`,
+        to: email,
+        subject: `📋 Your notification digest – ${totalCount} missed notification${totalCount === 1 ? '' : 's'}`,
+        html: `
+          <h2>Here's what you missed 📋</h2>
+          <p>You had <strong>${totalCount}</strong> notification${totalCount === 1 ? '' : 's'} during your quiet hours.</p>
+          <table border="0" cellpadding="0" cellspacing="0" style="border-collapse:collapse;margin-top:16px">
+            <thead>
+              <tr style="background:#f3f4f6">
+                <th style="padding:8px;text-align:left">Type</th>
+                <th style="padding:8px;text-align:center">Count</th>
+              </tr>
+            </thead>
+            <tbody>${rows}</tbody>
+          </table>
+          <p style="margin-top:16px;color:#6b7280;font-size:12px">
+            Open the app to view your notifications in full.
+          </p>
+        `,
+      });
+    } catch (err) {
+      this.logger.error(`Failed to send digest email to ${email}`, err);
+    }
+  }
 }

--- a/src/notification-digest/dto/notification-digest-response.dto.ts
+++ b/src/notification-digest/dto/notification-digest-response.dto.ts
@@ -1,0 +1,35 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class QuietHoursConfigResponseDto {
+  @ApiProperty()
+  userId!: string;
+
+  @ApiProperty()
+  isEnabled!: boolean;
+
+  @ApiProperty()
+  startTime!: string;
+
+  @ApiProperty()
+  endTime!: string;
+
+  @ApiProperty()
+  timezone!: string;
+
+  @ApiProperty({ type: [String] })
+  exemptTypes!: string[];
+
+  @ApiProperty()
+  updatedAt!: Date;
+}
+
+export class DigestSendResponseDto {
+  @ApiProperty()
+  digestId!: string;
+
+  @ApiProperty()
+  notificationCount!: number;
+
+  @ApiProperty()
+  sentAt!: Date;
+}

--- a/src/notification-digest/dto/set-quiet-hours.dto.ts
+++ b/src/notification-digest/dto/set-quiet-hours.dto.ts
@@ -1,0 +1,49 @@
+import { ApiProperty } from '@nestjs/swagger';
+import {
+  ArrayUnique,
+  IsArray,
+  IsBoolean,
+  IsIn,
+  IsOptional,
+  IsString,
+  Matches,
+} from 'class-validator';
+import { InAppNotificationType } from '../../notifications/entities/notification.entity';
+
+const TIME_REGEX = /^([01]\d|2[0-3]):[0-5]\d$/;
+
+export const EXEMPT_NOTIFICATION_TYPES = [
+  InAppNotificationType.TRANSFER_RECEIVED,
+  'SECURITY_ALERT',
+] as const;
+
+export class SetQuietHoursDto {
+  @ApiProperty({ example: true })
+  @IsBoolean()
+  isEnabled!: boolean;
+
+  @ApiProperty({ example: '22:00', description: '24-hour HH:MM format' })
+  @IsString()
+  @Matches(TIME_REGEX, { message: 'startTime must be in HH:MM format' })
+  startTime!: string;
+
+  @ApiProperty({ example: '08:00', description: '24-hour HH:MM format' })
+  @IsString()
+  @Matches(TIME_REGEX, { message: 'endTime must be in HH:MM format' })
+  endTime!: string;
+
+  @ApiProperty({ example: 'America/New_York', description: 'IANA timezone' })
+  @IsString()
+  timezone!: string;
+
+  @ApiProperty({
+    example: ['TRANSFER_RECEIVED', 'SECURITY_ALERT'],
+    description: 'Notification types exempt from quiet hours',
+    required: false,
+  })
+  @IsOptional()
+  @IsArray()
+  @ArrayUnique()
+  @IsIn(EXEMPT_NOTIFICATION_TYPES, { each: true })
+  exemptTypes?: string[];
+}

--- a/src/notification-digest/entities/notification-digest.entity.ts
+++ b/src/notification-digest/entities/notification-digest.entity.ts
@@ -1,0 +1,41 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  Index,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+
+export enum DigestPeriod {
+  HOURLY = 'HOURLY',
+  DAILY = 'DAILY',
+}
+
+@Entity('notification_digests')
+@Index('idx_digest_user_scheduled', ['userId', 'scheduledFor'])
+@Index('idx_digest_user_sent', ['userId', 'summarySent'])
+export class NotificationDigest {
+  @PrimaryGeneratedColumn('uuid')
+  id!: string;
+
+  @Column({ type: 'uuid' })
+  userId!: string;
+
+  @Column({ type: 'enum', enum: DigestPeriod })
+  period!: DigestPeriod;
+
+  @Column({ type: 'simple-array', nullable: true })
+  notificationIds!: string[];
+
+  @Column({ type: 'boolean', default: false })
+  summarySent!: boolean;
+
+  @Column({ type: 'timestamp' })
+  scheduledFor!: Date;
+
+  @Column({ type: 'timestamp', nullable: true })
+  sentAt!: Date | null;
+
+  @CreateDateColumn({ type: 'timestamp' })
+  createdAt!: Date;
+}

--- a/src/notification-digest/entities/quiet-hours-config.entity.ts
+++ b/src/notification-digest/entities/quiet-hours-config.entity.ts
@@ -1,0 +1,56 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  Index,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+import { InAppNotificationType } from '../../notifications/entities/notification.entity';
+
+@Entity('quiet_hours_configs')
+export class QuietHoursConfig {
+  @PrimaryGeneratedColumn('uuid')
+  id!: string;
+
+  @Column({ type: 'uuid', unique: true })
+  @Index('idx_quiet_hours_user')
+  userId!: string;
+
+  @Column({ type: 'boolean', default: false })
+  isEnabled!: boolean;
+
+  /**
+   * 24-hour format string e.g. "22:00"
+   */
+  @Column({ type: 'varchar', length: 5, default: '22:00' })
+  startTime!: string;
+
+  /**
+   * 24-hour format string e.g. "08:00"
+   */
+  @Column({ type: 'varchar', length: 5, default: '08:00' })
+  endTime!: string;
+
+  /**
+   * IANA timezone identifier e.g. "America/New_York"
+   */
+  @Column({ type: 'varchar', length: 64, default: 'UTC' })
+  timezone!: string;
+
+  /**
+   * Notification types that bypass quiet hours (always delivered immediately)
+   */
+  @Column({
+    type: 'simple-array',
+    nullable: true,
+    default: `${InAppNotificationType.TRANSFER_RECEIVED},SECURITY_ALERT`,
+  })
+  exemptTypes!: string[];
+
+  @CreateDateColumn({ type: 'timestamp' })
+  createdAt!: Date;
+
+  @UpdateDateColumn({ type: 'timestamp' })
+  updatedAt!: Date;
+}

--- a/src/notification-digest/notification-digest.controller.spec.ts
+++ b/src/notification-digest/notification-digest.controller.spec.ts
@@ -1,0 +1,47 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { NotificationDigestController } from './notification-digest.controller';
+import { NotificationDigestService } from './notification-digest.service';
+
+describe('NotificationDigestController', () => {
+  let controller: NotificationDigestController;
+  let service: NotificationDigestService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [NotificationDigestController],
+      providers: [
+        {
+          provide: NotificationDigestService,
+          useValue: {
+            getQuietHoursConfig: jest.fn(),
+            setQuietHours: jest.fn(),
+            sendDigest: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    controller = module.get<NotificationDigestController>(NotificationDigestController);
+    service = module.get<NotificationDigestService>(NotificationDigestService);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  it('getQuietHours calls service', async () => {
+    await controller.getQuietHours({ user: { userId: '123' } });
+    expect(service.getQuietHoursConfig).toHaveBeenCalledWith('123');
+  });
+
+  it('setQuietHours calls service', async () => {
+    const dto = { isEnabled: true, startTime: '22:00', endTime: '08:00', timezone: 'UTC' };
+    await controller.setQuietHours({ user: { userId: '123' } }, dto);
+    expect(service.setQuietHours).toHaveBeenCalledWith('123', dto);
+  });
+
+  it('sendNow calls service', async () => {
+    await controller.sendNow({ user: { userId: '123' } });
+    expect(service.sendDigest).toHaveBeenCalledWith('123');
+  });
+});

--- a/src/notification-digest/notification-digest.controller.ts
+++ b/src/notification-digest/notification-digest.controller.ts
@@ -1,0 +1,69 @@
+import {
+  Body,
+  Controller,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Post,
+  Put,
+  Request,
+  UseGuards,
+} from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiOperation,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { NotificationDigestService } from './notification-digest.service';
+import { SetQuietHoursDto } from './dto/set-quiet-hours.dto';
+import {
+  DigestSendResponseDto,
+  QuietHoursConfigResponseDto,
+} from './dto/notification-digest-response.dto';
+
+@ApiTags('Notification Digest')
+@ApiBearerAuth()
+@UseGuards(JwtAuthGuard)
+@Controller()
+export class NotificationDigestController {
+  constructor(private readonly digestService: NotificationDigestService) {}
+
+  // ─── GET /settings/quiet-hours ───────────────────────────────────────────────
+
+  @Get('settings/quiet-hours')
+  @ApiOperation({ summary: "Get the current user's quiet hours configuration" })
+  @ApiResponse({ status: 200, type: QuietHoursConfigResponseDto })
+  async getQuietHours(
+    @Request() req: { user: { userId: string } },
+  ): Promise<QuietHoursConfigResponseDto> {
+    return this.digestService.getQuietHoursConfig(req.user.userId);
+  }
+
+  // ─── PUT /settings/quiet-hours ───────────────────────────────────────────────
+
+  @Put('settings/quiet-hours')
+  @ApiOperation({ summary: "Update the current user's quiet hours configuration" })
+  @ApiResponse({ status: 200, type: QuietHoursConfigResponseDto })
+  async setQuietHours(
+    @Request() req: { user: { userId: string } },
+    @Body() dto: SetQuietHoursDto,
+  ): Promise<QuietHoursConfigResponseDto> {
+    return this.digestService.setQuietHours(req.user.userId, dto);
+  }
+
+  // ─── POST /notifications/digest/send-now ────────────────────────────────────
+
+  @Post('notifications/digest/send-now')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: 'Immediately flush and send the pending notification digest',
+  })
+  @ApiResponse({ status: 200, type: DigestSendResponseDto })
+  async sendNow(
+    @Request() req: { user: { userId: string } },
+  ): Promise<DigestSendResponseDto> {
+    return this.digestService.sendDigest(req.user.userId);
+  }
+}

--- a/src/notification-digest/notification-digest.e2e.spec.ts
+++ b/src/notification-digest/notification-digest.e2e.spec.ts
@@ -1,0 +1,33 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication } from '@nestjs/common';
+import * as request from 'supertest';
+import { AppModule } from '../app.module';
+
+describe('NotificationDigestController (e2e)', () => {
+  let app: INestApplication;
+  let jwtToken: string;
+  let userId: string;
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    await app.init();
+
+    // In a real e2e test environment, we would seed the DB and get a token.
+    // For this test, we assume standard auth bypass or mock token generation.
+    // We will simulate the endpoints using a mock user guard or bypass if possible.
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('GET /settings/quiet-hours (Unauthorized)', () => {
+    return request(app.getHttpServer())
+      .get('/settings/quiet-hours')
+      .expect(401);
+  });
+});

--- a/src/notification-digest/notification-digest.module.ts
+++ b/src/notification-digest/notification-digest.module.ts
@@ -1,0 +1,23 @@
+import { Module, forwardRef } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { NotificationDigest } from './entities/notification-digest.entity';
+import { QuietHoursConfig } from './entities/quiet-hours-config.entity';
+import { NotificationDigestService } from './notification-digest.service';
+import { NotificationDigestController } from './notification-digest.controller';
+import { NotificationsModule } from '../notifications/notifications.module';
+import { MessagingModule } from '../messaging/messaging.module';
+import { MailModule } from '../mail/mail.module';
+import { User } from '../users/entities/user.entity';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([NotificationDigest, QuietHoursConfig, User]),
+    forwardRef(() => NotificationsModule),
+    MessagingModule,
+    MailModule,
+  ],
+  controllers: [NotificationDigestController],
+  providers: [NotificationDigestService],
+  exports: [NotificationDigestService],
+})
+export class NotificationDigestModule {}

--- a/src/notification-digest/notification-digest.service.spec.ts
+++ b/src/notification-digest/notification-digest.service.spec.ts
@@ -1,0 +1,164 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { DataSource, Repository } from 'typeorm';
+import { NotificationDigestService } from './notification-digest.service';
+import { NotificationDigest, DigestPeriod } from './entities/notification-digest.entity';
+import { QuietHoursConfig } from './entities/quiet-hours-config.entity';
+import { User } from '../users/entities/user.entity';
+import { NotificationsRepository } from '../notifications/notifications.repository';
+import { NotificationsGateway } from '../messaging/gateways/notifications.gateway';
+import { MailService } from '../mail/mail.service';
+import { InAppNotificationType } from '../notifications/entities/notification.entity';
+import { EXEMPT_NOTIFICATION_TYPES } from './dto/set-quiet-hours.dto';
+
+describe('NotificationDigestService', () => {
+  let service: NotificationDigestService;
+  let digestRepo: Repository<NotificationDigest>;
+  let quietHoursRepo: Repository<QuietHoursConfig>;
+  let userRepo: Repository<User>;
+  let mailService: MailService;
+  let notificationsGateway: NotificationsGateway;
+  let queryBuilder: any;
+
+  beforeEach(async () => {
+    queryBuilder = {
+      where: jest.fn().mockReturnThis(),
+      andWhere: jest.fn().mockReturnThis(),
+      getMany: jest.fn().mockResolvedValue([]),
+    };
+
+    const mockDataSource = {
+      getRepository: jest.fn().mockReturnValue({
+        createQueryBuilder: jest.fn().mockReturnValue(queryBuilder),
+      }),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        NotificationDigestService,
+        {
+          provide: getRepositoryToken(NotificationDigest),
+          useValue: {
+            create: jest.fn(),
+            save: jest.fn(),
+            findOne: jest.fn(),
+            find: jest.fn(),
+          },
+        },
+        {
+          provide: getRepositoryToken(QuietHoursConfig),
+          useValue: {
+            create: jest.fn(),
+            save: jest.fn(),
+            findOne: jest.fn(),
+          },
+        },
+        {
+          provide: getRepositoryToken(User),
+          useValue: {
+            findOne: jest.fn(),
+          },
+        },
+        {
+          provide: NotificationsRepository,
+          useValue: {
+            findByIdForUser: jest.fn(),
+          },
+        },
+        {
+          provide: NotificationsGateway,
+          useValue: {
+            sendNotification: jest.fn(),
+          },
+        },
+        {
+          provide: MailService,
+          useValue: {
+            sendDigestEmail: jest.fn(),
+          },
+        },
+        {
+          provide: DataSource,
+          useValue: mockDataSource,
+        },
+      ],
+    }).compile();
+
+    service = module.get<NotificationDigestService>(NotificationDigestService);
+    digestRepo = module.get(getRepositoryToken(NotificationDigest));
+    quietHoursRepo = module.get(getRepositoryToken(QuietHoursConfig));
+    userRepo = module.get(getRepositoryToken(User));
+    mailService = module.get(MailService);
+    notificationsGateway = module.get(NotificationsGateway);
+  });
+
+  describe('isInQuietHours', () => {
+    it('returns false if not enabled', async () => {
+      jest.spyOn(quietHoursRepo, 'findOne').mockResolvedValue({ isEnabled: false } as any);
+      const result = await service.isInQuietHours('user-1');
+      expect(result).toBe(false);
+    });
+
+    it('handles normal window bounds correctly', async () => {
+      jest.spyOn(service as any, 'getNowInTimezone').mockReturnValue('10:00');
+      jest.spyOn(quietHoursRepo, 'findOne').mockResolvedValue({
+        isEnabled: true,
+        startTime: '09:00',
+        endTime: '17:00',
+      } as any);
+
+      const result = await service.isInQuietHours('user-1');
+      expect(result).toBe(true);
+    });
+
+    it('handles overnight window correctly', async () => {
+      jest.spyOn(service as any, 'getNowInTimezone').mockReturnValue('23:00');
+      jest.spyOn(quietHoursRepo, 'findOne').mockResolvedValue({
+        isEnabled: true,
+        startTime: '22:00',
+        endTime: '08:00',
+      } as any);
+
+      const result = await service.isInQuietHours('user-1');
+      expect(result).toBe(true);
+    });
+  });
+
+  describe('queueForDigest', () => {
+    it('creates new digest if none pending', async () => {
+      jest.spyOn(digestRepo, 'findOne').mockResolvedValue(null);
+      const createSpy = jest.spyOn(digestRepo, 'create').mockReturnValue({ id: 'd-1' } as any);
+      const saveSpy = jest.spyOn(digestRepo, 'save');
+
+      await service.queueForDigest('u-1', 'n-1');
+
+      expect(createSpy).toHaveBeenCalledWith(expect.objectContaining({ userId: 'u-1' }));
+      expect(saveSpy).toHaveBeenCalled();
+    });
+
+    it('appends to existing digest', async () => {
+      const digest = { id: 'd-1', notificationIds: ['n-1'] };
+      jest.spyOn(digestRepo, 'findOne').mockResolvedValue(digest as any);
+      const saveSpy = jest.spyOn(digestRepo, 'save');
+
+      await service.queueForDigest('u-1', 'n-2');
+
+      expect(digest.notificationIds).toContain('n-2');
+      expect(saveSpy).toHaveBeenCalledWith(digest);
+    });
+  });
+
+  describe('isExemptType', () => {
+    it('returns true for TRANSFER_RECEIVED', () => {
+      expect(
+        service.isExemptType(InAppNotificationType.TRANSFER_RECEIVED, [...EXEMPT_NOTIFICATION_TYPES]),
+      ).toBe(true);
+    });
+
+    it('returns false for NEW_MESSAGE', () => {
+      expect(
+        service.isExemptType(InAppNotificationType.NEW_MESSAGE, [...EXEMPT_NOTIFICATION_TYPES]),
+      ).toBe(false);
+    });
+  });
+});

--- a/src/notification-digest/notification-digest.service.ts
+++ b/src/notification-digest/notification-digest.service.ts
@@ -1,0 +1,347 @@
+import { Injectable, Logger, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Cron } from '@nestjs/schedule';
+import { DataSource, Repository } from 'typeorm';
+import {
+  NotificationDigest,
+  DigestPeriod,
+} from './entities/notification-digest.entity';
+import { QuietHoursConfig } from './entities/quiet-hours-config.entity';
+import { NotificationsRepository } from '../notifications/notifications.repository';
+import { NotificationsGateway } from '../messaging/gateways/notifications.gateway';
+import { MailService } from '../mail/mail.service';
+import { User } from '../users/entities/user.entity';
+import { SetQuietHoursDto, EXEMPT_NOTIFICATION_TYPES } from './dto/set-quiet-hours.dto';
+import {
+  QuietHoursConfigResponseDto,
+  DigestSendResponseDto,
+} from './dto/notification-digest-response.dto';
+import { InAppNotificationType } from '../notifications/entities/notification.entity';
+import { NotificationType } from '../messaging/dto/notification-events.dto';
+
+@Injectable()
+export class NotificationDigestService {
+  private readonly logger = new Logger(NotificationDigestService.name);
+
+  constructor(
+    @InjectRepository(NotificationDigest)
+    private readonly digestRepository: Repository<NotificationDigest>,
+    @InjectRepository(QuietHoursConfig)
+    private readonly quietHoursRepository: Repository<QuietHoursConfig>,
+    private readonly notificationsRepository: NotificationsRepository,
+    private readonly notificationsGateway: NotificationsGateway,
+    private readonly mailService: MailService,
+    @InjectRepository(User)
+    private readonly userRepository: Repository<User>,
+    private readonly dataSource: DataSource,
+  ) {}
+
+  // ─── Quiet Hours Config ──────────────────────────────────────────────────────
+
+  async getQuietHoursConfig(userId: string): Promise<QuietHoursConfigResponseDto> {
+    const config = await this.findOrCreateConfig(userId);
+    return this.toConfigDto(config);
+  }
+
+  async setQuietHours(
+    userId: string,
+    dto: SetQuietHoursDto,
+  ): Promise<QuietHoursConfigResponseDto> {
+    const config = await this.findOrCreateConfig(userId);
+
+    config.isEnabled = dto.isEnabled;
+    config.startTime = dto.startTime;
+    config.endTime = dto.endTime;
+    config.timezone = dto.timezone;
+    config.exemptTypes = dto.exemptTypes ?? [...EXEMPT_NOTIFICATION_TYPES];
+
+    const saved = await this.quietHoursRepository.save(config);
+    return this.toConfigDto(saved);
+  }
+
+  /**
+   * Returns true when the current wall-clock moment falls within the user's
+   * configured quiet window, respecting their IANA timezone.
+   */
+  async isInQuietHours(userId: string): Promise<boolean> {
+    const config = await this.findOrCreateConfig(userId);
+
+    if (!config.isEnabled) return false;
+
+    const nowInTz = this.getNowInTimezone(config.timezone);
+    return this.timeIsInWindow(nowInTz, config.startTime, config.endTime);
+  }
+
+  // ─── Digest Queue & Delivery ────────────────────────────────────────────────
+
+  /**
+   * Queue a notification for the digest instead of delivering it immediately.
+   * Creates or appends to the pending hourly digest for the user.
+   */
+  async queueForDigest(userId: string, notificationId: string): Promise<void> {
+    const now = new Date();
+    // Find open (unsent) digest for this user
+    let digest = await this.digestRepository.findOne({
+      where: { userId, summarySent: false, period: DigestPeriod.HOURLY },
+      order: { createdAt: 'DESC' },
+    });
+
+    if (!digest) {
+      // Create a new digest slot scheduled 1 hour from now
+      const scheduledFor = new Date(now.getTime() + 60 * 60 * 1000);
+      digest = this.digestRepository.create({
+        userId,
+        period: DigestPeriod.HOURLY,
+        notificationIds: [notificationId],
+        summarySent: false,
+        scheduledFor,
+        sentAt: null,
+      });
+    } else {
+      if (!digest.notificationIds) digest.notificationIds = [];
+      if (!digest.notificationIds.includes(notificationId)) {
+        digest.notificationIds = [...digest.notificationIds, notificationId];
+      }
+    }
+
+    await this.digestRepository.save(digest);
+    this.logger.debug(
+      `Queued notification ${notificationId} into digest for user ${userId}`,
+    );
+  }
+
+  /**
+   * Immediately send the pending digest for a user and mark it as sent.
+   * Used by flushOnWakeup and the manual "send-now" endpoint.
+   */
+  async sendDigest(userId: string): Promise<DigestSendResponseDto> {
+    const digest = await this.digestRepository.findOne({
+      where: { userId, summarySent: false },
+      order: { createdAt: 'DESC' },
+    });
+
+    if (!digest || !digest.notificationIds?.length) {
+      throw new NotFoundException('No pending digest found for user');
+    }
+
+    return this.deliverDigest(digest);
+  }
+
+  /**
+   * Called when a user's quiet-hours window ends.
+   * Sends the accumulated digest for every user whose quiet window just ended.
+   */
+  async flushOnWakeup(): Promise<void> {
+    // Find all users who have a pending digest
+    const pendingDigests = await this.digestRepository.find({
+      where: { summarySent: false },
+    });
+
+    const userIds = [...new Set(pendingDigests.map((d) => d.userId))];
+
+    for (const userId of userIds) {
+      const isInQH = await this.isInQuietHours(userId);
+      if (!isInQH) {
+        // Quiet hours just ended – flush
+        const userDigests = pendingDigests.filter(
+          (d: NotificationDigest) => d.userId === userId && d.notificationIds?.length,
+        );
+        for (const d of userDigests) {
+          try {
+            await this.deliverDigest(d);
+          } catch (err) {
+            this.logger.error(`Failed to flush digest ${d.id} for user ${userId}`, err);
+          }
+        }
+      }
+    }
+  }
+
+  // ─── Cron Scheduler ─────────────────────────────────────────────────────────
+
+  /**
+   * Runs every hour. Delivers all digests whose scheduledFor time has passed.
+   */
+  @Cron('0 * * * *')
+  async runHourlyDigestScheduler(): Promise<void> {
+    this.logger.log('Running hourly digest scheduler…');
+    const now = new Date();
+
+    const due = await this.dataSource
+      .getRepository(NotificationDigest)
+      .createQueryBuilder('d')
+      .where('d.summarySent = false')
+      .andWhere('d.scheduledFor <= :now', { now })
+      .andWhere("array_length(d.notificationIds, 1) > 0")
+      .getMany();
+
+    this.logger.log(`Found ${due.length} due digests`);
+
+    for (const digest of due) {
+      try {
+        await this.deliverDigest(digest);
+      } catch (err) {
+        this.logger.error(`Failed to deliver digest ${digest.id}`, err);
+      }
+    }
+
+    // Also check for users whose quiet hours have ended
+    await this.flushOnWakeup();
+  }
+
+  // ─── Quiet-Hours Gate (used by NotificationsService) ────────────────────────
+
+  /**
+   * Checks if a notification type is exempt from quiet hours.
+   */
+  isExemptType(type: InAppNotificationType, exemptTypes: string[]): boolean {
+    return exemptTypes.includes(type as string);
+  }
+
+  // ─── Private Helpers ─────────────────────────────────────────────────────────
+
+  private async deliverDigest(digest: NotificationDigest): Promise<DigestSendResponseDto> {
+    const notificationIds = digest.notificationIds ?? [];
+    const userId = digest.userId;
+
+    // Fetch notification records for the digest
+    const notifications = await Promise.allSettled(
+      notificationIds.map((id) =>
+        this.notificationsRepository.findByIdForUser(id, userId),
+      ),
+    );
+
+    const valid = notifications
+      .filter((r) => r.status === 'fulfilled' && r.value)
+      .map((r) => (r as PromiseFulfilledResult<any>).value!);
+
+    if (valid.length === 0) {
+      // Mark empty digest as sent so it doesn't loop
+      digest.summarySent = true;
+      digest.sentAt = new Date();
+      await this.digestRepository.save(digest);
+      throw new NotFoundException('No valid notifications found in digest');
+    }
+
+    // Build grouped summary
+    const grouped = this.groupByType(valid);
+    const summaryText = this.buildSummaryText(grouped);
+
+    // Push single WebSocket summary notification
+    await this.notificationsGateway.sendNotification(userId, {
+      id: digest.id,
+      type: NotificationType.NEW_MESSAGE, // generic digest type
+      title: `📋 Notification Digest (${valid.length} missed)`,
+      body: summaryText,
+      data: { digestId: digest.id, count: valid.length },
+    });
+
+    // Send digest email if user has an email address
+    try {
+      const user = await this.userRepository.findOne({ where: { id: userId } });
+      if (user?.email) {
+        await this.mailService.sendDigestEmail(user.email, grouped, valid.length);
+      }
+    } catch (err) {
+      this.logger.error(`Failed to send digest email for user ${userId}`, err);
+    }
+
+    // Mark digest as sent
+    digest.summarySent = true;
+    digest.sentAt = new Date();
+    await this.digestRepository.save(digest);
+
+    const sentAt = digest.sentAt!;
+    return {
+      digestId: digest.id,
+      notificationCount: valid.length,
+      sentAt,
+    };
+  }
+
+  private groupByType(notifications: any[]): Record<string, any[]> {
+    return notifications.reduce(
+      (acc, n) => {
+        const key: string = n.type ?? 'OTHER';
+        if (!acc[key]) acc[key] = [];
+        acc[key].push(n);
+        return acc;
+      },
+      {} as Record<string, any[]>,
+    );
+  }
+
+  private buildSummaryText(grouped: Record<string, any[]>): string {
+    return Object.entries(grouped)
+      .map(([type, items]) => `${type.replace(/_/g, ' ')}: ${items.length}`)
+      .join(' · ');
+  }
+
+  private async findOrCreateConfig(userId: string): Promise<QuietHoursConfig> {
+    let config = await this.quietHoursRepository.findOne({ where: { userId } });
+    if (!config) {
+      config = this.quietHoursRepository.create({
+        userId,
+        isEnabled: false,
+        startTime: '22:00',
+        endTime: '08:00',
+        timezone: 'UTC',
+        exemptTypes: [...EXEMPT_NOTIFICATION_TYPES],
+      });
+      await this.quietHoursRepository.save(config);
+    }
+    return config;
+  }
+
+  /**
+   * Get current time in user's timezone as HH:MM string.
+   */
+  private getNowInTimezone(tz: string): string {
+    try {
+      return new Intl.DateTimeFormat('en-US', {
+        timeZone: tz,
+        hour: '2-digit',
+        minute: '2-digit',
+        hour12: false,
+      }).format(new Date());
+    } catch {
+      // Fallback to UTC if invalid timezone
+      return new Date().toISOString().substring(11, 16);
+    }
+  }
+
+  /**
+   * Checks if a given HH:MM time falls within the start–end window.
+   * Supports overnight windows (e.g. 22:00 – 08:00).
+   */
+  private timeIsInWindow(current: string, start: string, end: string): boolean {
+    const toMinutes = (t: string) => {
+      const [h, m] = t.split(':').map(Number);
+      return h * 60 + m;
+    };
+
+    const cur = toMinutes(current);
+    const s = toMinutes(start);
+    const e = toMinutes(end);
+
+    if (s <= e) {
+      // Normal window: e.g. 09:00 – 17:00
+      return cur >= s && cur < e;
+    } else {
+      // Overnight window: e.g. 22:00 – 08:00
+      return cur >= s || cur < e;
+    }
+  }
+
+  private toConfigDto(config: QuietHoursConfig): QuietHoursConfigResponseDto {
+    return {
+      userId: config.userId,
+      isEnabled: config.isEnabled,
+      startTime: config.startTime,
+      endTime: config.endTime,
+      timezone: config.timezone,
+      exemptTypes: config.exemptTypes ?? [...EXEMPT_NOTIFICATION_TYPES],
+      updatedAt: config.updatedAt,
+    };
+  }
+}

--- a/src/notifications/notifications.module.ts
+++ b/src/notifications/notifications.module.ts
@@ -1,15 +1,20 @@
-import { Module } from '@nestjs/common';
+import { Module, forwardRef } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { MessagingModule } from '../messaging/messaging.module';
 import { Notification } from './entities/notification.entity';
 import { NotificationsController } from './notifications.controller';
 import { NotificationsRepository } from './notifications.repository';
 import { NotificationsService } from './notifications.service';
+import { NotificationDigestModule } from '../notification-digest/notification-digest.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Notification]), MessagingModule],
+  imports: [
+    TypeOrmModule.forFeature([Notification]),
+    MessagingModule,
+    forwardRef(() => NotificationDigestModule),
+  ],
   controllers: [NotificationsController],
   providers: [NotificationsRepository, NotificationsService],
-  exports: [NotificationsService],
+  exports: [NotificationsService, NotificationsRepository],
 })
 export class NotificationsModule {}

--- a/src/notifications/notifications.service.ts
+++ b/src/notifications/notifications.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import { Injectable, NotFoundException, Inject, forwardRef } from '@nestjs/common';
 import { NotificationsGateway } from '../messaging/gateways/notifications.gateway';
 import { NotificationType } from '../messaging/dto/notification-events.dto';
 import { CreateNotificationDto } from './dto/create-notification.dto';
@@ -10,24 +10,44 @@ import {
 } from './dto/notification-response.dto';
 import { InAppNotificationType, Notification } from './entities/notification.entity';
 import { NotificationsRepository } from './notifications.repository';
+import { NotificationDigestService } from '../notification-digest/notification-digest.service';
 
 @Injectable()
 export class NotificationsService {
   constructor(
     private readonly notificationsRepository: NotificationsRepository,
     private readonly notificationsGateway: NotificationsGateway,
+    @Inject(forwardRef(() => NotificationDigestService))
+    private readonly notificationDigestService: NotificationDigestService,
   ) {}
 
   async createNotification(input: CreateNotificationDto): Promise<NotificationResponseDto> {
     const notification = await this.notificationsRepository.createAndSave(input);
 
-    await this.notificationsGateway.sendNotification(input.userId, {
-      id: notification.id,
-      type: this.toGatewayType(input.type),
-      title: notification.title,
-      body: notification.body,
-      data: notification.data ?? undefined,
-    });
+    let deliverImmediately = true;
+    const config = await this.notificationDigestService.getQuietHoursConfig(input.userId);
+    
+    if (config.isEnabled) {
+      const isExempt = this.notificationDigestService.isExemptType(input.type, config.exemptTypes);
+      if (!isExempt) {
+        const inQuietHours = await this.notificationDigestService.isInQuietHours(input.userId);
+        if (inQuietHours) {
+          deliverImmediately = false;
+        }
+      }
+    }
+
+    if (deliverImmediately) {
+      await this.notificationsGateway.sendNotification(input.userId, {
+        id: notification.id,
+        type: this.toGatewayType(input.type),
+        title: notification.title,
+        body: notification.body,
+        data: notification.data ?? undefined,
+      });
+    } else {
+      await this.notificationDigestService.queueForDigest(input.userId, notification.id);
+    }
 
     await this.emitUnreadCount(input.userId);
 


### PR DESCRIPTION
# Feat: Smart Notification Digest Module

## Related Issue

- Closes #581

## Description
This PR implements the **Smart Notification Digest** module to reduce user notification fatigue. It introduces the ability for users to define "quiet hours" where low-priority push notifications are suppressed and instead batched into a scheduled summary. 

Once the quiet period ends (or when the hourly cron job detects scheduled digests are due), the accumulated notifications are dispatched via a single summarized in-app push and a categorized HTML email. Critical events (`TRANSFER_RECEIVED`, `SECURITY_ALERT`) automatically bypass quiet hours for immediate delivery.

## Changes Made
- **Entities & Configurations** (`src/notification-digest/entities/`): 
  - Added `NotificationDigest` entity to track queued notifications and their schedule.
  - Added `QuietHoursConfig` entity to store the `isEnabled` toggle, `startTime`/`endTime` (HH:MM format), IANA `timezone`, and `exemptTypes`.
- **Digest Service & Delivery** (`NotificationDigestService`): 
  - Centralizes timezone-aware logic (`isInQuietHours`).
  - Analyzes pending notification queues and compiles grouped notification summaries safely.
  - Implements an `@Cron('0 * * * *')` hourly scheduler to deliver digests and run automatic wake-up flushes.
- **REST API Endpoints** (`NotificationDigestController`):
  - `GET /settings/quiet-hours` – View current configuration.
  - `PUT /settings/quiet-hours` – Update quiet hours, timezone, and exemptions.
  - `POST /notifications/digest/send-now` – Force immediate delivery of the pending digest.
- **Notifications Services Hook** (`NotificationsService`): 
  - Updated the core `createNotification` flow to intercept deliveries. If a user is currently inside their quiet hours and the notification type isn't globally exempted, it dynamically queues to the digest payload instead of the WebSockets gateway.
- **MailService Extension**: 
  - Added `sendDigestEmail` formatting to construct and route aggregate HTML emails representing the missed payload (tabulated by Event Type and Count).
- **Module Wiring & Testing**: 
  - Wired `NotificationDigestModule` into `AppModule`.
  - Authored skeleton unit and e2e test suites covering timezone boundaries, manual API dispatches, and exemption checks.

## Acceptance Criteria
- [x] Push notifications suppressed during user-configured quiet hours
- [x] Quiet period end triggers single digest push summarizing missed notifications
- [x] Security and transfer notifications always bypass quiet hours
- [x] Digest email formatted with grouped notification types
- [x] Timezone-aware quiet hours (not UTC-based)
- [x] Unit + e2e test suites present
