### PR TITLE
feat: gasless Stellar fee sponsorship (quotas, fee bump, in-chat wiring)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ lerna-debug.log*
 
 # Tests
 /coverage
+/coverage-e2e
 /.nyc_output
 
 # IDEs and editors

--- a/src/admin/entities/system-setting.entity.ts
+++ b/src/admin/entities/system-setting.entity.ts
@@ -3,17 +3,17 @@ import { Entity, PrimaryColumn, Column, CreateDateColumn, UpdateDateColumn } fro
 @Entity('system_settings')
 export class SystemSetting {
   @PrimaryColumn({ type: 'varchar', length: 50 })
-  key: string;
+  key!: string;
 
   @Column({ type: 'text' })
-  value: string;
+  value!: string;
 
   @Column({ type: 'varchar', length: 255, nullable: true })
-  description: string;
+  description!: string | null;
 
   @CreateDateColumn()
-  createdAt: Date;
+  createdAt!: Date;
 
   @UpdateDateColumn()
-  updatedAt: Date;
+  updatedAt!: Date;
 }

--- a/src/config/env.validation.ts
+++ b/src/config/env.validation.ts
@@ -67,6 +67,12 @@ export const envValidationSchema = Joi.object({
   STELLAR_HORIZON_MAINNET_URL: Joi.string().uri().default('https://horizon.stellar.org'),
   STELLAR_HORIZON_TESTNET_URL: Joi.string().uri().default('https://horizon-testnet.stellar.org'),
 
+  // Gasless fee sponsorship (Stellar fee-bump; optional until configured)
+  SPONSORSHIP_SPONSOR_SECRET: Joi.string().allow('').optional(),
+  SPONSORSHIP_PLATFORM_ACCOUNT_PUBLIC_KEY: Joi.string().allow('').optional(),
+  SPONSORSHIP_LOW_BALANCE_XLM_THRESHOLD: Joi.number().default(100),
+  SPONSORSHIP_BALANCE_NETWORK: Joi.string().valid('testnet', 'mainnet').default('testnet'),
+
   // SEP-10 Web Authentication
   SEP10_SERVER_SECRET: Joi.string().required(),
   SEP10_HOME_DOMAIN: Joi.string().default('localhost'),

--- a/src/fee-sponsorship/admin-fee-sponsorship.controller.spec.ts
+++ b/src/fee-sponsorship/admin-fee-sponsorship.controller.spec.ts
@@ -1,0 +1,39 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AdminGuard } from '../auth/guards/admin.guard';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { AdminFeeSponsorshipController } from './admin-fee-sponsorship.controller';
+import { FeeSponsorshipService } from './fee-sponsorship.service';
+
+describe('AdminFeeSponsorshipController', () => {
+  let controller: AdminFeeSponsorshipController;
+  let service: { configureQuota: jest.Mock };
+
+  beforeEach(async () => {
+    service = {
+      configureQuota: jest.fn().mockResolvedValue({
+        silverQuota: 50,
+        goldQuota: 20,
+        blackQuota: 0,
+        newUserDays: 30,
+      }),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [AdminFeeSponsorshipController],
+      providers: [{ provide: FeeSponsorshipService, useValue: service }],
+    })
+      .overrideGuard(JwtAuthGuard)
+      .useValue({ canActivate: () => true })
+      .overrideGuard(AdminGuard)
+      .useValue({ canActivate: () => true })
+      .compile();
+
+    controller = module.get(AdminFeeSponsorshipController);
+  });
+
+  it('configure delegates', async () => {
+    const r = await controller.configure({ silverQuota: 60 });
+    expect(service.configureQuota).toHaveBeenCalledWith({ silverQuota: 60 });
+    expect(r.silverQuota).toBe(50);
+  });
+});

--- a/src/fee-sponsorship/admin-fee-sponsorship.controller.ts
+++ b/src/fee-sponsorship/admin-fee-sponsorship.controller.ts
@@ -1,0 +1,23 @@
+import { Body, Controller, Post, UseGuards } from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiTags } from '@nestjs/swagger';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { AdminGuard } from '../auth/guards/admin.guard';
+import {
+  AdminSponsorshipConfigDto,
+  AdminSponsorshipConfigResponseDto,
+} from './dto/fee-sponsorship.dto';
+import { FeeSponsorshipService } from './fee-sponsorship.service';
+
+@ApiTags('admin-sponsorship')
+@ApiBearerAuth()
+@Controller('admin/sponsorship')
+@UseGuards(JwtAuthGuard, AdminGuard)
+export class AdminFeeSponsorshipController {
+  constructor(private readonly feeSponsorshipService: FeeSponsorshipService) {}
+
+  @Post('config')
+  @ApiOperation({ summary: 'Configure per-tier monthly sponsorship quotas and new-user window' })
+  async configure(@Body() dto: AdminSponsorshipConfigDto): Promise<AdminSponsorshipConfigResponseDto> {
+    return this.feeSponsorshipService.configureQuota(dto);
+  }
+}

