### PR TITLE
feat(contracts): Soroban private payments pool with commitments and n…

### DIFF
--- a/contracts/Cargo.lock
+++ b/contracts/Cargo.lock
@@ -761,6 +761,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e04e2fd2b8188ea827b32ef11de88377086d690286ab35747ef7f9bf3ccb590"
 
 [[package]]
+name = "integration-tests"
+version = "0.1.0"
+dependencies = [
+ "ed25519-dalek",
+ "messaging",
+ "payments",
+ "private_payments",
+ "rand",
+ "rooms",
+ "soroban-sdk",
+ "xp",
+]
+
+[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -829,6 +843,13 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "messaging"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk",
+]
 
 [[package]]
 name = "messaging-registry"
@@ -916,6 +937,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "payments"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk",
+]
+
+[[package]]
 name = "pkcs8"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -957,6 +985,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
 dependencies = [
  "elliptic-curve",
+]
+
+[[package]]
+name = "private_payments"
+version = "0.1.0"
+dependencies = [
+ "ed25519-dalek",
+ "rand",
+ "soroban-sdk",
 ]
 
 [[package]]
@@ -1035,6 +1072,13 @@ checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
 dependencies = [
  "hmac",
  "subtle",
+]
+
+[[package]]
+name = "rooms"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk",
 ]
 
 [[package]]
@@ -1724,6 +1768,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "xp"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk",
 ]
 
 [[package]]

--- a/contracts/Cargo.toml
+++ b/contracts/Cargo.toml
@@ -3,6 +3,7 @@ resolver = "2"
 members = [
     "gasless-common",
     "contracts/*",
+    "integration-tests",
 ]
 
 [workspace.dependencies]

--- a/contracts/contracts/private_payments/Cargo.toml
+++ b/contracts/contracts/private_payments/Cargo.toml
@@ -1,14 +1,21 @@
 [package]
-name = "integration-tests"
+name = "private_payments"
 version = "0.1.0"
 edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+doctest = false
+
+[features]
+default = []
+testhelpers = []
+
+[dependencies]
+soroban-sdk = { workspace = true }
 
 [dev-dependencies]
 soroban-sdk = { workspace = true, features = ["testutils"] }
-messaging  = { path = "../messaging" }
-payments   = { path = "../payments" }
-private_payments = { path = "../contracts/private_payments", features = ["testhelpers"] }
-rooms      = { path = "../rooms" }
-xp         = { path = "../xp" }
 ed25519-dalek = { version = "2.1", default-features = false, features = ["rand_core"] }
 rand = { version = "0.8", default-features = false, features = ["std_rng"] }

