### PR TITLE
feat(bridge_adapter): Soroban cross-chain lock and M-of-N relay (#631)

### DIFF
--- a/contracts/Cargo.toml
+++ b/contracts/Cargo.toml
@@ -2,6 +2,7 @@
 resolver = "2"
 members = [
     "gasless-common",
+    "bridge_adapter",
     "contracts/*",
     "integration-tests",
 ]

--- a/contracts/bridge_adapter/Cargo.toml
+++ b/contracts/bridge_adapter/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "bridge_adapter"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+doctest = false
+
+[dependencies]
+soroban-sdk = { workspace = true }
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/contracts/bridge_adapter/src/lib.rs
+++ b/contracts/bridge_adapter/src/lib.rs
@@ -1,0 +1,409 @@
+#![no_std]
+
+use soroban_sdk::{
+    contract, contracterror, contractimpl, contracttype, token, Address, Bytes, BytesN, Env, Symbol,
+};
+
+/// Seconds after lock before depositor may refund if relay is incomplete.
+pub const REFUND_TIMEOUT_SECS: u64 = 86_400;
+
+const DOM_DEPOSIT: &[u8] = b"WHSPR/BRIDGE/DEPOSIT/v1\0";
+
+pub type DepositId = BytesN<32>;
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum DepositStatus {
+    Pending,
+    Relayed,
+    Completed,
+    Refunded,
+}
+
+/// Bridge-side lock record: tokens are held until `Completed` or `Refunded`.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct BridgeDeposit {
+    pub depositor: Address,
+    pub token: Address,
+    pub amount: i128,
+    pub target_chain: u32,
+    pub target_address: Bytes,
+    /// Monotonic per-contract sequence at lock time; binds relay intent and prevents replay.
+    pub nonce: u64,
+    pub status: DepositStatus,
+    pub locked_at: u64,
+    /// EVM (or other dest) tx hash, agreed upon by relayers after first confirmation.
+    pub dest_tx_hash: Bytes,
+    pub relay_confirmations: u32,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RelayerRecord {
+    pub relayer: Address,
+    pub is_active: bool,
+    pub total_relayed: u64,
+    pub added_at: u64,
+}
+
+#[derive(Clone)]
+#[contracttype]
+enum DataKey {
+    Admin,
+    RelayerThreshold,
+    NextDepositSeq,
+    Deposit(DepositId),
+    Relayer(Address),
+    DepositRelayConf(DepositId, Address),
+}
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum ContractError {
+    NotInitialized = 1,
+    AlreadyInitialized = 2,
+    Unauthorized = 3,
+    InvalidAmount = 4,
+    InvalidThreshold = 5,
+    DepositNotFound = 6,
+    InvalidDepositStatus = 7,
+    NotActiveRelayer = 8,
+    AlreadyConfirmed = 9,
+    DestTxHashMismatch = 10,
+    RefundTooEarly = 11,
+    NotDepositor = 12,
+    RelayerAlreadyActive = 13,
+    RelayerNotFound = 14,
+    InvalidTargetAddress = 15,
+    SequenceOverflow = 16,
+    InvalidTxHash = 17,
+}
+
+fn require_admin(env: &Env, admin: &Address) -> Result<(), ContractError> {
+    admin.require_auth();
+    let stored: Address = env
+        .storage()
+        .instance()
+        .get(&DataKey::Admin)
+        .ok_or(ContractError::NotInitialized)?;
+    if stored != *admin {
+        return Err(ContractError::Unauthorized);
+    }
+    Ok(())
+}
+
+fn append_address_strkey(_env: &Env, buf: &mut Bytes, addr: &Address) {
+    let s = addr.to_string();
+    let n = s.len() as usize;
+    if n > 96 {
+        panic!();
+    }
+    let mut tmp = [0u8; 96];
+    s.copy_into_slice(&mut tmp[..n]);
+    buf.extend_from_slice(&tmp[..n]);
+}
+
+fn next_deposit_id(env: &Env) -> Result<(DepositId, u64), ContractError> {
+    let mut seq: u64 = env
+        .storage()
+        .instance()
+        .get(&DataKey::NextDepositSeq)
+        .unwrap_or(0);
+    seq = seq.checked_add(1).ok_or(ContractError::SequenceOverflow)?;
+    env.storage()
+        .instance()
+        .set(&DataKey::NextDepositSeq, &seq);
+
+    let mut pre = Bytes::new(env);
+    pre.extend_from_slice(DOM_DEPOSIT);
+    pre.extend_from_slice(&seq.to_be_bytes());
+    let ca = env.current_contract_address();
+    append_address_strkey(env, &mut pre, &ca);
+    let id = env.crypto().sha256(&pre).to_bytes();
+    Ok((id, seq))
+}
+
+fn load_deposit(env: &Env, id: &DepositId) -> Result<BridgeDeposit, ContractError> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::Deposit(id.clone()))
+        .ok_or(ContractError::DepositNotFound)
+}
+
+fn save_deposit(env: &Env, id: &DepositId, d: &BridgeDeposit) {
+    env.storage()
+        .persistent()
+        .set(&DataKey::Deposit(id.clone()), d);
+}
+
+fn load_relayer(env: &Env, relayer: &Address) -> Result<RelayerRecord, ContractError> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::Relayer(relayer.clone()))
+        .ok_or(ContractError::RelayerNotFound)
+}
+
+#[contract]
+pub struct BridgeAdapterContract;
+
+#[contractimpl]
+impl BridgeAdapterContract {
+    /// Initialize bridge admin and M-of-N threshold (M) for relay finality.
+    pub fn initialize(env: Env, admin: Address, relayer_threshold: u32) -> Result<(), ContractError> {
+        if env.storage().instance().has(&DataKey::Admin) {
+            return Err(ContractError::AlreadyInitialized);
+        }
+        if relayer_threshold == 0 {
+            return Err(ContractError::InvalidThreshold);
+        }
+        env.storage().instance().set(&DataKey::Admin, &admin);
+        env.storage()
+            .instance()
+            .set(&DataKey::RelayerThreshold, &relayer_threshold);
+        env.storage().instance().set(&DataKey::NextDepositSeq, &0_u64);
+        Ok(())
+    }
+
+    pub fn get_admin(env: Env) -> Result<Address, ContractError> {
+        env.storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .ok_or(ContractError::NotInitialized)
+    }
+
+    pub fn get_relayer_threshold(env: Env) -> Result<u32, ContractError> {
+        env.storage()
+            .instance()
+            .get(&DataKey::RelayerThreshold)
+            .ok_or(ContractError::NotInitialized)
+    }
+
+    /// Lock `amount` of Soroban `token` into this contract and emit bridge metadata.
+    pub fn lock_and_bridge(
+        env: Env,
+        depositor: Address,
+        token: Address,
+        amount: i128,
+        target_chain: u32,
+        target_address: Bytes,
+    ) -> Result<DepositId, ContractError> {
+        depositor.require_auth();
+        if !env.storage().instance().has(&DataKey::Admin) {
+            return Err(ContractError::NotInitialized);
+        }
+        if amount <= 0 {
+            return Err(ContractError::InvalidAmount);
+        }
+        if target_address.is_empty() {
+            return Err(ContractError::InvalidTargetAddress);
+        }
+
+        let (deposit_id, nonce) = next_deposit_id(&env)?;
+        let ts = env.ledger().timestamp();
+        let hold = env.current_contract_address();
+        let client = token::Client::new(&env, &token);
+        client.transfer(&depositor, &hold, &amount);
+
+        let record = BridgeDeposit {
+            depositor: depositor.clone(),
+            token: token.clone(),
+            amount,
+            target_chain,
+            target_address: target_address.clone(),
+            nonce,
+            status: DepositStatus::Pending,
+            locked_at: ts,
+            dest_tx_hash: Bytes::new(&env),
+            relay_confirmations: 0,
+        };
+        save_deposit(&env, &deposit_id, &record);
+
+        env.events().publish(
+            (
+                Symbol::new(&env, "bridge_lock"),
+                deposit_id.clone(),
+                depositor.clone(),
+            ),
+            (
+                token,
+                amount,
+                target_chain,
+                target_address,
+                nonce,
+                ts,
+            ),
+        );
+
+        Ok(deposit_id)
+    }
+
+    /// A registered active relayer attests destination delivery. Requires Stellar `relayer`
+    /// authorization (M-of-N unique relayers). `tx_hash` is the destination-chain tx id (bytes).
+    pub fn confirm_relay(
+        env: Env,
+        relayer: Address,
+        deposit_id: DepositId,
+        tx_hash: Bytes,
+    ) -> Result<(), ContractError> {
+        relayer.require_auth();
+        if tx_hash.is_empty() {
+            return Err(ContractError::InvalidTxHash);
+        }
+        let threshold = Self::get_relayer_threshold(env.clone())?;
+        let r = load_relayer(&env, &relayer)?;
+        if !r.is_active {
+            return Err(ContractError::NotActiveRelayer);
+        }
+
+        let conf_key = DataKey::DepositRelayConf(deposit_id.clone(), relayer.clone());
+        if env.storage().persistent().has(&conf_key) {
+            return Err(ContractError::AlreadyConfirmed);
+        }
+
+        let mut dep = load_deposit(&env, &deposit_id)?;
+        match dep.status {
+            DepositStatus::Pending | DepositStatus::Relayed => {}
+            DepositStatus::Completed | DepositStatus::Refunded => {
+                return Err(ContractError::InvalidDepositStatus);
+            }
+        }
+
+        if dep.relay_confirmations > 0 {
+            if dep.dest_tx_hash != tx_hash {
+                return Err(ContractError::DestTxHashMismatch);
+            }
+        } else {
+            dep.dest_tx_hash = tx_hash.clone();
+        }
+
+        env.storage().persistent().set(&conf_key, &true);
+
+        dep.relay_confirmations = dep
+            .relay_confirmations
+            .checked_add(1)
+            .ok_or(ContractError::InvalidDepositStatus)?;
+
+        let mut rr = r;
+        rr.total_relayed = rr
+            .total_relayed
+            .checked_add(1)
+            .ok_or(ContractError::InvalidDepositStatus)?;
+        env.storage()
+            .persistent()
+            .set(&DataKey::Relayer(relayer.clone()), &rr);
+
+        if dep.relay_confirmations >= threshold {
+            dep.status = DepositStatus::Completed;
+        } else {
+            dep.status = DepositStatus::Relayed;
+        }
+        save_deposit(&env, &deposit_id, &dep);
+
+        let status_tag: u32 = match dep.status {
+            DepositStatus::Pending => 0,
+            DepositStatus::Relayed => 1,
+            DepositStatus::Completed => 2,
+            DepositStatus::Refunded => 3,
+        };
+        env.events().publish(
+            (Symbol::new(&env, "bridge_confirm"), deposit_id.clone(), relayer.clone()),
+            (tx_hash, dep.relay_confirmations, status_tag),
+        );
+
+        Ok(())
+    }
+
+    /// Depositor reclaims funds if relay is not completed within [`REFUND_TIMEOUT_SECS`].
+    pub fn refund(env: Env, depositor: Address, deposit_id: DepositId) -> Result<(), ContractError> {
+        depositor.require_auth();
+        let mut dep = load_deposit(&env, &deposit_id)?;
+        if dep.depositor != depositor {
+            return Err(ContractError::NotDepositor);
+        }
+        match dep.status {
+            DepositStatus::Pending | DepositStatus::Relayed => {}
+            DepositStatus::Completed | DepositStatus::Refunded => {
+                return Err(ContractError::InvalidDepositStatus);
+            }
+        }
+        let now = env.ledger().timestamp();
+        if now < dep.locked_at.saturating_add(REFUND_TIMEOUT_SECS) {
+            return Err(ContractError::RefundTooEarly);
+        }
+
+        let hold = env.current_contract_address();
+        let client = token::Client::new(&env, &dep.token);
+        client.transfer(&hold, &dep.depositor, &dep.amount);
+
+        dep.status = DepositStatus::Refunded;
+        save_deposit(&env, &deposit_id, &dep);
+
+        env.events().publish(
+            (
+                Symbol::new(&env, "bridge_refund"),
+                deposit_id.clone(),
+                depositor.clone(),
+            ),
+            (dep.token.clone(), dep.amount, now),
+        );
+
+        Ok(())
+    }
+
+    pub fn add_relayer(env: Env, admin: Address, relayer: Address) -> Result<(), ContractError> {
+        require_admin(&env, &admin)?;
+        let ts = env.ledger().timestamp();
+        if let Some(mut existing) = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Relayer(relayer.clone()))
+        {
+            if existing.is_active {
+                return Err(ContractError::RelayerAlreadyActive);
+            }
+            existing.is_active = true;
+            existing.added_at = ts;
+            env.storage()
+                .persistent()
+                .set(&DataKey::Relayer(relayer), &existing);
+        } else {
+            let rec = RelayerRecord {
+                relayer: relayer.clone(),
+                is_active: true,
+                total_relayed: 0,
+                added_at: ts,
+            };
+            env.storage()
+                .persistent()
+                .set(&DataKey::Relayer(relayer), &rec);
+        }
+        Ok(())
+    }
+
+    pub fn remove_relayer(env: Env, admin: Address, relayer: Address) -> Result<(), ContractError> {
+        require_admin(&env, &admin)?;
+        let mut rec = load_relayer(&env, &relayer)?;
+        if !rec.is_active {
+            return Err(ContractError::RelayerNotFound);
+        }
+        rec.is_active = false;
+        env.storage()
+            .persistent()
+            .set(&DataKey::Relayer(relayer), &rec);
+        Ok(())
+    }
+
+    pub fn get_deposit(env: Env, deposit_id: DepositId) -> Option<BridgeDeposit> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Deposit(deposit_id))
+    }
+
+    pub fn get_relayer(env: Env, relayer: Address) -> Option<RelayerRecord> {
+        env.storage().persistent().get(&DataKey::Relayer(relayer))
+    }
+}
+
+#[cfg(test)]
+mod test;