--- a/src/fee-sponsorship/dto/fee-sponsorship.dto.ts
+++ b/src/fee-sponsorship/dto/fee-sponsorship.dto.ts
@@ -1,0 +1,108 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import { IsInt, IsOptional, Max, Min } from 'class-validator';
+
+export class SponsorshipQuotaResponseDto {
+  @ApiProperty()
+  period!: string;
+
+  @ApiProperty()
+  quotaUsed!: number;
+
+  @ApiProperty()
+  quotaLimit!: number;
+
+  @ApiProperty()
+  remaining!: number;
+
+  @ApiProperty()
+  resetAt!: string;
+
+  @ApiProperty()
+  eligible!: boolean;
+
+  @ApiPropertyOptional()
+  ineligibleReason?: string | null;
+}
+
+export class SponsorshipHistoryItemDto {
+  @ApiProperty()
+  id!: string;
+
+  @ApiProperty()
+  txHash!: string;
+
+  @ApiProperty()
+  feeAmount!: string;
+
+  @ApiProperty()
+  sponsoredBy!: string;
+
+  @ApiPropertyOptional()
+  tokenId!: string | null;
+
+  @ApiProperty()
+  createdAt!: string;
+}
+
+export class SponsorshipHistoryResponseDto {
+  @ApiProperty({ type: [SponsorshipHistoryItemDto] })
+  items!: SponsorshipHistoryItemDto[];
+
+  @ApiProperty()
+  total!: number;
+
+  @ApiProperty()
+  page!: number;
+
+  @ApiProperty()
+  limit!: number;
+}
+
+export class AdminSponsorshipConfigDto {
+  @ApiPropertyOptional({ minimum: 0, maximum: 1_000_000 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(0)
+  @Max(1_000_000)
+  silverQuota?: number;
+
+  @ApiPropertyOptional({ minimum: 0, maximum: 1_000_000 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(0)
+  @Max(1_000_000)
+  goldQuota?: number;
+
+  @ApiPropertyOptional({ minimum: 0, maximum: 1_000_000 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(0)
+  @Max(1_000_000)
+  blackQuota?: number;
+
+  @ApiPropertyOptional({ minimum: 1, maximum: 365 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(365)
+  newUserDays?: number;
+}
+
+export class AdminSponsorshipConfigResponseDto {
+  @ApiProperty()
+  silverQuota!: number;
+
+  @ApiProperty()
+  goldQuota!: number;
+
+  @ApiProperty()
+  blackQuota!: number;
+
+  @ApiProperty()
+  newUserDays!: number;
+}

--- a/src/fee-sponsorship/entities/fee-sponsorship.entity.ts
+++ b/src/fee-sponsorship/entities/fee-sponsorship.entity.ts
@@ -1,0 +1,48 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  Index,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+import { User } from '../../users/entities/user.entity';
+
+export enum SponsorshipSource {
+  PLATFORM = 'PLATFORM',
+  PARTNER = 'PARTNER',
+}
+
+@Entity('fee_sponsorships')
+@Index('idx_fee_sponsorships_user_created', ['userId', 'createdAt'])
+@Index('idx_fee_sponsorships_tx_hash', ['txHash'])
+export class FeeSponsorship {
+  @PrimaryGeneratedColumn('uuid')
+  id!: string;
+
+  @Column({ type: 'uuid' })
+  @Index('idx_fee_sponsorships_user_id')
+  userId!: string;
+
+  @ManyToOne(() => User, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'userId' })
+  user!: User;
+
+  @Column({ type: 'varchar', length: 128 })
+  txHash!: string;
+
+  /** Estimated or actual fee in XLM (string for precision). */
+  @Column({ type: 'varchar', length: 32 })
+  feeAmount!: string;
+
+  @Column({ type: 'enum', enum: SponsorshipSource, default: SponsorshipSource.PLATFORM })
+  sponsoredBy!: SponsorshipSource;
+
+  /** Asset code, contract id, or "native" / "XLM". */
+  @Column({ type: 'varchar', length: 128, nullable: true })
+  tokenId!: string | null;
+
+  @CreateDateColumn({ type: 'timestamptz' })
+  createdAt!: Date;
+}

--- a/src/fee-sponsorship/entities/sponsorship-quota.entity.ts
+++ b/src/fee-sponsorship/entities/sponsorship-quota.entity.ts
@@ -1,0 +1,43 @@
+import {
+  Column,
+  Entity,
+  Index,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+  Unique,
+  UpdateDateColumn,
+} from 'typeorm';
+import { User } from '../../users/entities/user.entity';
+
+@Entity('sponsorship_quotas')
+@Unique('uq_sponsorship_quota_user_period', ['userId', 'period'])
+export class SponsorshipQuota {
+  @PrimaryGeneratedColumn('uuid')
+  id!: string;
+
+  @Column({ type: 'uuid' })
+  @Index('idx_sponsorship_quotas_user_period', ['userId', 'period'])
+  userId!: string;
+
+  @ManyToOne(() => User, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'userId' })
+  user!: User;
+
+  /** Calendar month UTC, e.g. 2026-03 */
+  @Column({ type: 'varchar', length: 7 })
+  period!: string;
+
+  @Column({ type: 'int', default: 0 })
+  quotaUsed!: number;
+
+  @Column({ type: 'int' })
+  quotaLimit!: number;
+
+  /** First instant of next calendar month (UTC) when this period ends. */
+  @Column({ type: 'timestamptz' })
+  resetAt!: Date;
+
+  @UpdateDateColumn({ type: 'timestamptz' })
+  updatedAt!: Date;
+}

--- a/src/fee-sponsorship/fee-sponsorship.constants.ts
+++ b/src/fee-sponsorship/fee-sponsorship.constants.ts
@@ -1,0 +1,12 @@
+export const SPONSORSHIP_SETTING_SILVER = 'sponsorship_silver_quota';
+export const SPONSORSHIP_SETTING_GOLD = 'sponsorship_gold_quota';
+export const SPONSORSHIP_SETTING_BLACK = 'sponsorship_black_quota';
+export const SPONSORSHIP_SETTING_NEW_USER_DAYS = 'sponsorship_new_user_days';
+
+export const DEFAULT_SILVER_QUOTA = 50;
+export const DEFAULT_GOLD_QUOTA = 20;
+export const DEFAULT_BLACK_QUOTA = 0;
+export const DEFAULT_NEW_USER_DAYS = 30;
+
+/** Alert when platform sponsorship account native balance falls below this (XLM). */
+export const DEFAULT_LOW_BALANCE_XLM = 100;

--- a/src/fee-sponsorship/fee-sponsorship.controller.spec.ts
+++ b/src/fee-sponsorship/fee-sponsorship.controller.spec.ts
@@ -1,0 +1,38 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { FeeSponsorshipController } from './fee-sponsorship.controller';
+import { FeeSponsorshipService } from './fee-sponsorship.service';
+
+describe('FeeSponsorshipController', () => {
+  let controller: FeeSponsorshipController;
+  let service: { getRemainingQuota: jest.Mock; getSponsorshipHistory: jest.Mock };
+
+  const uid = 'u1';
+
+  beforeEach(async () => {
+    service = {
+      getRemainingQuota: jest.fn().mockResolvedValue({ eligible: true, remaining: 10 }),
+      getSponsorshipHistory: jest.fn().mockResolvedValue({ items: [], total: 0, page: 1, limit: 20 }),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [FeeSponsorshipController],
+      providers: [{ provide: FeeSponsorshipService, useValue: service }],
+    })
+      .overrideGuard(JwtAuthGuard)
+      .useValue({ canActivate: () => true })
+      .compile();
+
+    controller = module.get(FeeSponsorshipController);
+  });
+
+  it('getQuota', async () => {
+    await controller.getQuota(uid);
+    expect(service.getRemainingQuota).toHaveBeenCalledWith(uid);
+  });
+
+  it('getHistory', async () => {
+    await controller.getHistory(uid, '2', '5');
+    expect(service.getSponsorshipHistory).toHaveBeenCalledWith(uid, 2, 5);
+  });
+});

--- a/src/fee-sponsorship/fee-sponsorship.controller.ts
+++ b/src/fee-sponsorship/fee-sponsorship.controller.ts
@@ -1,0 +1,32 @@
+import { Controller, Get, Query, UseGuards } from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiTags } from '@nestjs/swagger';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { CurrentUser } from '../auth/decorators/current-user.decorator';
+import { FeeSponsorshipService } from './fee-sponsorship.service';
+import { SponsorshipHistoryResponseDto, SponsorshipQuotaResponseDto } from './dto/fee-sponsorship.dto';
+
+@ApiTags('sponsorship')
+@ApiBearerAuth()
+@Controller('sponsorship')
+@UseGuards(JwtAuthGuard)
+export class FeeSponsorshipController {
+  constructor(private readonly feeSponsorshipService: FeeSponsorshipService) {}
+
+  @Get('quota')
+  @ApiOperation({ summary: 'Remaining monthly sponsored transaction quota' })
+  async getQuota(@CurrentUser('id') userId: string): Promise<SponsorshipQuotaResponseDto> {
+    return this.feeSponsorshipService.getRemainingQuota(userId);
+  }
+
+  @Get('history')
+  @ApiOperation({ summary: 'Sponsored fee history for the current user' })
+  async getHistory(
+    @CurrentUser('id') userId: string,
+    @Query('page') page?: string,
+    @Query('limit') limit?: string,
+  ): Promise<SponsorshipHistoryResponseDto> {
+    const p = page ? parseInt(page, 10) : 1;
+    const l = limit ? parseInt(limit, 10) : 20;
+    return this.feeSponsorshipService.getSponsorshipHistory(userId, p, l);
+  }
+}

--- a/src/fee-sponsorship/fee-sponsorship.module.ts
+++ b/src/fee-sponsorship/fee-sponsorship.module.ts
@@ -1,0 +1,21 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { SystemSetting } from '../admin/entities/system-setting.entity';
+import { Referral } from '../referrals/entities/referral.entity';
+import { User } from '../users/entities/user.entity';
+import { AdminFeeSponsorshipController } from './admin-fee-sponsorship.controller';
+import { FeeSponsorship } from './entities/fee-sponsorship.entity';
+import { SponsorshipQuota } from './entities/sponsorship-quota.entity';
+import { FeeSponsorshipController } from './fee-sponsorship.controller';
+import { FeeSponsorshipService } from './fee-sponsorship.service';
+import { StellarFeeBumpService } from './stellar-fee-bump.service';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([FeeSponsorship, SponsorshipQuota, User, Referral, SystemSetting]),
+  ],
+  controllers: [FeeSponsorshipController, AdminFeeSponsorshipController],
+  providers: [FeeSponsorshipService, StellarFeeBumpService],
+  exports: [FeeSponsorshipService, StellarFeeBumpService],
+})
+export class FeeSponsorshipModule {}

--- a/src/fee-sponsorship/fee-sponsorship.monitor.spec.ts
+++ b/src/fee-sponsorship/fee-sponsorship.monitor.spec.ts
@@ -1,0 +1,81 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { DataSource } from 'typeorm';
+import { ConfigService } from '@nestjs/config';
+import { SystemSetting } from '../admin/entities/system-setting.entity';
+import { Referral } from '../referrals/entities/referral.entity';
+import { User } from '../users/entities/user.entity';
+import { FeeSponsorship } from './entities/fee-sponsorship.entity';
+import { SponsorshipQuota } from './entities/sponsorship-quota.entity';
+import { FeeSponsorshipService } from './fee-sponsorship.service';
+import { StellarFeeBumpService } from './stellar-fee-bump.service';
+
+const loadAccount = jest.fn();
+
+jest.mock('@stellar/stellar-sdk', () => ({
+  Horizon: {
+    Server: jest.fn().mockImplementation(() => ({
+      loadAccount: (...args: unknown[]) => loadAccount(...args),
+    })),
+  },
+}));
+
+describe('FeeSponsorshipService monitorPlatformFeeAccountBalance', () => {
+  let service: FeeSponsorshipService;
+
+  beforeEach(async () => {
+    loadAccount.mockReset();
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        FeeSponsorshipService,
+        { provide: getRepositoryToken(FeeSponsorship), useValue: {} },
+        { provide: getRepositoryToken(SponsorshipQuota), useValue: {} },
+        { provide: getRepositoryToken(User), useValue: {} },
+        { provide: getRepositoryToken(Referral), useValue: {} },
+        { provide: getRepositoryToken(SystemSetting), useValue: {} },
+        { provide: DataSource, useValue: { transaction: jest.fn() } },
+        {
+          provide: ConfigService,
+          useValue: {
+            get: jest.fn((k: string, def?: string | number) => {
+              if (k === 'SPONSORSHIP_PLATFORM_ACCOUNT_PUBLIC_KEY') {
+                return 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF';
+              }
+              if (k === 'SPONSORSHIP_LOW_BALANCE_XLM_THRESHOLD') {
+                return 100;
+              }
+              if (k === 'SPONSORSHIP_BALANCE_NETWORK') {
+                return 'testnet';
+              }
+              if (k === 'STELLAR_HORIZON_TESTNET_URL') {
+                return 'https://horizon-testnet.stellar.org';
+              }
+              return def ?? '';
+            }),
+          },
+        },
+        { provide: StellarFeeBumpService, useValue: { isSponsorConfigured: () => false } },
+      ],
+    }).compile();
+
+    service = module.get(FeeSponsorshipService);
+  });
+
+  it('warns when balance below threshold', async () => {
+    loadAccount.mockResolvedValue({
+      balances: [{ asset_type: 'native', balance: '50.0000000' }],
+    });
+    const w = jest.spyOn((service as any).logger, 'warn').mockImplementation();
+    await service.monitorPlatformFeeAccountBalance();
+    expect(w).toHaveBeenCalledWith(expect.stringMatching(/ADMIN_ALERT_SPONSORSHIP_LOW_BALANCE/));
+    w.mockRestore();
+  });
+
+  it('warns when horizon check fails', async () => {
+    loadAccount.mockRejectedValue(new Error('network'));
+    const w = jest.spyOn((service as any).logger, 'warn').mockImplementation();
+    await service.monitorPlatformFeeAccountBalance();
+    expect(w).toHaveBeenCalledWith(expect.stringMatching(/Sponsorship balance check failed/));
+    w.mockRestore();
+  });
+});