--- a/contracts/contracts/private_payments/src/lib.rs
+++ b/contracts/contracts/private_payments/src/lib.rs
@@ -1,0 +1,439 @@
+#![no_std]
+#![allow(clippy::too_many_arguments)]
+
+use soroban_sdk::{
+    contract, contracterror, contractimpl, contracttype, token, Address, Bytes, BytesN, Env, Symbol,
+};
+
+/// Domain-separated commitment: binds viewing key (ed25519 pubkey) to note economics.
+const DOM_COMMIT: &[u8] = b"PV1/COMMIT";
+/// Nullifier derivation: unique per (pubkey, commitment).
+const DOM_NULL: &[u8] = b"PV1/NULL";
+const DOM_WITHDRAW: &[u8] = b"PV1/WITHDRAW";
+const DOM_TRANSFER: &[u8] = b"PV1/TRANSFER";
+
+/// Fixed layout: commitment (32) || ed25519 pubkey (32) || signature (64).
+pub const PROOF_LEN: u32 = 128;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[contracttype]
+pub struct NoteRecord {
+    pub owner: Address,
+    pub commitment: BytesN<32>,
+    /// Placeholder at deposit; logical nullifier is `derive_nullifier(pk, commitment)`.
+    pub nullifier: BytesN<32>,
+    pub is_spent: bool,
+    pub created_at: u64,
+    pub token: Address,
+    pub amount: i128,
+}
+
+#[derive(Clone)]
+#[contracttype]
+pub enum DataKey {
+    Note(BytesN<32>),
+    Spent(BytesN<32>),
+}
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum ContractError {
+    NoteNotFound = 1,
+    AlreadySpent = 2,
+    InvalidProof = 3,
+    ProofLength = 4,
+    NullifierReuse = 5,
+    CommitmentMismatch = 6,
+    AmountMismatch = 7,
+    CommitmentAlreadyExists = 8,
+}
+
+#[contract]
+pub struct PrivatePaymentsContract;
+
+fn append_address_strkey(_env: &Env, buf: &mut Bytes, addr: &Address) {
+    let s = addr.to_string();
+    let n = s.len() as usize;
+    if n > 96 {
+        panic!();
+    }
+    let mut tmp = [0u8; 96];
+    s.copy_into_slice(&mut tmp[..n]);
+    buf.extend_from_slice(&tmp[..n]);
+}
+
+fn append_bytes32(buf: &mut Bytes, x: &BytesN<32>) {
+    let a = x.to_array();
+    buf.extend_from_slice(&a);
+}
+
+pub(crate) fn build_commit_preimage(
+    env: &Env,
+    pubkey: &BytesN<32>,
+    token: &Address,
+    amount: i128,
+    owner: &Address,
+) -> Bytes {
+    let mut b = Bytes::new(env);
+    b.extend_from_slice(DOM_COMMIT);
+    append_bytes32(&mut b, pubkey);
+    append_address_strkey(env, &mut b, token);
+    b.extend_from_slice(&amount.to_be_bytes());
+    append_address_strkey(env, &mut b, owner);
+    b
+}
+
+pub(crate) fn expected_commitment(
+    env: &Env,
+    pubkey: &BytesN<32>,
+    token: &Address,
+    amount: i128,
+    owner: &Address,
+) -> BytesN<32> {
+    let pre = build_commit_preimage(env, pubkey, token, amount, owner);
+    env.crypto().sha256(&pre).to_bytes()
+}
+
+pub(crate) fn derive_nullifier(
+    env: &Env,
+    pubkey: &BytesN<32>,
+    commitment: &BytesN<32>,
+) -> BytesN<32> {
+    let mut b = Bytes::new(env);
+    b.extend_from_slice(DOM_NULL);
+    append_bytes32(&mut b, pubkey);
+    append_bytes32(&mut b, commitment);
+    env.crypto().sha256(&b).to_bytes()
+}
+
+pub(crate) fn build_withdraw_message(
+    env: &Env,
+    nullifier: &BytesN<32>,
+    recipient: &Address,
+    amount: i128,
+    token: &Address,
+    commitment: &BytesN<32>,
+) -> Bytes {
+    let mut b = Bytes::new(env);
+    b.extend_from_slice(DOM_WITHDRAW);
+    append_bytes32(&mut b, nullifier);
+    append_address_strkey(env, &mut b, recipient);
+    b.extend_from_slice(&amount.to_be_bytes());
+    append_address_strkey(env, &mut b, token);
+    append_bytes32(&mut b, commitment);
+    b
+}
+
+pub(crate) fn build_transfer_message(
+    env: &Env,
+    old_nullifier: &BytesN<32>,
+    new_commitment: &BytesN<32>,
+    token: &Address,
+    amount: i128,
+    old_commitment: &BytesN<32>,
+    owner: &Address,
+) -> Bytes {
+    let mut b = Bytes::new(env);
+    b.extend_from_slice(DOM_TRANSFER);
+    append_bytes32(&mut b, old_nullifier);
+    append_bytes32(&mut b, new_commitment);
+    append_address_strkey(env, &mut b, token);
+    b.extend_from_slice(&amount.to_be_bytes());
+    append_bytes32(&mut b, old_commitment);
+    append_address_strkey(env, &mut b, owner);
+    b
+}
+
+fn parse_proof(env: &Env, proof: &Bytes) -> Result<(BytesN<32>, BytesN<32>, BytesN<64>), ContractError> {
+    if proof.len() != PROOF_LEN {
+        return Err(ContractError::ProofLength);
+    }
+    let mut buf = [0u8; 128];
+    proof.copy_into_slice(&mut buf);
+    let mut c = [0u8; 32];
+    let mut p = [0u8; 32];
+    let mut s = [0u8; 64];
+    c.copy_from_slice(&buf[0..32]);
+    p.copy_from_slice(&buf[32..64]);
+    s.copy_from_slice(&buf[64..128]);
+    Ok((
+        BytesN::from_array(env, &c),
+        BytesN::from_array(env, &p),
+        BytesN::from_array(env, &s),
+    ))
+}
+
+impl PrivatePaymentsContract {
+    fn load_note(env: &Env, commitment: &BytesN<32>) -> Result<NoteRecord, ContractError> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Note(commitment.clone()))
+            .ok_or(ContractError::NoteNotFound)
+    }
+
+    fn save_note(env: &Env, commitment: &BytesN<32>, note: &NoteRecord) {
+        env.storage()
+            .persistent()
+            .set(&DataKey::Note(commitment.clone()), note);
+    }
+
+    fn mark_spent(env: &Env, nullifier: &BytesN<32>) -> Result<(), ContractError> {
+        let key = DataKey::Spent(nullifier.clone());
+        if env.storage().persistent().has(&key) {
+            return Err(ContractError::NullifierReuse);
+        }
+        env.storage().persistent().set(&key, &true);
+        Ok(())
+    }
+}
+
+#[contractimpl]
+impl PrivatePaymentsContract {
+    /// Lock `amount` of `token` and record a note under `commitment`.
+    /// The depositor must later prove knowledge of an ed25519 key whose derived commitment matches.
+    pub fn deposit(
+        env: Env,
+        owner: Address,
+        token_addr: Address,
+        amount: i128,
+        commitment: BytesN<32>,
+    ) -> Result<(), ContractError> {
+        owner.require_auth();
+        if amount <= 0 {
+            return Err(ContractError::AmountMismatch);
+        }
+        if env
+            .storage()
+            .persistent()
+            .has(&DataKey::Note(commitment.clone()))
+        {
+            return Err(ContractError::CommitmentAlreadyExists);
+        }
+
+        let mp = env.current_contract_address();
+        let pay = token::Client::new(&env, &token_addr);
+        pay.transfer(&owner, &mp, &amount);
+
+        let note = NoteRecord {
+            owner: owner.clone(),
+            commitment: commitment.clone(),
+            nullifier: BytesN::from_array(&env, &[0u8; 32]),
+            is_spent: false,
+            created_at: env.ledger().timestamp(),
+            token: token_addr,
+            amount,
+        };
+        Self::save_note(&env, &commitment, &note);
+
+        // No nullifier exists yet; omit amount/recipient from event surface.
+        env.events().publish(
+            (Symbol::new(&env, "note_committed"), commitment.clone()),
+            (),
+        );
+        Ok(())
+    }
+
+    /// Verify ed25519 proof over the withdraw transcript and release tokens.
+    /// Proof verification uses Soroban host crypto (`ed25519_verify`); invalid signatures trap (tx failure).
+    pub fn withdraw(
+        env: Env,
+        proof: Bytes,
+        nullifier: BytesN<32>,
+        recipient: Address,
+        amount: i128,
+    ) -> Result<(), ContractError> {
+        let (commitment, pubkey, sig) = parse_proof(&env, &proof)?;
+        let mut note = Self::load_note(&env, &commitment)?;
+        if note.is_spent {
+            return Err(ContractError::AlreadySpent);
+        }
+        if amount != note.amount {
+            return Err(ContractError::AmountMismatch);
+        }
+
+        let exp_commit = expected_commitment(&env, &pubkey, &note.token, note.amount, &note.owner);
+        if exp_commit != commitment || commitment != note.commitment {
+            return Err(ContractError::CommitmentMismatch);
+        }
+
+        let nul = derive_nullifier(&env, &pubkey, &commitment);
+        if nul != nullifier {
+            return Err(ContractError::InvalidProof);
+        }
+
+        let msg = build_withdraw_message(
+            &env,
+            &nullifier,
+            &recipient,
+            amount,
+            &note.token,
+            &commitment,
+        );
+        env.crypto().ed25519_verify(&pubkey, &msg, &sig);
+
+        Self::mark_spent(&env, &nullifier)?;
+        note.is_spent = true;
+        note.nullifier = nullifier.clone();
+        Self::save_note(&env, &commitment, &note);
+
+        let mp = env.current_contract_address();
+        let pay = token::Client::new(&env, &note.token);
+        pay.transfer(&mp, &recipient, &amount);
+
+        env.events()
+            .publish((Symbol::new(&env, "nullifier_spent"), nullifier.clone()), ());
+        Ok(())
+    }
+
+    /// Spend a note (reveals `old_nullifier`) and create a fresh note under `new_commitment` (same token/amount/owner).
+    pub fn transfer_private(
+        env: Env,
+        proof: Bytes,
+        old_nullifier: BytesN<32>,
+        new_commitment: BytesN<32>,
+    ) -> Result<(), ContractError> {
+        let (old_commitment, pubkey, sig) = parse_proof(&env, &proof)?;
+        let mut note = Self::load_note(&env, &old_commitment)?;
+        if note.is_spent {
+            return Err(ContractError::AlreadySpent);
+        }
+
+        let exp_commit =
+            expected_commitment(&env, &pubkey, &note.token, note.amount, &note.owner);
+        if exp_commit != old_commitment || old_commitment != note.commitment {
+            return Err(ContractError::CommitmentMismatch);
+        }
+
+        let expected_nul = derive_nullifier(&env, &pubkey, &old_commitment);
+        if expected_nul != old_nullifier {
+            return Err(ContractError::InvalidProof);
+        }
+
+        if env
+            .storage()
+            .persistent()
+            .has(&DataKey::Note(new_commitment.clone()))
+        {
+            return Err(ContractError::CommitmentAlreadyExists);
+        }
+
+        let msg = build_transfer_message(
+            &env,
+            &old_nullifier,
+            &new_commitment,
+            &note.token,
+            note.amount,
+            &old_commitment,
+            &note.owner,
+        );
+        env.crypto().ed25519_verify(&pubkey, &msg, &sig);
+
+        Self::mark_spent(&env, &old_nullifier)?;
+
+        note.is_spent = true;
+        note.nullifier = old_nullifier.clone();
+        Self::save_note(&env, &old_commitment, &note);
+
+        let new_note = NoteRecord {
+            owner: note.owner.clone(),
+            commitment: new_commitment.clone(),
+            nullifier: BytesN::from_array(&env, &[0u8; 32]),
+            is_spent: false,
+            created_at: env.ledger().timestamp(),
+            token: note.token.clone(),
+            amount: note.amount,
+        };
+        Self::save_note(&env, &new_commitment, &new_note);
+
+        env.events().publish(
+            (Symbol::new(&env, "nullifier_spent"), old_nullifier.clone()),
+            (),
+        );
+        Ok(())
+    }
+
+    pub fn is_spent(env: Env, nullifier: BytesN<32>) -> bool {
+        env.storage()
+            .persistent()
+            .has(&DataKey::Spent(nullifier))
+    }
+
+    pub fn get_commitment(env: Env, commitment: BytesN<32>) -> bool {
+        env.storage()
+            .persistent()
+            .has(&DataKey::Note(commitment))
+    }
+
+    pub fn get_note(env: Env, commitment: BytesN<32>) -> Result<NoteRecord, ContractError> {
+        Self::load_note(&env, &commitment)
+    }
+}
+
+#[cfg(feature = "testhelpers")]
+pub mod testkit {
+    //! Helpers for off-chain / integration test proof construction only.
+    use soroban_sdk::{Address, Bytes, BytesN, Env};
+
+    pub const PROOF_LEN: u32 = crate::PROOF_LEN;
+
+    pub fn expected_commitment(
+        env: &Env,
+        pubkey: &BytesN<32>,
+        token: &Address,
+        amount: i128,
+        owner: &Address,
+    ) -> BytesN<32> {
+        crate::expected_commitment(env, pubkey, token, amount, owner)
+    }
+
+    pub fn derive_nullifier(env: &Env, pubkey: &BytesN<32>, commitment: &BytesN<32>) -> BytesN<32> {
+        crate::derive_nullifier(env, pubkey, commitment)
+    }
+
+    pub fn build_withdraw_message(
+        env: &Env,
+        nullifier: &BytesN<32>,
+        recipient: &Address,
+        amount: i128,
+        token: &Address,
+        commitment: &BytesN<32>,
+    ) -> Bytes {
+        crate::build_withdraw_message(env, nullifier, recipient, amount, token, commitment)
+    }
+
+    pub fn build_transfer_message(
+        env: &Env,
+        old_nullifier: &BytesN<32>,
+        new_commitment: &BytesN<32>,
+        token: &Address,
+        amount: i128,
+        old_commitment: &BytesN<32>,
+        owner: &Address,
+    ) -> Bytes {
+        crate::build_transfer_message(
+            env,
+            old_nullifier,
+            new_commitment,
+            token,
+            amount,
+            old_commitment,
+            owner,
+        )
+    }
+
+    pub fn assemble_proof(
+        env: &Env,
+        commitment: BytesN<32>,
+        pubkey_bytes: &[u8; 32],
+        sig_bytes: &[u8; 64],
+    ) -> Bytes {
+        let mut buf = [0u8; 128];
+        buf[0..32].copy_from_slice(&commitment.to_array());
+        buf[32..64].copy_from_slice(pubkey_bytes);
+        buf[64..128].copy_from_slice(sig_bytes);
+        Bytes::from_slice(env, &buf)
+    }
+}
+
+#[cfg(test)]
+mod test;