--- a/contracts/bridge_adapter/src/test.rs
+++ b/contracts/bridge_adapter/src/test.rs
@@ -1,0 +1,509 @@
+#![allow(deprecated)]
+
+use crate::{
+    BridgeAdapterContract, BridgeAdapterContractClient, ContractError, DepositStatus,
+    REFUND_TIMEOUT_SECS,
+};
+use soroban_sdk::{
+    testutils::Address as _,
+    token, Address, Bytes, Env,
+};
+
+fn deploy<'a>(env: &'a Env) -> (Address, BridgeAdapterContractClient<'a>) {
+    let id = env.register_contract(None, BridgeAdapterContract);
+    let client = BridgeAdapterContractClient::new(env, &id);
+    (id, client)
+}
+
+fn mint_token_to(env: &Env, holder: &Address, amount: i128) -> Address {
+    let id = env
+        .register_stellar_asset_contract_v2(holder.clone())
+        .address();
+    token::StellarAssetClient::new(env, &id).mint(holder, &amount);
+    id
+}
+
+fn addr_bytes(env: &Env, addr: &Address) -> Bytes {
+    let s = addr.to_string();
+    Bytes::from_slice(env, s.as_bytes())
+}
+
+#[test]
+fn initialize_sets_admin_and_threshold() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let (_, client) = deploy(&env);
+    client.initialize(&admin, &2u32).unwrap();
+    assert_eq!(client.get_admin().unwrap(), admin);
+    assert_eq!(client.get_relayer_threshold().unwrap(), 2);
+}
+
+#[test]
+fn initialize_rejects_zero_threshold() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let (_, client) = deploy(&env);
+    let e = client
+        .try_initialize(&admin, &0u32)
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(e, ContractError::InvalidThreshold);
+}
+
+#[test]
+fn initialize_twice_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let (_, client) = deploy(&env);
+    client.initialize(&admin, &2u32).unwrap();
+    let e = client
+        .try_initialize(&admin, &1u32)
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(e, ContractError::AlreadyInitialized);
+}
+
+#[test]
+fn lock_and_bridge_holds_tokens_and_records_deposit() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let depositor = Address::generate(&env);
+    let (bridge_id, client) = deploy(&env);
+    client.initialize(&admin, &2u32).unwrap();
+    let tok = mint_token_to(&env, &depositor, 1_000_000i128);
+    let bal_before = token::Client::new(&env, &tok).balance(&depositor);
+    let dep_id = client
+        .lock_and_bridge(
+            &depositor,
+            &tok,
+            &100i128,
+            &137u32,
+            &addr_bytes(&env, &Address::generate(&env)),
+        )
+        .unwrap();
+    let dep = client.get_deposit(&dep_id).unwrap();
+    assert_eq!(dep.depositor, depositor);
+    assert_eq!(dep.token, tok);
+    assert_eq!(dep.amount, 100);
+    assert_eq!(dep.target_chain, 137);
+    assert_eq!(dep.status, DepositStatus::Pending);
+    assert_eq!(dep.nonce, 1);
+    let tc = token::Client::new(&env, &tok);
+    assert_eq!(tc.balance(&depositor), bal_before - 100);
+    assert_eq!(tc.balance(&bridge_id), 100);
+}
+
+#[test]
+fn lock_empty_target_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let depositor = Address::generate(&env);
+    let (_, client) = deploy(&env);
+    client.initialize(&admin, &1u32).unwrap();
+    let tok = mint_token_to(&env, &depositor, 100i128);
+    let e = client
+        .try_lock_and_bridge(&depositor, &tok, &10i128, &1u32, &Bytes::new(&env))
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(e, ContractError::InvalidTargetAddress);
+}
+
+#[test]
+fn confirm_non_relayer_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let depositor = Address::generate(&env);
+    let r1 = Address::generate(&env);
+    let stranger = Address::generate(&env);
+    let (_, client) = deploy(&env);
+    client.initialize(&admin, &1u32).unwrap();
+    client.add_relayer(&admin, &r1).unwrap();
+    let tok = mint_token_to(&env, &depositor, 1_000i128);
+    let dep_id = client
+        .lock_and_bridge(
+            &depositor,
+            &tok,
+            &50i128,
+            &1u32,
+            &addr_bytes(&env, &Address::generate(&env)),
+        )
+        .unwrap();
+    let th = Bytes::from_slice(&env, &[0xabu8; 32]);
+    let e = client
+        .try_confirm_relay(&stranger, &dep_id, &th)
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(e, ContractError::RelayerNotFound);
+}
+
+#[test]
+fn confirm_inactive_relayer_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let depositor = Address::generate(&env);
+    let r1 = Address::generate(&env);
+    let (_, client) = deploy(&env);
+    client.initialize(&admin, &1u32).unwrap();
+    client.add_relayer(&admin, &r1).unwrap();
+    client.remove_relayer(&admin, &r1).unwrap();
+    let tok = mint_token_to(&env, &depositor, 500i128);
+    let dep_id = client
+        .lock_and_bridge(
+            &depositor,
+            &tok,
+            &50i128,
+            &1u32,
+            &addr_bytes(&env, &Address::generate(&env)),
+        )
+        .unwrap();
+    let th = Bytes::from_slice(&env, &[1u8; 32]);
+    let e = client
+        .try_confirm_relay(&r1, &dep_id, &th)
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(e, ContractError::NotActiveRelayer);
+}
+
+#[test]
+fn m_of_n_relay_marks_completed() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let depositor = Address::generate(&env);
+    let r1 = Address::generate(&env);
+    let r2 = Address::generate(&env);
+    let (_, client) = deploy(&env);
+    client.initialize(&admin, &2u32).unwrap();
+    client.add_relayer(&admin, &r1).unwrap();
+    client.add_relayer(&admin, &r2).unwrap();
+    let tok = mint_token_to(&env, &depositor, 1_000i128);
+    let dep_id = client
+        .lock_and_bridge(
+            &depositor,
+            &tok,
+            &80i128,
+            &8453u32,
+            &addr_bytes(&env, &Address::generate(&env)),
+        )
+        .unwrap();
+
+    let th = Bytes::from_slice(&env, &[2u8; 32]);
+    client.confirm_relay(&r1, &dep_id, &th).unwrap();
+    let d1 = client.get_deposit(&dep_id).unwrap();
+    assert_eq!(d1.status, DepositStatus::Relayed);
+    assert_eq!(d1.relay_confirmations, 1);
+
+    client.confirm_relay(&r2, &dep_id, &th).unwrap();
+    let d2 = client.get_deposit(&dep_id).unwrap();
+    assert_eq!(d2.status, DepositStatus::Completed);
+    assert_eq!(d2.relay_confirmations, 2);
+    assert_eq!(d2.dest_tx_hash, th);
+}
+
+#[test]
+fn same_relayer_cannot_confirm_twice() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let depositor = Address::generate(&env);
+    let r1 = Address::generate(&env);
+    let (_, client) = deploy(&env);
+    client.initialize(&admin, &2u32).unwrap();
+    client.add_relayer(&admin, &r1).unwrap();
+    let tok = mint_token_to(&env, &depositor, 500i128);
+    let dep_id = client
+        .lock_and_bridge(
+            &depositor,
+            &tok,
+            &50i128,
+            &1u32,
+            &addr_bytes(&env, &Address::generate(&env)),
+        )
+        .unwrap();
+    let th = Bytes::from_slice(&env, &[3u8; 32]);
+    client.confirm_relay(&r1, &dep_id, &th).unwrap();
+    let e = client
+        .try_confirm_relay(&r1, &dep_id, &th)
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(e, ContractError::AlreadyConfirmed);
+}
+
+#[test]
+fn second_relayer_must_match_tx_hash() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let depositor = Address::generate(&env);
+    let r1 = Address::generate(&env);
+    let r2 = Address::generate(&env);
+    let (_, client) = deploy(&env);
+    client.initialize(&admin, &2u32).unwrap();
+    client.add_relayer(&admin, &r1).unwrap();
+    client.add_relayer(&admin, &r2).unwrap();
+    let tok = mint_token_to(&env, &depositor, 500i128);
+    let dep_id = client
+        .lock_and_bridge(
+            &depositor,
+            &tok,
+            &50i128,
+            &1u32,
+            &addr_bytes(&env, &Address::generate(&env)),
+        )
+        .unwrap();
+    let th1 = Bytes::from_slice(&env, &[4u8; 32]);
+    let th2 = Bytes::from_slice(&env, &[5u8; 32]);
+    client.confirm_relay(&r1, &dep_id, &th1).unwrap();
+    let e = client
+        .try_confirm_relay(&r2, &dep_id, &th2)
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(e, ContractError::DestTxHashMismatch);
+}
+
+#[test]
+fn refund_after_timeout_returns_tokens() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().with_mut(|li| li.timestamp = 10_000);
+    let admin = Address::generate(&env);
+    let depositor = Address::generate(&env);
+    let (_, client) = deploy(&env);
+    client.initialize(&admin, &2u32).unwrap();
+    let tok = mint_token_to(&env, &depositor, 1_000i128);
+    let dep_id = client
+        .lock_and_bridge(
+            &depositor,
+            &tok,
+            &200i128,
+            &1u32,
+            &addr_bytes(&env, &Address::generate(&env)),
+        )
+        .unwrap();
+    let bal_locked = token::Client::new(&env, &tok).balance(&depositor);
+    let future = 10_000 + REFUND_TIMEOUT_SECS + 1;
+    env.ledger().with_mut(|li| li.timestamp = future);
+    client.refund(&depositor, &dep_id).unwrap();
+    let tc = token::Client::new(&env, &tok);
+    assert_eq!(tc.balance(&depositor), bal_locked + 200);
+    assert_eq!(
+        client.get_deposit(&dep_id).unwrap().status,
+        DepositStatus::Refunded
+    );
+}
+
+#[test]
+fn refund_before_timeout_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().with_mut(|li| li.timestamp = 5_000);
+    let admin = Address::generate(&env);
+    let depositor = Address::generate(&env);
+    let (_, client) = deploy(&env);
+    client.initialize(&admin, &1u32).unwrap();
+    let tok = mint_token_to(&env, &depositor, 500i128);
+    let dep_id = client
+        .lock_and_bridge(
+            &depositor,
+            &tok,
+            &50i128,
+            &1u32,
+            &addr_bytes(&env, &Address::generate(&env)),
+        )
+        .unwrap();
+    let e = client
+        .try_refund(&depositor, &dep_id)
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(e, ContractError::RefundTooEarly);
+}
+
+#[test]
+fn only_depositor_can_refund() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().with_mut(|li| li.timestamp = 0);
+    let admin = Address::generate(&env);
+    let depositor = Address::generate(&env);
+    let other = Address::generate(&env);
+    let (_, client) = deploy(&env);
+    client.initialize(&admin, &1u32).unwrap();
+    let tok = mint_token_to(&env, &depositor, 500i128);
+    let dep_id = client
+        .lock_and_bridge(
+            &depositor,
+            &tok,
+            &50i128,
+            &1u32,
+            &addr_bytes(&env, &Address::generate(&env)),
+        )
+        .unwrap();
+    env.ledger().with_mut(|li| li.timestamp = REFUND_TIMEOUT_SECS + 1);
+    let e = client.try_refund(&other, &dep_id).unwrap_err().unwrap();
+    assert_eq!(e, ContractError::NotDepositor);
+}
+
+#[test]
+fn cannot_refund_completed() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let depositor = Address::generate(&env);
+    let r1 = Address::generate(&env);
+    let (_, client) = deploy(&env);
+    client.initialize(&admin, &1u32).unwrap();
+    client.add_relayer(&admin, &r1).unwrap();
+    let tok = mint_token_to(&env, &depositor, 500i128);
+    let dep_id = client
+        .lock_and_bridge(
+            &depositor,
+            &tok,
+            &50i128,
+            &1u32,
+            &addr_bytes(&env, &Address::generate(&env)),
+        )
+        .unwrap();
+    client
+        .confirm_relay(
+            &r1,
+            &dep_id,
+            &Bytes::from_slice(&env, &[9u8; 32]),
+        )
+        .unwrap();
+    env.ledger().with_mut(|li| li.timestamp = REFUND_TIMEOUT_SECS + 10_000);
+    let e = client.try_refund(&depositor, &dep_id).unwrap_err().unwrap();
+    assert_eq!(e, ContractError::InvalidDepositStatus);
+}
+
+#[test]
+fn relayer_totals_increment() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let depositor = Address::generate(&env);
+    let r1 = Address::generate(&env);
+    let (_, client) = deploy(&env);
+    client.initialize(&admin, &1u32).unwrap();
+    client.add_relayer(&admin, &r1).unwrap();
+    let tok = mint_token_to(&env, &depositor, 500i128);
+    let dep_id = client
+        .lock_and_bridge(
+            &depositor,
+            &tok,
+            &50i128,
+            &1u32,
+            &addr_bytes(&env, &Address::generate(&env)),
+        )
+        .unwrap();
+    client
+        .confirm_relay(
+            &r1,
+            &dep_id,
+            &Bytes::from_slice(&env, &[7u8; 32]),
+        )
+        .unwrap();
+    let rec = client.get_relayer(&r1).unwrap();
+    assert_eq!(rec.total_relayed, 1);
+}
+
+#[test]
+fn duplicate_active_relayer_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let r1 = Address::generate(&env);
+    let (_, client) = deploy(&env);
+    client.initialize(&admin, &1u32).unwrap();
+    client.add_relayer(&admin, &r1).unwrap();
+    let e = client.try_add_relayer(&admin, &r1).unwrap_err().unwrap();
+    assert_eq!(e, ContractError::RelayerAlreadyActive);
+}
+
+#[test]
+fn confirm_empty_tx_hash_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let depositor = Address::generate(&env);
+    let r1 = Address::generate(&env);
+    let (_, client) = deploy(&env);
+    client.initialize(&admin, &1u32).unwrap();
+    client.add_relayer(&admin, &r1).unwrap();
+    let tok = mint_token_to(&env, &depositor, 500i128);
+    let dep_id = client
+        .lock_and_bridge(
+            &depositor,
+            &tok,
+            &10i128,
+            &1u32,
+            &addr_bytes(&env, &Address::generate(&env)),
+        )
+        .unwrap();
+    let e = client
+        .try_confirm_relay(&r1, &dep_id, &Bytes::new(&env))
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(e, ContractError::InvalidTxHash);
+}
+
+#[test]
+fn non_admin_cannot_add_relayer() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let bad = Address::generate(&env);
+    let r1 = Address::generate(&env);
+    let (_, client) = deploy(&env);
+    client.initialize(&admin, &1u32).unwrap();
+    let e = client.try_add_relayer(&bad, &r1).unwrap_err().unwrap();
+    assert_eq!(e, ContractError::Unauthorized);
+}
+
+#[test]
+fn get_deposit_unknown_none() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let (_, client) = deploy(&env);
+    client.initialize(&admin, &1u32).unwrap();
+    let fake = soroban_sdk::BytesN::from_array(&env, &[0xffu8; 32]);
+    assert!(client.get_deposit(&fake).is_none());
+}
+
+#[test]
+fn nonce_increments_per_lock() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let depositor = Address::generate(&env);
+    let (_, client) = deploy(&env);
+    client.initialize(&admin, &1u32).unwrap();
+    let tok = mint_token_to(&env, &depositor, 1_000i128);
+    let d0 = client
+        .lock_and_bridge(
+            &depositor,
+            &tok,
+            &1i128,
+            &1u32,
+            &addr_bytes(&env, &Address::generate(&env)),
+        )
+        .unwrap();
+    let d1 = client
+        .lock_and_bridge(
+            &depositor,
+            &tok,
+            &1i128,
+            &1u32,
+            &addr_bytes(&env, &Address::generate(&env)),
+        )
+        .unwrap();
+    assert_eq!(client.get_deposit(&d0).unwrap().nonce, 1);
+    assert_eq!(client.get_deposit(&d1).unwrap().nonce, 2);
+}