--- a/src/fee-sponsorship/fee-sponsorship.service.spec.ts
+++ b/src/fee-sponsorship/fee-sponsorship.service.spec.ts
@@ -1,0 +1,430 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { DataSource } from 'typeorm';
+import { ConfigService } from '@nestjs/config';
+import { SystemSetting } from '../admin/entities/system-setting.entity';
+import { Referral } from '../referrals/entities/referral.entity';
+import { User, UserTier } from '../users/entities/user.entity';
+import { FeeSponsorship } from './entities/fee-sponsorship.entity';
+import { SponsorshipQuota } from './entities/sponsorship-quota.entity';
+import { FeeSponsorshipService } from './fee-sponsorship.service';
+import { StellarFeeBumpService } from './stellar-fee-bump.service';
+
+describe('FeeSponsorshipService', () => {
+  let service: FeeSponsorshipService;
+  let sponsorships: any;
+  let quotas: any;
+  let users: any;
+  let referrals: any;
+  let settings: any;
+  let dataSource: { transaction: jest.Mock; createQueryBuilder?: jest.Mock };
+  let stellarFeeBump: { buildFeeBumpEnvelopeXdr: jest.Mock; isSponsorConfigured: jest.Mock };
+
+  const userId = 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11';
+
+  const silverUser = (): User =>
+    Object.assign(new User(), {
+      id: userId,
+      tier: UserTier.SILVER,
+      createdAt: new Date(Date.now() - 90 * 86_400_000),
+    });
+
+  beforeEach(async () => {
+    sponsorships = {
+      findAndCount: jest.fn().mockResolvedValue([[], 0]),
+      create: jest.fn((x) => Object.assign(new FeeSponsorship(), x)),
+      save: jest.fn(async (x) => x),
+    };
+    quotas = {
+      findOne: jest.fn(),
+      create: jest.fn((x) => Object.assign(new SponsorshipQuota(), x)),
+      save: jest.fn(async (x) => x),
+    };
+    users = { findOne: jest.fn() };
+    referrals = { findOne: jest.fn() };
+    settings = { findOne: jest.fn(), create: jest.fn((x) => x), save: jest.fn(async (x) => x) };
+
+    dataSource = {
+      transaction: jest.fn(async (fn: any) => {
+        const manager = {
+          getRepository: (entity: unknown) => {
+            if (entity === SponsorshipQuota) {
+              return {
+                findOne: quotas.findOne,
+                create: quotas.create,
+                save: quotas.save,
+              };
+            }
+            if (entity === FeeSponsorship) {
+              return {
+                create: sponsorships.create,
+                save: sponsorships.save,
+              };
+            }
+            if (entity === User) {
+              return { findOne: users.findOne };
+            }
+            return {};
+          },
+        };
+        return fn(manager);
+      }),
+    };
+
+    stellarFeeBump = {
+      buildFeeBumpEnvelopeXdr: jest.fn(),
+      isSponsorConfigured: jest.fn().mockReturnValue(false),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        FeeSponsorshipService,
+        { provide: getRepositoryToken(FeeSponsorship), useValue: sponsorships },
+        { provide: getRepositoryToken(SponsorshipQuota), useValue: quotas },
+        { provide: getRepositoryToken(User), useValue: users },
+        { provide: getRepositoryToken(Referral), useValue: referrals },
+        { provide: getRepositoryToken(SystemSetting), useValue: settings },
+        { provide: DataSource, useValue: dataSource },
+        {
+          provide: ConfigService,
+          useValue: { get: jest.fn((_k: string, d?: string) => d ?? '') },
+        },
+        { provide: StellarFeeBumpService, useValue: stellarFeeBump },
+      ],
+    }).compile();
+
+    service = module.get(FeeSponsorshipService);
+  });
+
+  it('currentPeriodUtc returns YYYY-MM', () => {
+    const d = new Date(Date.UTC(2026, 2, 15));
+    expect(service.currentPeriodUtc(d)).toBe('2026-03');
+  });
+
+  it('resetAtForPeriod returns first of next month UTC', () => {
+    const r = service.resetAtForPeriod('2026-03');
+    expect(r.toISOString()).toBe('2026-04-01T00:00:00.000Z');
+  });
+
+  describe('checkEligibility', () => {
+    it('rejects BLACK with zero quota', async () => {
+      users.findOne.mockResolvedValue(
+        Object.assign(new User(), {
+          id: userId,
+          tier: UserTier.BLACK,
+          createdAt: new Date(),
+        }),
+      );
+      settings.findOne.mockResolvedValue(null);
+      const r = await service.checkEligibility(userId);
+      expect(r.eligible).toBe(false);
+      expect(r.reason).toBe('BLACK_TIER_SELF_PAY');
+    });
+
+    it('accepts SILVER', async () => {
+      users.findOne.mockResolvedValue(silverUser());
+      settings.findOne.mockResolvedValue(null);
+      const r = await service.checkEligibility(userId);
+      expect(r.eligible).toBe(true);
+    });
+
+    it('accepts old user with referral record', async () => {
+      users.findOne.mockResolvedValue(
+        Object.assign(new User(), {
+          id: userId,
+          tier: UserTier.GOLD,
+          createdAt: new Date(Date.now() - 400 * 86_400_000),
+        }),
+      );
+      referrals.findOne.mockResolvedValue({ id: 'r1' });
+      settings.findOne.mockResolvedValue(null);
+      const r = await service.checkEligibility(userId);
+      expect(r.eligible).toBe(true);
+    });
+
+    it('accepts new user regardless of tier (non-Black)', async () => {
+      users.findOne.mockResolvedValue(
+        Object.assign(new User(), {
+          id: userId,
+          tier: UserTier.GOLD,
+          createdAt: new Date(),
+        }),
+      );
+      referrals.findOne.mockResolvedValue(null);
+      settings.findOne.mockResolvedValue(null);
+      const r = await service.checkEligibility(userId);
+      expect(r.eligible).toBe(true);
+    });
+
+    it('rejects unknown user', async () => {
+      users.findOne.mockResolvedValue(null);
+      const r = await service.checkEligibility('00000000-0000-0000-0000-000000000099');
+      expect(r.eligible).toBe(false);
+      expect(r.reason).toBe('USER_NOT_FOUND');
+    });
+  });
+
+  describe('sponsorTransaction', () => {
+    it('increments quota and saves sponsorship', async () => {
+      users.findOne.mockResolvedValue(silverUser());
+      const q = Object.assign(new SponsorshipQuota(), {
+        userId,
+        period: service.currentPeriodUtc(),
+        quotaUsed: 0,
+        quotaLimit: 50,
+        resetAt: service.resetAtForPeriod(service.currentPeriodUtc()),
+      });
+      quotas.findOne.mockResolvedValue(q);
+
+      const rec = await service.sponsorTransaction({
+        userId,
+        txHash: 'abc123',
+        feeAmountXlm: '0.00001',
+        tokenId: 'XLM',
+      });
+
+      expect(rec.txHash).toBe('abc123');
+      expect(q.quotaUsed).toBe(1);
+    });
+
+    it('throws when quota exhausted', async () => {
+      users.findOne.mockResolvedValue(silverUser());
+      dataSource.transaction.mockImplementation(async (fn: any) => {
+        const exhausted = Object.assign(new SponsorshipQuota(), {
+          userId,
+          period: service.currentPeriodUtc(),
+          quotaUsed: 50,
+          quotaLimit: 50,
+          resetAt: new Date(),
+        });
+        const manager = {
+          getRepository: (entity: unknown) => {
+            if (entity === SponsorshipQuota) {
+              return {
+                findOne: jest.fn().mockResolvedValue(exhausted),
+                create: quotas.create,
+                save: quotas.save,
+              };
+            }
+            if (entity === User) {
+              return { findOne: users.findOne };
+            }
+            return {};
+          },
+        };
+        return fn(manager);
+      });
+
+      await expect(
+        service.sponsorTransaction({
+          userId,
+          txHash: 'x',
+          feeAmountXlm: '0.0001',
+        }),
+      ).rejects.toThrow(/exhausted/);
+    });
+  });
+
+  describe('getSponsorshipHistory', () => {
+    it('maps rows to DTOs', async () => {
+      const row = Object.assign(new FeeSponsorship(), {
+        id: 's1',
+        txHash: 'tx',
+        feeAmount: '0.0001',
+        sponsoredBy: 'PLATFORM',
+        tokenId: 'XLM',
+        createdAt: new Date(),
+      });
+      sponsorships.findAndCount.mockResolvedValue([[row], 1]);
+      const r = await service.getSponsorshipHistory(userId, 1, 10);
+      expect(r.items).toHaveLength(1);
+      expect(r.items[0].feeAmount).toBe('0.0001');
+    });
+  });
+
+  describe('configureQuota', () => {
+    it('persists settings', async () => {
+      settings.findOne.mockResolvedValue(null);
+      await service.configureQuota({ silverQuota: 55, goldQuota: 25 });
+      expect(settings.save).toHaveBeenCalled();
+    });
+
+    it('updates existing setting row', async () => {
+      settings.findOne.mockResolvedValue({
+        key: 'sponsorship_silver_quota',
+        value: '50',
+      } as SystemSetting);
+      await service.configureQuota({ silverQuota: 60 });
+      expect(settings.save).toHaveBeenCalled();
+    });
+  });
+
+  describe('buildFeeBumpEnvelope', () => {
+    it('delegates to stellar service', () => {
+      stellarFeeBump.buildFeeBumpEnvelopeXdr.mockReturnValue('feebump_xdr');
+      expect(service.buildFeeBumpEnvelope('inner', '200')).toBe('feebump_xdr');
+    });
+  });
+
+  describe('getRemainingQuota', () => {
+    it('returns QUOTA_EXHAUSTED when used >= limit', async () => {
+      users.findOne.mockResolvedValue(silverUser());
+      settings.findOne.mockResolvedValue(null);
+      const period = service.currentPeriodUtc();
+      const q = Object.assign(new SponsorshipQuota(), {
+        userId,
+        period,
+        quotaUsed: 50,
+        quotaLimit: 50,
+        resetAt: service.resetAtForPeriod(period),
+      });
+      quotas.findOne.mockResolvedValue(q);
+      const r = await service.getRemainingQuota(userId);
+      expect(r.remaining).toBe(0);
+      expect(r.eligible).toBe(false);
+      expect(r.ineligibleReason).toBe('QUOTA_EXHAUSTED');
+    });
+
+    it('creates quota row when missing', async () => {
+      users.findOne.mockResolvedValue(silverUser());
+      settings.findOne.mockResolvedValue(null);
+      quotas.findOne.mockResolvedValue(null);
+      quotas.save.mockImplementation(async (x: SponsorshipQuota) => x);
+      const r = await service.getRemainingQuota(userId);
+      expect(quotas.create).toHaveBeenCalled();
+      expect(r.quotaLimit).toBe(50);
+    });
+  });
+
+  describe('tryConsumeSponsorshipSlot', () => {
+    it('returns false when ineligible', async () => {
+      users.findOne.mockResolvedValue(
+        Object.assign(new User(), {
+          id: userId,
+          tier: UserTier.BLACK,
+          createdAt: new Date(),
+        }),
+      );
+      settings.findOne.mockResolvedValue(null);
+      const ok = await service.tryConsumeSponsorshipSlot({
+        userId,
+        txHash: 'h1',
+        feeAmountXlm: '0.0001',
+      });
+      expect(ok).toBe(false);
+    });
+
+    it('returns true when eligible and quota available', async () => {
+      users.findOne.mockResolvedValue(silverUser());
+      referrals.findOne.mockResolvedValue(null);
+      settings.findOne.mockResolvedValue(null);
+      const period = service.currentPeriodUtc();
+      const q = Object.assign(new SponsorshipQuota(), {
+        userId,
+        period,
+        quotaUsed: 0,
+        quotaLimit: 50,
+        resetAt: service.resetAtForPeriod(period),
+      });
+      quotas.findOne.mockResolvedValue(q);
+      dataSource.transaction.mockImplementation(async (fn: any) => {
+        const manager = {
+          getRepository: (entity: unknown) => {
+            if (entity === SponsorshipQuota) {
+              return {
+                findOne: jest.fn().mockResolvedValue({ ...q, quotaUsed: 0 }),
+                create: quotas.create,
+                save: jest.fn(async (row: SponsorshipQuota) => row),
+              };
+            }
+            if (entity === FeeSponsorship) {
+              return {
+                create: sponsorships.create,
+                save: sponsorships.save,
+              };
+            }
+            if (entity === User) {
+              return { findOne: users.findOne };
+            }
+            return {};
+          },
+        };
+        return fn(manager);
+      });
+
+      const ok = await service.tryConsumeSponsorshipSlot({
+        userId,
+        txHash: 'txok',
+        feeAmountXlm: '0.0001',
+      });
+      expect(ok).toBe(true);
+    });
+  });
+
+  describe('getConfiguredQuotas', () => {
+    it('returns defaults when settings missing', async () => {
+      settings.findOne.mockResolvedValue(null);
+      const c = await service.getConfiguredQuotas();
+      expect(c.silverQuota).toBe(50);
+      expect(c.goldQuota).toBe(20);
+      expect(c.blackQuota).toBe(0);
+      expect(c.newUserDays).toBe(30);
+    });
+
+    it('uses stored silver quota from settings', async () => {
+      settings.findOne.mockImplementation(async (opts: any) => {
+        const k = opts?.where?.key as string;
+        if (k === 'sponsorship_silver_quota') {
+          return { key: k, value: '77' } as SystemSetting;
+        }
+        return null;
+      });
+      const c = await service.getConfiguredQuotas();
+      expect(c.silverQuota).toBe(77);
+    });
+  });
+
+  describe('monitorPlatformFeeAccountBalance', () => {
+    it('no-op when public key not configured', async () => {
+      const module: TestingModule = await Test.createTestingModule({
+        providers: [
+          FeeSponsorshipService,
+          { provide: getRepositoryToken(FeeSponsorship), useValue: sponsorships },
+          { provide: getRepositoryToken(SponsorshipQuota), useValue: quotas },
+          { provide: getRepositoryToken(User), useValue: users },
+          { provide: getRepositoryToken(Referral), useValue: referrals },
+          { provide: getRepositoryToken(SystemSetting), useValue: settings },
+          { provide: DataSource, useValue: dataSource },
+          { provide: ConfigService, useValue: { get: jest.fn(() => '') } },
+          { provide: StellarFeeBumpService, useValue: stellarFeeBump },
+        ],
+      }).compile();
+      const svc = module.get(FeeSponsorshipService);
+      await expect(svc.monitorPlatformFeeAccountBalance()).resolves.toBeUndefined();
+    });
+  });
+
+  describe('resetQuotas', () => {
+    it('runs delete for stale periods', async () => {
+      const execute = jest.fn().mockResolvedValue({ affected: 2 });
+      const qb = {
+        delete: jest.fn().mockReturnThis(),
+        from: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        execute,
+      };
+      (dataSource as any).createQueryBuilder = jest.fn(() => qb);
+
+      await service.resetQuotas();
+
+      expect(execute).toHaveBeenCalled();
+    });
+  });
+
+  describe('isFeeBumpAvailable', () => {
+    it('delegates to stellar service', () => {
+      stellarFeeBump.isSponsorConfigured.mockReturnValue(true);
+      expect(service.isFeeBumpAvailable()).toBe(true);
+    });
+  });
+});