--- a/contracts/contracts/private_payments/src/test.rs
+++ b/contracts/contracts/private_payments/src/test.rs
@@ -1,0 +1,289 @@
+#![allow(deprecated)]
+
+use ed25519_dalek::Signer;
+use rand::rngs::StdRng;
+use rand::SeedableRng;
+use soroban_sdk::{
+    testutils::Address as _,
+    token, Address, Bytes, Env,
+};
+
+use crate::{
+    build_transfer_message, build_withdraw_message, derive_nullifier, expected_commitment,
+    ContractError, PrivatePaymentsContract, PrivatePaymentsContractClient,
+};
+
+fn env_setup() -> Env {
+    let env = Env::default();
+    env.mock_all_auths();
+    env
+}
+
+fn deploy(env: &Env) -> (Address, PrivatePaymentsContractClient<'_>) {
+    let id = env.register_contract(None, PrivatePaymentsContract);
+    let client = PrivatePaymentsContractClient::new(env, &id);
+    (id, client)
+}
+
+fn mint_token(env: &Env, holder: &Address) -> Address {
+    let token_id = env
+        .register_stellar_asset_contract_v2(holder.clone())
+        .address();
+    token::StellarAssetClient::new(env, &token_id).mint(holder, &1_000_000_000i128);
+    token_id
+}
+
+fn signing_key(seed: u64) -> ed25519_dalek::SigningKey {
+    let mut rng = StdRng::seed_from_u64(seed);
+    ed25519_dalek::SigningKey::generate(&mut rng)
+}
+
+fn assemble_proof(
+    env: &Env,
+    commitment: soroban_sdk::BytesN<32>,
+    sk: &ed25519_dalek::SigningKey,
+    sig_bytes: &[u8; 64],
+) -> Bytes {
+    let mut buf = [0u8; 128];
+    buf[0..32].copy_from_slice(&commitment.to_array());
+    buf[32..64].copy_from_slice(&sk.verifying_key().to_bytes());
+    buf[64..128].copy_from_slice(sig_bytes);
+    Bytes::from_slice(env, &buf)
+}
+
+#[test]
+fn deposit_creates_note_and_escrows_tokens() {
+    let env = env_setup();
+    let (pool, pp) = deploy(&env);
+    let owner = Address::generate(&env);
+    let token = mint_token(&env, &owner);
+    let sk = signing_key(1);
+    let pk = soroban_sdk::BytesN::from_array(&env, &sk.verifying_key().to_bytes());
+    let commitment = expected_commitment(&env, &pk, &token, 50_000i128, &owner);
+
+    pp.deposit(&owner, &token, &50_000i128, &commitment);
+
+    assert!(pp.get_commitment(&commitment));
+    let note = pp.get_note(&commitment);
+    assert_eq!(note.amount, 50_000i128);
+    assert_eq!(note.owner, owner);
+    assert!(!note.is_spent);
+
+    let tc = token::Client::new(&env, &token);
+    assert_eq!(tc.balance(&pool), 50_000i128);
+}
+
+#[test]
+fn withdraw_transfers_out_and_marks_nullifier_spent() {
+    let env = env_setup();
+    let (pool, pp) = deploy(&env);
+    let owner = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    let token = mint_token(&env, &owner);
+    let sk = signing_key(7);
+    let pk = soroban_sdk::BytesN::from_array(&env, &sk.verifying_key().to_bytes());
+    let amount = 12_000i128;
+    let commitment = expected_commitment(&env, &pk, &token, amount, &owner);
+    pp.deposit(&owner, &token, &amount, &commitment);
+
+    let nullifier = derive_nullifier(&env, &pk, &commitment);
+    let msg = build_withdraw_message(
+        &env,
+        &nullifier,
+        &recipient,
+        amount,
+        &token,
+        &commitment,
+    );
+    let mut msg_buf = [0u8; 512];
+    let ml = msg.len() as usize;
+    msg.copy_into_slice(&mut msg_buf[..ml]);
+    let sig = sk.sign(&msg_buf[..ml]);
+    let proof = assemble_proof(&env, commitment.clone(), &sk, &sig.to_bytes());
+
+    pp.withdraw(&proof, &nullifier, &recipient, &amount);
+
+    assert!(pp.is_spent(&nullifier));
+    let tc = token::Client::new(&env, &token);
+    assert_eq!(tc.balance(&recipient), amount);
+    assert_eq!(tc.balance(&pool), 0i128);
+    let note = pp.get_note(&commitment);
+    assert!(note.is_spent);
+}
+
+#[test]
+fn double_withdraw_same_nullifier_fails() {
+    let env = env_setup();
+    let (_pool, pp) = deploy(&env);
+    let owner = Address::generate(&env);
+    let r1 = Address::generate(&env);
+    let r2 = Address::generate(&env);
+    let token = mint_token(&env, &owner);
+    let sk = signing_key(9);
+    let pk = soroban_sdk::BytesN::from_array(&env, &sk.verifying_key().to_bytes());
+    let amount = 5_000i128;
+    let commitment = expected_commitment(&env, &pk, &token, amount, &owner);
+    pp.deposit(&owner, &token, &amount, &commitment);
+
+    let nullifier = derive_nullifier(&env, &pk, &commitment);
+    let msg = build_withdraw_message(&env, &nullifier, &r1, amount, &token, &commitment);
+    let mut msg_buf = [0u8; 512];
+    let ml = msg.len() as usize;
+    msg.copy_into_slice(&mut msg_buf[..ml]);
+    let sig = sk.sign(&msg_buf[..ml]);
+    let proof = assemble_proof(&env, commitment.clone(), &sk, &sig.to_bytes());
+
+    pp.withdraw(&proof, &nullifier, &r1, &amount);
+
+    let msg2 = build_withdraw_message(&env, &nullifier, &r2, amount, &token, &commitment);
+    let mut msg_buf2 = [0u8; 512];
+    let ml2 = msg2.len() as usize;
+    msg2.copy_into_slice(&mut msg_buf2[..ml2]);
+    let sig2 = sk.sign(&msg_buf2[..ml2]);
+    let proof2 = assemble_proof(&env, commitment.clone(), &sk, &sig2.to_bytes());
+
+    let e = pp.try_withdraw(&proof2, &nullifier, &r2, &amount);
+    assert_eq!(e.err(), Some(Ok(ContractError::AlreadySpent)));
+}
+
+#[test]
+fn withdraw_wrong_amount_fails_before_crypto() {
+    let env = env_setup();
+    let (_pool, pp) = deploy(&env);
+    let owner = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    let token = mint_token(&env, &owner);
+    let sk = signing_key(3);
+    let pk = soroban_sdk::BytesN::from_array(&env, &sk.verifying_key().to_bytes());
+    let amount = 8_000i128;
+    let commitment = expected_commitment(&env, &pk, &token, amount, &owner);
+    pp.deposit(&owner, &token, &amount, &commitment);
+
+    let nullifier = derive_nullifier(&env, &pk, &commitment);
+    let msg = build_withdraw_message(
+        &env,
+        &nullifier,
+        &recipient,
+        amount,
+        &token,
+        &commitment,
+    );
+    let mut msg_buf = [0u8; 512];
+    let ml = msg.len() as usize;
+    msg.copy_into_slice(&mut msg_buf[..ml]);
+    let sig = sk.sign(&msg_buf[..ml]);
+    let proof = assemble_proof(&env, commitment.clone(), &sk, &sig.to_bytes());
+
+    let e = pp.try_withdraw(&proof, &nullifier, &recipient, &(amount - 1));
+    assert_eq!(e.err(), Some(Ok(ContractError::AmountMismatch)));
+}
+
+#[test]
+fn withdraw_bad_signature_traps() {
+    let env = env_setup();
+    let (_pool, pp) = deploy(&env);
+    let owner = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    let token = mint_token(&env, &owner);
+    let sk = signing_key(4);
+    let pk = soroban_sdk::BytesN::from_array(&env, &sk.verifying_key().to_bytes());
+    let amount = 3_000i128;
+    let commitment = expected_commitment(&env, &pk, &token, amount, &owner);
+    pp.deposit(&owner, &token, &amount, &commitment);
+
+    let nullifier = derive_nullifier(&env, &pk, &commitment);
+    let bad_sig = [7u8; 64];
+    let proof = assemble_proof(&env, commitment.clone(), &sk, &bad_sig);
+
+    let e = pp.try_withdraw(&proof, &nullifier, &recipient, &amount);
+    assert!(e.is_err());
+}
+
+#[test]
+fn transfer_private_swaps_commitment_and_spends_nullifier() {
+    let env = env_setup();
+    let (_pool, pp) = deploy(&env);
+    let owner = Address::generate(&env);
+    let token = mint_token(&env, &owner);
+    let sk = signing_key(11);
+    let pk = soroban_sdk::BytesN::from_array(&env, &sk.verifying_key().to_bytes());
+    let amount = 20_000i128;
+    let c_old = expected_commitment(&env, &pk, &token, amount, &owner);
+    pp.deposit(&owner, &token, &amount, &c_old);
+
+    let sk2 = signing_key(12);
+    let pk2 = soroban_sdk::BytesN::from_array(&env, &sk2.verifying_key().to_bytes());
+    let c_new = expected_commitment(&env, &pk2, &token, amount, &owner);
+
+    let old_nul = derive_nullifier(&env, &pk, &c_old);
+    let msg = build_transfer_message(
+        &env,
+        &old_nul,
+        &c_new,
+        &token,
+        amount,
+        &c_old,
+        &owner,
+    );
+    let mut msg_buf = [0u8; 512];
+    let ml = msg.len() as usize;
+    msg.copy_into_slice(&mut msg_buf[..ml]);
+    let sig = sk.sign(&msg_buf[..ml]);
+    let proof = assemble_proof(&env, c_old.clone(), &sk, &sig.to_bytes());
+
+    pp.transfer_private(&proof, &old_nul, &c_new);
+
+    assert!(pp.is_spent(&old_nul));
+    assert!(pp.get_commitment(&c_new));
+    assert!(pp.get_note(&c_old).is_spent);
+    assert!(!pp.get_note(&c_new).is_spent);
+}
+
+#[test]
+fn proof_wrong_length_errors() {
+    let env = env_setup();
+    let (_pool, pp) = deploy(&env);
+    let owner = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    let token = mint_token(&env, &owner);
+    let sk = signing_key(5);
+    let pk = soroban_sdk::BytesN::from_array(&env, &sk.verifying_key().to_bytes());
+    let amount = 1_000i128;
+    let commitment = expected_commitment(&env, &pk, &token, amount, &owner);
+    pp.deposit(&owner, &token, &amount, &commitment);
+
+    let short = Bytes::from_slice(&env, &[0u8; 64]);
+    let nullifier = derive_nullifier(&env, &pk, &commitment);
+    let e = pp.try_withdraw(&short, &nullifier, &recipient, &amount);
+    assert_eq!(e.err(), Some(Ok(ContractError::ProofLength)));
+}
+
+#[test]
+fn duplicate_deposit_commitment_rejected() {
+    let env = env_setup();
+    let (_pool, pp) = deploy(&env);
+    let owner = Address::generate(&env);
+    let token = mint_token(&env, &owner);
+    let sk = signing_key(6);
+    let pk = soroban_sdk::BytesN::from_array(&env, &sk.verifying_key().to_bytes());
+    let commitment = expected_commitment(&env, &pk, &token, 100i128, &owner);
+    pp.deposit(&owner, &token, &100i128, &commitment);
+    let e = pp.try_deposit(&owner, &token, &100i128, &commitment);
+    assert_eq!(e.err(), Some(Ok(ContractError::CommitmentAlreadyExists)));
+}
+
+#[test]
+fn is_spent_false_for_unknown_nullifier() {
+    let env = env_setup();
+    let (_pool, pp) = deploy(&env);
+    let n = soroban_sdk::BytesN::from_array(&env, &[9u8; 32]);
+    assert!(!pp.is_spent(&n));
+}
+
+#[test]
+fn get_commitment_false_for_unknown() {
+    let env = env_setup();
+    let (_pool, pp) = deploy(&env);
+    let c = soroban_sdk::BytesN::from_array(&env, &[8u8; 32]);
+    assert!(!pp.get_commitment(&c));
+}