--- a/contracts/integration-tests/Cargo.toml
+++ b/contracts/integration-tests/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 [dev-dependencies]
 soroban-sdk = { workspace = true, features = ["testutils"] }
+bridge_adapter = { path = "../bridge_adapter" }
 messaging  = { path = "../messaging" }
 payments   = { path = "../payments" }
 private_payments = { path = "../contracts/private_payments", features = ["testhelpers"] }

--- a/contracts/integration-tests/tests/bridge_adapter_flow.rs
+++ b/contracts/integration-tests/tests/bridge_adapter_flow.rs
@@ -1,0 +1,112 @@
+#![allow(deprecated)]
+
+use bridge_adapter::{BridgeAdapterContract, BridgeAdapterContractClient, DepositStatus};
+use soroban_sdk::{
+    testutils::Address as _,
+    token, Address, Bytes, Env,
+};
+
+fn env_setup() -> Env {
+    let env = Env::default();
+    env.mock_all_auths();
+    env
+}
+
+fn mint(env: &Env, holder: &Address) -> Address {
+    let id = env
+        .register_stellar_asset_contract_v2(holder.clone())
+        .address();
+    token::StellarAssetClient::new(env, &id).mint(holder, &500_000_000i128);
+    id
+}
+
+fn as_target(env: &Env, addr: &Address) -> Bytes {
+    Bytes::from_slice(env, addr.to_string().as_bytes())
+}
+
+#[test]
+fn integration_full_bridge_polygon_to_evm_style_flow() {
+    let env = env_setup();
+    let bridge_id = env.register_contract(None, BridgeAdapterContract);
+    let bridge = BridgeAdapterContractClient::new(&env, &bridge_id);
+
+    let admin = Address::generate(&env);
+    let depositor = Address::generate(&env);
+    let rel_a = Address::generate(&env);
+    let rel_b = Address::generate(&env);
+
+    bridge.initialize(&admin, &2u32).unwrap();
+    bridge.add_relayer(&admin, &rel_a).unwrap();
+    bridge.add_relayer(&admin, &rel_b).unwrap();
+
+    let tok = mint(&env, &depositor);
+    let amount = 1_250_000i128;
+    let dest = Address::generate(&env);
+
+    let dep_id = bridge
+        .lock_and_bridge(
+            &depositor,
+            &tok,
+            &amount,
+            &137u32,
+            &as_target(&env, &dest),
+        )
+        .unwrap();
+
+    assert_eq!(
+        token::Client::new(&env, &tok).balance(&bridge_id),
+        amount
+    );
+
+    let evm_tx = Bytes::from_slice(&env, &[0x81u8; 32]);
+    bridge.confirm_relay(&rel_a, &dep_id, &evm_tx).unwrap();
+    let d_mid = bridge.get_deposit(&dep_id).unwrap();
+    assert_eq!(d_mid.status, DepositStatus::Relayed);
+
+    bridge.confirm_relay(&rel_b, &dep_id, &evm_tx).unwrap();
+    let d_done = bridge.get_deposit(&dep_id).unwrap();
+    assert_eq!(d_done.status, DepositStatus::Completed);
+    assert_eq!(d_done.relay_confirmations, 2);
+
+    assert_eq!(
+        bridge.get_relayer(&rel_a).unwrap().total_relayed,
+        1u64
+    );
+    assert_eq!(
+        bridge.get_relayer(&rel_b).unwrap().total_relayed,
+        1u64
+    );
+}
+
+#[test]
+fn integration_refund_after_deadline_when_under_threshold() {
+    let env = env_setup();
+    env.ledger().with_mut(|li| li.timestamp = 100);
+    let bridge_id = env.register_contract(None, BridgeAdapterContract);
+    let bridge = BridgeAdapterContractClient::new(&env, &bridge_id);
+
+    let admin = Address::generate(&env);
+    let depositor = Address::generate(&env);
+    bridge.initialize(&admin, &3u32).unwrap();
+
+    let tok = mint(&env, &depositor);
+    let dep_id = bridge
+        .lock_and_bridge(
+            &depositor,
+            &tok,
+            &50_000i128,
+            &8453u32,
+            &as_target(&env, &Address::generate(&env)),
+        )
+        .unwrap();
+
+    let bal = token::Client::new(&env, &tok).balance(&depositor);
+    env.ledger().with_mut(|li| {
+        li.timestamp = 100 + bridge_adapter::REFUND_TIMEOUT_SECS + 1
+    });
+    bridge.refund(&depositor, &dep_id).unwrap();
+    assert_eq!(
+        token::Client::new(&env, &tok).balance(&depositor),
+        bal + 50_000i128
+    );
+}


### PR DESCRIPTION
Add bridge_adapter workspace crate with bridge deposit storage, relayer registry, lock_and_bridge, confirm_relay, refund after 24h, and admin relayer management. Events bridge_lock, bridge_confirm, bridge_refund. Register the crate in the workspace, wire integration-tests, and add end-to-end scenarios.

closes #631 