--- a/src/fee-sponsorship/fee-sponsorship.service.ts
+++ b/src/fee-sponsorship/fee-sponsorship.service.ts
@@ -1,0 +1,400 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Cron, CronExpression } from '@nestjs/schedule';
+import { DataSource, Repository } from 'typeorm';
+import * as StellarSdk from '@stellar/stellar-sdk';
+import { SystemSetting } from '../admin/entities/system-setting.entity';
+import { Referral } from '../referrals/entities/referral.entity';
+import { User, UserTier } from '../users/entities/user.entity';
+import {
+  DEFAULT_BLACK_QUOTA,
+  DEFAULT_GOLD_QUOTA,
+  DEFAULT_LOW_BALANCE_XLM,
+  DEFAULT_NEW_USER_DAYS,
+  DEFAULT_SILVER_QUOTA,
+  SPONSORSHIP_SETTING_BLACK,
+  SPONSORSHIP_SETTING_GOLD,
+  SPONSORSHIP_SETTING_NEW_USER_DAYS,
+  SPONSORSHIP_SETTING_SILVER,
+} from './fee-sponsorship.constants';
+import {
+  AdminSponsorshipConfigDto,
+  AdminSponsorshipConfigResponseDto,
+  SponsorshipHistoryItemDto,
+  SponsorshipQuotaResponseDto,
+} from './dto/fee-sponsorship.dto';
+import { FeeSponsorship, SponsorshipSource } from './entities/fee-sponsorship.entity';
+import { SponsorshipQuota } from './entities/sponsorship-quota.entity';
+import { StellarFeeBumpService } from './stellar-fee-bump.service';
+
+export interface SponsorshipEligibility {
+  eligible: boolean;
+  reason?: string;
+}
+
+export interface SponsorTransactionInput {
+  userId: string;
+  txHash: string;
+  feeAmountXlm: string;
+  tokenId?: string | null;
+  sponsoredBy?: SponsorshipSource;
+}
+
+@Injectable()
+export class FeeSponsorshipService {
+  private readonly logger = new Logger(FeeSponsorshipService.name);
+
+  constructor(
+    @InjectRepository(FeeSponsorship)
+    private readonly sponsorships: Repository<FeeSponsorship>,
+    @InjectRepository(SponsorshipQuota)
+    private readonly quotas: Repository<SponsorshipQuota>,
+    @InjectRepository(User)
+    private readonly users: Repository<User>,
+    @InjectRepository(Referral)
+    private readonly referrals: Repository<Referral>,
+    @InjectRepository(SystemSetting)
+    private readonly settings: Repository<SystemSetting>,
+    private readonly dataSource: DataSource,
+    private readonly configService: ConfigService,
+    private readonly stellarFeeBump: StellarFeeBumpService,
+  ) {}
+
+  currentPeriodUtc(date = new Date()): string {
+    const y = date.getUTCFullYear();
+    const m = String(date.getUTCMonth() + 1).padStart(2, '0');
+    return `${y}-${m}`;
+  }
+
+  /** First instant of the month after `period` (UTC). period format YYYY-MM with month 01-12. */
+  resetAtForPeriod(period: string): Date {
+    const [ys, ms] = period.split('-');
+    const y = parseInt(ys, 10);
+    const monthHuman = parseInt(ms, 10);
+    return new Date(Date.UTC(y, monthHuman, 1));
+  }
+
+  private async getIntSetting(key: string, fallback: number): Promise<number> {
+    const row = await this.settings.findOne({ where: { key } });
+    if (!row?.value) {
+      return fallback;
+    }
+    const n = parseInt(row.value, 10);
+    return Number.isFinite(n) ? n : fallback;
+  }
+
+  private async tierQuotaLimit(tier: UserTier): Promise<number> {
+    switch (tier) {
+      case UserTier.SILVER:
+        return this.getIntSetting(SPONSORSHIP_SETTING_SILVER, DEFAULT_SILVER_QUOTA);
+      case UserTier.GOLD:
+        return this.getIntSetting(SPONSORSHIP_SETTING_GOLD, DEFAULT_GOLD_QUOTA);
+      case UserTier.BLACK:
+        return this.getIntSetting(SPONSORSHIP_SETTING_BLACK, DEFAULT_BLACK_QUOTA);
+      default:
+        return DEFAULT_SILVER_QUOTA;
+    }
+  }
+
+  private async newUserDays(): Promise<number> {
+    return this.getIntSetting(SPONSORSHIP_SETTING_NEW_USER_DAYS, DEFAULT_NEW_USER_DAYS);
+  }
+
+  async getConfiguredQuotas(): Promise<AdminSponsorshipConfigResponseDto> {
+    const [silverQuota, goldQuota, blackQuota, newUserDays] = await Promise.all([
+      this.getIntSetting(SPONSORSHIP_SETTING_SILVER, DEFAULT_SILVER_QUOTA),
+      this.getIntSetting(SPONSORSHIP_SETTING_GOLD, DEFAULT_GOLD_QUOTA),
+      this.getIntSetting(SPONSORSHIP_SETTING_BLACK, DEFAULT_BLACK_QUOTA),
+      this.getIntSetting(SPONSORSHIP_SETTING_NEW_USER_DAYS, DEFAULT_NEW_USER_DAYS),
+    ]);
+    return { silverQuota, goldQuota, blackQuota, newUserDays };
+  }
+
+  async configureQuota(dto: AdminSponsorshipConfigDto): Promise<AdminSponsorshipConfigResponseDto> {
+    const upsert = async (key: string, value: number, description: string) => {
+      let row = await this.settings.findOne({ where: { key } });
+      if (!row) {
+        row = this.settings.create({ key, value: String(value), description });
+      } else {
+        row.value = String(value);
+      }
+      await this.settings.save(row);
+    };
+
+    if (dto.silverQuota !== undefined) {
+      await upsert(SPONSORSHIP_SETTING_SILVER, dto.silverQuota, 'Monthly sponsored tx quota for Silver tier');
+    }
+    if (dto.goldQuota !== undefined) {
+      await upsert(SPONSORSHIP_SETTING_GOLD, dto.goldQuota, 'Monthly sponsored tx quota for Gold tier');
+    }
+    if (dto.blackQuota !== undefined) {
+      await upsert(SPONSORSHIP_SETTING_BLACK, dto.blackQuota, 'Monthly sponsored tx quota for Black tier (0 = self-pay)');
+    }
+    if (dto.newUserDays !== undefined) {
+      await upsert(
+        SPONSORSHIP_SETTING_NEW_USER_DAYS,
+        dto.newUserDays,
+        'Account age in days treated as "new user" for sponsorship eligibility',
+      );
+    }
+
+    return this.getConfiguredQuotas();
+  }
+
+  private accountAgeDays(user: User): number {
+    const created = user.createdAt instanceof Date ? user.createdAt : new Date(user.createdAt);
+    return (Date.now() - created.getTime()) / (86_400_000);
+  }
+
+  private async userHasReferralAsReferee(userId: string): Promise<boolean> {
+    const row = await this.referrals.findOne({ where: { refereeId: userId } });
+    return Boolean(row);
+  }
+
+  async checkEligibility(userId: string): Promise<SponsorshipEligibility> {
+    const user = await this.users.findOne({ where: { id: userId } });
+    if (!user) {
+      return { eligible: false, reason: 'USER_NOT_FOUND' };
+    }
+
+    if (user.tier === UserTier.BLACK) {
+      const limit = await this.tierQuotaLimit(UserTier.BLACK);
+      if (limit <= 0) {
+        return { eligible: false, reason: 'BLACK_TIER_SELF_PAY' };
+      }
+    }
+
+    const limit = await this.tierQuotaLimit(user.tier);
+    if (limit <= 0) {
+      return { eligible: false, reason: 'ZERO_QUOTA_LIMIT' };
+    }
+
+    const days = await this.newUserDays();
+    const isNewUser = this.accountAgeDays(user) < days;
+    const referred = await this.userHasReferralAsReferee(userId);
+    const tierOk = user.tier === UserTier.SILVER || user.tier === UserTier.GOLD;
+
+    if (tierOk || isNewUser || referred) {
+      return { eligible: true };
+    }
+
+    return { eligible: false, reason: 'NOT_ELIGIBLE_TIER_OR_REFERRAL_OR_NEW' };
+  }
+
+  async getOrCreateQuotaRow(userId: string, period: string): Promise<SponsorshipQuota> {
+    const user = await this.users.findOne({ where: { id: userId } });
+    if (!user) {
+      throw new Error('User not found');
+    }
+    const limit = await this.tierQuotaLimit(user.tier);
+    let row = await this.quotas.findOne({ where: { userId, period } });
+    if (!row) {
+      row = this.quotas.create({
+        userId,
+        period,
+        quotaUsed: 0,
+        quotaLimit: limit,
+        resetAt: this.resetAtForPeriod(period),
+      });
+      await this.quotas.save(row);
+    } else if (row.quotaLimit !== limit) {
+      row.quotaLimit = limit;
+      row.resetAt = this.resetAtForPeriod(period);
+      await this.quotas.save(row);
+    }
+    return row;
+  }
+
+  async getRemainingQuota(userId: string): Promise<SponsorshipQuotaResponseDto> {
+    const period = this.currentPeriodUtc();
+    const eligibility = await this.checkEligibility(userId);
+    const row = await this.getOrCreateQuotaRow(userId, period);
+    const remaining = Math.max(0, row.quotaLimit - row.quotaUsed);
+
+    const eligible = eligibility.eligible && remaining > 0;
+    let ineligibleReason: string | null = null;
+    if (!eligibility.eligible) {
+      ineligibleReason = eligibility.reason ?? 'INELIGIBLE';
+    } else if (remaining <= 0) {
+      ineligibleReason = 'QUOTA_EXHAUSTED';
+    }
+
+    return {
+      period: row.period,
+      quotaUsed: row.quotaUsed,
+      quotaLimit: row.quotaLimit,
+      remaining,
+      resetAt: row.resetAt.toISOString(),
+      eligible,
+      ineligibleReason,
+    };
+  }
+
+  /**
+   * Records sponsorship and consumes one monthly quota slot (transactional).
+   * Call after a sponsored tx is submitted (or simulated for stub flows).
+   */
+  async sponsorTransaction(input: SponsorTransactionInput): Promise<FeeSponsorship> {
+    const period = this.currentPeriodUtc();
+    return this.dataSource.transaction(async (manager) => {
+      const quotaRepo = manager.getRepository(SponsorshipQuota);
+      const sponsorshipRepo = manager.getRepository(FeeSponsorship);
+      const userRepo = manager.getRepository(User);
+
+      let row = await quotaRepo.findOne({
+        where: { userId: input.userId, period },
+        lock: { mode: 'pessimistic_write' },
+      });
+
+      if (!row) {
+        const user = await userRepo.findOne({ where: { id: input.userId } });
+        if (!user) {
+          throw new Error('User not found');
+        }
+        const limit = await this.tierQuotaLimit(user.tier);
+        row = quotaRepo.create({
+          userId: input.userId,
+          period,
+          quotaUsed: 0,
+          quotaLimit: limit,
+          resetAt: this.resetAtForPeriod(period),
+        });
+        await quotaRepo.save(row);
+      }
+
+      if (!row || row.quotaUsed >= row.quotaLimit) {
+        throw new Error('Sponsorship quota exhausted');
+      }
+
+      row.quotaUsed += 1;
+      await quotaRepo.save(row);
+
+      const rec = sponsorshipRepo.create({
+        userId: input.userId,
+        txHash: input.txHash,
+        feeAmount: input.feeAmountXlm,
+        sponsoredBy: input.sponsoredBy ?? SponsorshipSource.PLATFORM,
+        tokenId: input.tokenId ?? null,
+      });
+      return sponsorshipRepo.save(rec);
+    });
+  }
+
+  /**
+   * If the user is eligible and has quota, records sponsorship and returns true.
+   * Otherwise returns false without throwing.
+   */
+  async tryConsumeSponsorshipSlot(input: SponsorTransactionInput): Promise<boolean> {
+    const eligibility = await this.checkEligibility(input.userId);
+    if (!eligibility.eligible) {
+      return false;
+    }
+    const period = this.currentPeriodUtc();
+    await this.getOrCreateQuotaRow(input.userId, period);
+    const remaining = await this.getRemainingQuota(input.userId);
+    if (!remaining.eligible || remaining.remaining <= 0) {
+      return false;
+    }
+    try {
+      await this.sponsorTransaction(input);
+      return true;
+    } catch (e) {
+      this.logger.warn(`Sponsorship consume failed: ${e instanceof Error ? e.message : e}`);
+      return false;
+    }
+  }
+
+  async getSponsorshipHistory(
+    userId: string,
+    page = 1,
+    limit = 20,
+  ): Promise<{ items: SponsorshipHistoryItemDto[]; total: number; page: number; limit: number }> {
+    const take = Math.min(Math.max(limit, 1), 100);
+    const skip = (Math.max(page, 1) - 1) * take;
+
+    const [rows, total] = await this.sponsorships.findAndCount({
+      where: { userId },
+      order: { createdAt: 'DESC' },
+      skip,
+      take,
+    });
+
+    const items: SponsorshipHistoryItemDto[] = rows.map((r) => ({
+      id: r.id,
+      txHash: r.txHash,
+      feeAmount: r.feeAmount,
+      sponsoredBy: r.sponsoredBy,
+      tokenId: r.tokenId,
+      createdAt: r.createdAt.toISOString(),
+    }));
+
+    return { items, total, page: Math.max(page, 1), limit: take };
+  }
+
+  /**
+   * Monthly cron: prune very old quota rows and log period roll.
+   * Quotas are keyed by calendar month; no in-place reset required.
+   */
+  @Cron('0 0 1 * *')
+  async resetQuotas(): Promise<void> {
+    this.logger.log(
+      `Sponsorship monthly cron: new calendar period ${this.currentPeriodUtc()} (quotas are lazy per user/period)`,
+    );
+    const cutoff = new Date();
+    cutoff.setUTCFullYear(cutoff.getUTCFullYear() - 2);
+    const oldPeriod = `${cutoff.getUTCFullYear()}-${String(cutoff.getUTCMonth() + 1).padStart(2, '0')}`;
+    const result = await this.dataSource
+      .createQueryBuilder()
+      .delete()
+      .from(SponsorshipQuota)
+      .where('period < :oldPeriod', { oldPeriod })
+      .execute();
+    if (result.affected && result.affected > 0) {
+      this.logger.log(`Removed ${result.affected} stale sponsorship_quota rows before ${oldPeriod}`);
+    }
+  }
+
+  @Cron(CronExpression.EVERY_HOUR)
+  async monitorPlatformFeeAccountBalance(): Promise<void> {
+    const publicKey = this.configService.get<string>('SPONSORSHIP_PLATFORM_ACCOUNT_PUBLIC_KEY', '')?.trim();
+    if (!publicKey) {
+      return;
+    }
+
+    const threshold = parseFloat(
+      this.configService.get<string>('SPONSORSHIP_LOW_BALANCE_XLM_THRESHOLD', String(DEFAULT_LOW_BALANCE_XLM)),
+    );
+    const useTestnet = this.configService.get<string>('SPONSORSHIP_BALANCE_NETWORK', 'testnet') === 'testnet';
+    const horizonUrl = useTestnet
+      ? this.configService.get<string>('STELLAR_HORIZON_TESTNET_URL', 'https://horizon-testnet.stellar.org')
+      : this.configService.get<string>('STELLAR_HORIZON_MAINNET_URL', 'https://horizon.stellar.org');
+
+    try {
+      const server = new StellarSdk.Horizon.Server(horizonUrl);
+      const account = await server.loadAccount(publicKey);
+      const native = account.balances.find((b) => b.asset_type === 'native');
+      const balance = native ? parseFloat((native as StellarSdk.Horizon.HorizonApi.BalanceLineNative).balance) : 0;
+      if (balance < threshold) {
+        this.logger.warn(
+          `ADMIN_ALERT_SPONSORSHIP_LOW_BALANCE: platform account ${publicKey} has ${balance} XLM (threshold ${threshold} XLM, network=${useTestnet ? 'testnet' : 'mainnet'}) — top up required`,
+        );
+      }
+    } catch (e) {
+      this.logger.warn(
+        `Sponsorship balance check failed for ${publicKey}: ${e instanceof Error ? e.message : e}`,
+      );
+    }
+  }
+
+  /**
+   * Wraps a user-signed inner envelope in a fee-bump envelope (platform pays fees).
+   */
+  buildFeeBumpEnvelope(innerEnvelopeXdr: string, maxFeeStroops: string): string {
+    return this.stellarFeeBump.buildFeeBumpEnvelopeXdr(innerEnvelopeXdr, maxFeeStroops);
+  }
+
+  isFeeBumpAvailable(): boolean {
+    return this.stellarFeeBump.isSponsorConfigured();
+  }
+}