--- a/contracts/integration-tests/tests/private_payments_flow.rs
+++ b/contracts/integration-tests/tests/private_payments_flow.rs
@@ -1,0 +1,72 @@
+#![allow(deprecated)]
+
+use ed25519_dalek::Signer;
+use rand::rngs::StdRng;
+use rand::SeedableRng;
+use private_payments::testkit::{
+    assemble_proof, build_withdraw_message, derive_nullifier, expected_commitment,
+};
+use private_payments::{PrivatePaymentsContract, PrivatePaymentsContractClient};
+use soroban_sdk::{
+    testutils::Address as _,
+    token, Address, Env,
+};
+
+fn env_setup() -> Env {
+    let env = Env::default();
+    env.mock_all_auths();
+    env
+}
+
+fn mint(env: &Env, holder: &Address) -> Address {
+    let id = env
+        .register_stellar_asset_contract_v2(holder.clone())
+        .address();
+    token::StellarAssetClient::new(env, &id).mint(holder, &500_000_000i128);
+    id
+}
+
+#[test]
+fn integration_deposit_withdraw_happy_path() {
+    let env = env_setup();
+    let pool = env.register_contract(None, PrivatePaymentsContract);
+    let pp = PrivatePaymentsContractClient::new(&env, &pool);
+
+    let owner = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    let tok = mint(&env, &owner);
+
+    let mut rng = StdRng::seed_from_u64(99);
+    let sk = ed25519_dalek::SigningKey::generate(&mut rng);
+    let pk = soroban_sdk::BytesN::from_array(&env, &sk.verifying_key().to_bytes());
+    let amount = 77_777i128;
+    let commitment = expected_commitment(&env, &pk, &tok, amount, &owner);
+
+    pp.deposit(&owner, &tok, &amount, &commitment);
+
+    let nullifier = derive_nullifier(&env, &pk, &commitment);
+    let msg = build_withdraw_message(
+        &env,
+        &nullifier,
+        &recipient,
+        amount,
+        &tok,
+        &commitment,
+    );
+    let mut buf = [0u8; 512];
+    let n = msg.len() as usize;
+    msg.copy_into_slice(&mut buf[..n]);
+    let sig = sk.sign(&buf[..n]);
+    let proof = assemble_proof(
+        &env,
+        commitment.clone(),
+        &sk.verifying_key().to_bytes(),
+        &sig.to_bytes(),
+    );
+
+    pp.withdraw(&proof, &nullifier, &recipient, &amount);
+
+    assert!(pp.is_spent(&nullifier));
+    let tc = token::Client::new(&env, &tok);
+    assert_eq!(tc.balance(&recipient), amount);
+}