--- a/src/fee-sponsorship/stellar-fee-bump.service.spec.ts
+++ b/src/fee-sponsorship/stellar-fee-bump.service.spec.ts
@@ -1,0 +1,75 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+import { StellarFeeBumpService } from './stellar-fee-bump.service';
+
+const mockSign = jest.fn();
+const mockToEnvelope = jest.fn(() => ({ toXDR: () => 'ZmVlYnVtcF94ZHI=' }));
+
+jest.mock('@stellar/stellar-sdk', () => {
+  const buildFeeBumpTransaction = jest.fn(() => ({ sign: mockSign, toEnvelope: mockToEnvelope }));
+  return {
+    Keypair: { fromSecret: jest.fn(() => ({ publicKey: () => 'GSPONSOR' })) },
+    Transaction: jest.fn(function MockTx() {
+      return { fee: '100' };
+    }),
+    TransactionBuilder: { buildFeeBumpTransaction },
+  };
+});
+
+describe('StellarFeeBumpService', () => {
+  let service: StellarFeeBumpService;
+
+  beforeEach(async () => {
+    mockSign.mockClear();
+    mockToEnvelope.mockClear();
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        StellarFeeBumpService,
+        {
+          provide: ConfigService,
+          useValue: {
+            get: jest.fn((k: string, def?: string) => {
+              if (k === 'SPONSORSHIP_SPONSOR_SECRET') {
+                return 'SAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABST3';
+              }
+              if (k === 'SOROBAN_NETWORK_PASSPHRASE') {
+                return 'Test SDF Network ; September 2015';
+              }
+              return def ?? '';
+            }),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get(StellarFeeBumpService);
+  });
+
+  it('isSponsorConfigured false when secret empty', async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        StellarFeeBumpService,
+        { provide: ConfigService, useValue: { get: jest.fn(() => '') } },
+      ],
+    }).compile();
+    const s = module.get(StellarFeeBumpService);
+    expect(s.isSponsorConfigured()).toBe(false);
+  });
+
+  it('buildFeeBumpEnvelopeXdr builds and signs', () => {
+    const xdr = service.buildFeeBumpEnvelopeXdr('AAAAAgAAAAB', '500000');
+    expect(xdr).toBe('ZmVlYnVtcF94ZHI=');
+    expect(mockSign).toHaveBeenCalled();
+  });
+
+  it('throws when secret missing', async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        StellarFeeBumpService,
+        { provide: ConfigService, useValue: { get: jest.fn(() => '') } },
+      ],
+    }).compile();
+    const s = module.get(StellarFeeBumpService);
+    expect(() => s.buildFeeBumpEnvelopeXdr('AAAA', '100')).toThrow(/SPONSORSHIP_SPONSOR_SECRET/);
+  });
+});

--- a/src/fee-sponsorship/stellar-fee-bump.service.ts
+++ b/src/fee-sponsorship/stellar-fee-bump.service.ts
@@ -1,0 +1,54 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import * as StellarSdk from '@stellar/stellar-sdk';
+
+/**
+ * Wraps a signed inner Stellar transaction in a fee-bump envelope so the platform sponsor pays network fees.
+ */
+@Injectable()
+export class StellarFeeBumpService {
+  private readonly logger = new Logger(StellarFeeBumpService.name);
+
+  constructor(private readonly configService: ConfigService) {}
+
+  private networkPassphrase(): string {
+    return this.configService.get<string>(
+      'SOROBAN_NETWORK_PASSPHRASE',
+      'Test SDF Network ; September 2015',
+    );
+  }
+
+  /** @returns true when sponsor secret is configured. */
+  isSponsorConfigured(): boolean {
+    const secret = this.configService.get<string>('SPONSORSHIP_SPONSOR_SECRET', '');
+    return Boolean(secret?.trim());
+  }
+
+  /**
+   * Builds a signed fee-bump transaction XDR (base64) wrapping the inner envelope.
+   * Inner transaction must already include all required signatures (e.g. user).
+   *
+   * @param innerEnvelopeXdr base64 transaction envelope XDR
+   * @param maxFeeStroops max fee the sponsor authorizes for the inner tx (string stroops)
+   */
+  buildFeeBumpEnvelopeXdr(innerEnvelopeXdr: string, maxFeeStroops: string): string {
+    const secret = this.configService.get<string>('SPONSORSHIP_SPONSOR_SECRET', '');
+    if (!secret?.trim()) {
+      throw new Error('SPONSORSHIP_SPONSOR_SECRET is not configured');
+    }
+
+    const passphrase = this.networkPassphrase();
+    const innerTx = new StellarSdk.Transaction(innerEnvelopeXdr, passphrase);
+    const sponsor = StellarSdk.Keypair.fromSecret(secret.trim());
+
+    const feeBump = StellarSdk.TransactionBuilder.buildFeeBumpTransaction(
+      sponsor,
+      maxFeeStroops,
+      innerTx,
+      passphrase,
+    );
+    feeBump.sign(sponsor);
+
+    return feeBump.toEnvelope().toXDR('base64');
+  }
+}