### PR DESCRIPTION
## Summary

Adds a Soroban `private_payments` pool contract that uses cryptographic commitments, ed25519 transcript proofs (Soroban host `ed25519_verify`), and a nullifier set to prevent double-spends. Spend-side events intentionally expose only nullifiers (and deposit events only the commitment), not amounts or counterparties in those payloads.
closes #633 
## Contract surface

- **Storage:** `NoteRecord` (owner, commitment, nullifier, `is_spent`, `created_at`, token, amount) keyed by commitment; `Spent(nullifier)` for replay protection.
- **`deposit(token, amount, commitment)`** — escrows tokens, stores note; event `note_committed` (commitment only).
- **`withdraw(proof, nullifier, recipient, amount)`** — verifies 128-byte proof `commitment ‖ pubkey ‖ signature`, releases tokens; event `nullifier_spent` (nullifier only).
- **`transfer_private(proof, old_nullifier, new_commitment)`** — spends old note, creates new commitment; event `nullifier_spent` for the old nullifier.
- **`is_spent` / `get_commitment`** — view helpers; `get_note` for diagnostics/tests.

## Workspace / tests

- `integration-tests` added to the contracts workspace; `private_payments` uses `crate-type = ["cdylib", "rlib"]` so integration tests can link the library.
- Optional **`testhelpers`** feature exposes `private_payments::testkit` for assembling valid proofs in tests.
- **Unit tests** in the crate; **integration test** `integration-tests/tests/private_payments_flow.rs` (deposit → withdraw).

## Caveats

- Deposit transactions and on-chain note storage still reveal amounts to anyone reading the ledger; this design focuses on **event-level** minimization and a clear path to stricter shielding (e.g. Merkle notes + circuit proofs) later.
- “Proof verification” here is **Ed25519 over domain-separated transcripts**, not a generic zk-SNARK verifier (not available as a single host API in Soroban SDK 22).

## How to test

```bash
cd contracts
cargo test -p private_payments
cargo test -p integration-tests