--- a/src/in-chat-transfers/in-chat-transfers.module.ts
+++ b/src/in-chat-transfers/in-chat-transfers.module.ts
@@ -7,6 +7,7 @@ import { Message } from '../messages/entities/message.entity';
 import { Transaction } from '../transactions/entities/transaction.entity';
 import { Wallet } from '../wallets/entities/wallet.entity';
 import { UsersModule } from '../users/users.module';
+import { FeeSponsorshipModule } from '../fee-sponsorship/fee-sponsorship.module';
 import { InChatTransfersController } from './in-chat-transfers.controller';
 import { InChatTransfersService } from './in-chat-transfers.service';
 import { InChatTransfer } from './entities/in-chat-transfer.entity';
@@ -25,6 +26,7 @@ import { TransfersGateway } from './transfers.gateway';
     ]),
     UsersModule,
     AddressBookModule,
+    FeeSponsorshipModule,
   ],
   controllers: [InChatTransfersController],
   providers: [InChatTransfersService, SorobanTransfersService, TransfersGateway],

--- a/src/in-chat-transfers/in-chat-transfers.service.ts
+++ b/src/in-chat-transfers/in-chat-transfers.service.ts
@@ -195,13 +195,16 @@ export class InChatTransfersService {
     await this.transfersRepository.save(transfer);
 
     try {
-      const txHash = await this.sorobanTransfersService.submitTransfer({
-        senderAddress,
-        recipientAddresses: recipientUsers.map((user) => user.walletAddress),
-        asset: transfer.asset,
-        amountPerRecipient: transfer.amountPerRecipient,
-        totalAmount: transfer.totalAmount,
-      });
+      const txHash = await this.sorobanTransfersService.submitTransfer(
+        {
+          senderAddress,
+          recipientAddresses: recipientUsers.map((user) => user.walletAddress),
+          asset: transfer.asset,
+          amountPerRecipient: transfer.amountPerRecipient,
+          totalAmount: transfer.totalAmount,
+        },
+        { userId: senderId },
+      );
 
       transaction.status = TransactionStatus.COMPLETED;
       transaction.txHash = txHash;

--- a/src/in-chat-transfers/soroban-transfers.service.spec.ts
+++ b/src/in-chat-transfers/soroban-transfers.service.spec.ts
@@ -1,0 +1,49 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { FeeSponsorshipService } from '../fee-sponsorship/fee-sponsorship.service';
+import { SorobanTransfersService } from './soroban-transfers.service';
+
+describe('SorobanTransfersService', () => {
+  it('submitTransfer without sponsorship service returns hash', async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [SorobanTransfersService],
+    }).compile();
+    const service = module.get(SorobanTransfersService);
+    const h = await service.submitTransfer({
+      senderAddress: 'G1',
+      recipientAddresses: ['G2'],
+      asset: 'XLM',
+      amountPerRecipient: '1',
+      totalAmount: '1',
+    });
+    expect(h).toMatch(/^soroban_xlm_/);
+  });
+
+  it('submitTransfer with sponsor context calls tryConsumeSponsorshipSlot', async () => {
+    const feeSponsorship = { tryConsumeSponsorshipSlot: jest.fn().mockResolvedValue(true) };
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        SorobanTransfersService,
+        { provide: FeeSponsorshipService, useValue: feeSponsorship },
+      ],
+    }).compile();
+    const service = module.get(SorobanTransfersService);
+    const h = await service.submitTransfer(
+      {
+        senderAddress: 'G1',
+        recipientAddresses: ['G2'],
+        asset: 'USDC',
+        amountPerRecipient: '5',
+        totalAmount: '5',
+      },
+      { userId: 'user-1' },
+    );
+    expect(h).toMatch(/^soroban_usdc_/);
+    expect(feeSponsorship.tryConsumeSponsorshipSlot).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: 'user-1',
+        txHash: h,
+        tokenId: 'USDC',
+      }),
+    );
+  });
+});

--- a/src/in-chat-transfers/soroban-transfers.service.ts
+++ b/src/in-chat-transfers/soroban-transfers.service.ts
@@ -1,5 +1,6 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Optional } from '@nestjs/common';
 import { randomUUID } from 'crypto';
+import { FeeSponsorshipService } from '../fee-sponsorship/fee-sponsorship.service';
 
 export interface SorobanTransferPayload {
   senderAddress: string;
@@ -9,8 +10,14 @@ export interface SorobanTransferPayload {
   totalAmount: string;
 }
 
+export interface SorobanTransferSponsorContext {
+  userId: string;
+}
+
 @Injectable()
 export class SorobanTransfersService {
+  constructor(@Optional() private readonly feeSponsorship?: FeeSponsorshipService) {}
+
   async estimateFee(asset: string, amount: string, recipientCount: number): Promise<string> {
     const normalizedAsset = asset.toUpperCase();
     const assetMultiplier = normalizedAsset === 'XLM' ? 10_000 : 15_000;
@@ -20,8 +27,32 @@ export class SorobanTransfersService {
     return (stroops / 10_000_000).toFixed(7);
   }
 
-  async submitTransfer(payload: SorobanTransferPayload): Promise<string> {
+  /**
+   * Submits (or simulates) a transfer. When `sponsor` is set and the user is eligible with quota,
+   * records fee sponsorship for the returned tx hash using the estimated network fee in XLM.
+   * When a real inner transaction XDR exists, use {@link FeeSponsorshipService.buildFeeBumpEnvelope} to wrap it.
+   */
+  async submitTransfer(
+    payload: SorobanTransferPayload,
+    sponsor?: SorobanTransferSponsorContext,
+  ): Promise<string> {
     const suffix = randomUUID().replace(/-/g, '').slice(0, 16);
-    return `soroban_${payload.asset.toLowerCase()}_${suffix}`;
+    const txHash = `soroban_${payload.asset.toLowerCase()}_${suffix}`;
+
+    if (sponsor?.userId && this.feeSponsorship) {
+      const feeEstimate = await this.estimateFee(
+        payload.asset,
+        payload.totalAmount,
+        payload.recipientAddresses.length,
+      );
+      await this.feeSponsorship.tryConsumeSponsorshipSlot({
+        userId: sponsor.userId,
+        txHash,
+        feeAmountXlm: feeEstimate,
+        tokenId: payload.asset,
+      });
+    }
+
+    return txHash;
   }
 }

--- a/src/migrations/1775300000000-FeeSponsorshipSchema.ts
+++ b/src/migrations/1775300000000-FeeSponsorshipSchema.ts
@@ -1,0 +1,56 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class FeeSponsorshipSchema1775300000000 implements MigrationInterface {
+  name = 'FeeSponsorshipSchema1775300000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TYPE "fee_sponsorships_sponsoredby_enum" AS ENUM ('PLATFORM', 'PARTNER')
+    `);
+
+    await queryRunner.query(`
+      CREATE TABLE "fee_sponsorships" (
+        "id" uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
+        "userId" uuid NOT NULL,
+        "txHash" varchar(128) NOT NULL,
+        "feeAmount" varchar(32) NOT NULL,
+        "sponsoredBy" "fee_sponsorships_sponsoredby_enum" NOT NULL DEFAULT 'PLATFORM',
+        "tokenId" varchar(128),
+        "createdAt" TIMESTAMPTZ NOT NULL DEFAULT now(),
+        CONSTRAINT "FK_fee_sponsorships_user" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE CASCADE
+      )
+    `);
+    await queryRunner.query(
+      `CREATE INDEX "idx_fee_sponsorships_user_created" ON "fee_sponsorships" ("userId", "createdAt")`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "idx_fee_sponsorships_tx_hash" ON "fee_sponsorships" ("txHash")`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "idx_fee_sponsorships_user_id" ON "fee_sponsorships" ("userId")`,
+    );
+
+    await queryRunner.query(`
+      CREATE TABLE "sponsorship_quotas" (
+        "id" uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
+        "userId" uuid NOT NULL,
+        "period" varchar(7) NOT NULL,
+        "quotaUsed" int NOT NULL DEFAULT 0,
+        "quotaLimit" int NOT NULL,
+        "resetAt" TIMESTAMPTZ NOT NULL,
+        "updatedAt" TIMESTAMPTZ NOT NULL DEFAULT now(),
+        CONSTRAINT "uq_sponsorship_quota_user_period" UNIQUE ("userId", "period"),
+        CONSTRAINT "FK_sponsorship_quotas_user" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE CASCADE
+      )
+    `);
+    await queryRunner.query(
+      `CREATE INDEX "idx_sponsorship_quotas_user_period" ON "sponsorship_quotas" ("userId", "period")`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP TABLE "sponsorship_quotas"`);
+    await queryRunner.query(`DROP TABLE "fee_sponsorships"`);
+    await queryRunner.query(`DROP TYPE "fee_sponsorships_sponsoredby_enum"`);
+  }
+}

--- a/test/e2e/fee-sponsorship.e2e-spec.ts
+++ b/test/e2e/fee-sponsorship.e2e-spec.ts
@@ -1,0 +1,57 @@
+import request from 'supertest';
+import { DataSource } from 'typeorm';
+import { INestApplication } from '@nestjs/common';
+import { AUTH_WALLETS } from './factories';
+import {
+  authenticateViaChallenge,
+  createTestApp,
+  truncateAllTables,
+} from './setup/create-test-app';
+
+describe('Fee sponsorship (e2e)', () => {
+  let app: INestApplication;
+  let dataSource: DataSource;
+
+  beforeAll(async () => {
+    ({ app, dataSource } = await createTestApp());
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  beforeEach(async () => {
+    await truncateAllTables(dataSource);
+  });
+
+  it('GET /api/sponsorship/quota returns quota shape for authenticated user', async () => {
+    const auth = await authenticateViaChallenge(app, AUTH_WALLETS.primary);
+
+    const res = await request(app.getHttpServer())
+      .get('/api/sponsorship/quota')
+      .set('Authorization', `Bearer ${auth.accessToken}`)
+      .expect(200);
+
+    expect(res.body).toMatchObject({
+      period: expect.any(String),
+      quotaUsed: expect.any(Number),
+      quotaLimit: expect.any(Number),
+      remaining: expect.any(Number),
+      resetAt: expect.any(String),
+      eligible: expect.any(Boolean),
+    });
+  });
+
+  it('GET /api/sponsorship/history returns paginated list', async () => {
+    const auth = await authenticateViaChallenge(app, AUTH_WALLETS.primary);
+
+    await request(app.getHttpServer())
+      .get('/api/sponsorship/history?page=1&limit=10')
+      .set('Authorization', `Bearer ${auth.accessToken}`)
+      .expect(200)
+      .expect((r) => {
+        expect(Array.isArray(r.body.items)).toBe(true);
+        expect(r.body.total).toBeDefined();
+      });
+  });
+});


### PR DESCRIPTION
## Summary
Adds a **gasless transaction sponsorship** layer: per-user **calendar-month quotas**, **eligibility** (tier / new-user window / referral), **per-tx fee history**, **admin-configurable limits** via `system_settings`, **Stellar fee-bump** helper for sponsor-paid fees, **hourly Horizon check** with an admin-oriented log when the platform account is low on XLM, and wiring so **in-chat Soroban transfers** consume sponsorship when allowed.
closes #625 
## Schema
- **`fee_sponsorships`**: `userId`, `txHash`, `feeAmount`, `sponsoredBy` (PLATFORM | PARTNER), `tokenId`, `createdAt`.
- **`sponsorship_quotas`**: `userId`, `period` (`YYYY-MM` UTC), `quotaUsed`, `quotaLimit`, `resetAt` (next month UTC); unique `(userId, period)`.
- Migration: `1775300000000-FeeSponsorshipSchema`.

## API
- **User (JWT)**: `GET /sponsorship/quota`, `GET /sponsorship/history?page=&limit=`.
- **Admin (JWT + AdminGuard)**: `POST /sponsorship/config` with optional `silverQuota`, `goldQuota`, `blackQuota`, `newUserDays`.

## Defaults & rules
- Monthly quotas: **Silver 50**, **Gold 20**, **Black 0** (self-pay unless overridden).
- Eligibility: not Black with zero limit; and (**Silver/Gold** OR **account age &lt; N days** OR **referral row as referee**).
- Monthly roll: cron `0 0 1 * *` logs period change and deletes quota rows older than ~2 years.

## Env (optional)
- `SPONSORSHIP_SPONSOR_SECRET` — sponsor key for fee-bump XDR.
- `SPONSORSHIP_PLATFORM_ACCOUNT_PUBLIC_KEY` — balance monitoring.
- `SPONSORSHIP_LOW_BALANCE_XLM_THRESHOLD` (default `100`), `SPONSORSHIP_BALANCE_NETWORK` (`testnet` | `mainnet`).

## Integration
- `SorobanTransfersService.submitTransfer(payload, { userId }?)` calls `tryConsumeSponsorshipSlot` when `FeeSponsorshipService` is present; `confirmTransfer` passes `senderId`.

## Tests
- Unit coverage for service, controllers, fee-bump, Horizon monitor (mocked), Soroban sponsorship path; module coverage **~91%** statements on `fee-sponsorship/**` (excluding specs/module).
- E2E: `test/e2e/fee-sponsorship.e2e-spec.ts` (quota + history).

## Ops
- Run the new migration in each environment before relying on tables.
- For real on-chain fee sponsorship, submit **fee-bump** envelopes built via `FeeSponsorshipService.buildFeeBumpEnvelope` / `StellarFeeBumpService` once inner txs are signed by users.

## Other
- `SystemSetting` entity: strict initialization (`!` / nullable `description`) for ts-jest compatibility.