### PR TITLE
[Soroban] Airdrop & Reward Distribution Contract

### DIFF
--- a/contracts/contracts/airdrop_distribution/Cargo.toml
+++ b/contracts/contracts/airdrop_distribution/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "airdrop_distribution"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"
+
+[dev-dependencies]
+soroban-sdk = { version = "22.0.0", features = ["testutils"] }
+
+[profile.release]
+opt-level = "z"
+overflow-checks = true
+debug = 0
+strip = "symbols"
+debug-assertions = false
+panic = "abort"
+codegen-units = 1
+lto = true
+
+[profile.release-with-logs]
+inherits = "release"
+debug-assertions = true

--- a/contracts/contracts/airdrop_distribution/src/errors.rs
+++ b/contracts/contracts/airdrop_distribution/src/errors.rs
@@ -1,0 +1,16 @@
+use soroban_sdk::contracterror;
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum AirdropError {
+    AlreadyInitialized = 1,
+    Unauthorized = 2,
+    CampaignNotFound = 3,
+    CampaignExpired = 4,
+    CampaignNotActive = 5,
+    AlreadyClaimed = 6,
+    InvalidMerkleProof = 7,
+    InvalidTimeRange = 8,
+    CampaignNotStarted = 9,
+}

--- a/contracts/contracts/airdrop_distribution/src/events.rs
+++ b/contracts/contracts/airdrop_distribution/src/events.rs
@@ -1,0 +1,22 @@
+use soroban_sdk::{symbol_short, Address, BytesN, Env};
+
+pub fn emit_campaign_created(env: &Env, campaign_id: &BytesN<32>, token: &Address, total_amount: i128) {
+    env.events().publish(
+        (symbol_short!("camp_crt"), campaign_id.clone()),
+        (token.clone(), total_amount),
+    );
+}
+
+pub fn emit_claimed(env: &Env, campaign_id: &BytesN<32>, claimer: &Address, amount: i128) {
+    env.events().publish(
+        (symbol_short!("claimed"), campaign_id.clone()),
+        (claimer.clone(), amount),
+    );
+}
+
+pub fn emit_campaign_cancelled(env: &Env, campaign_id: &BytesN<32>, returned: i128) {
+    env.events().publish(
+        (symbol_short!("camp_cnl"), campaign_id.clone()),
+        returned,
+    );
+}

--- a/contracts/contracts/airdrop_distribution/src/lib.rs
+++ b/contracts/contracts/airdrop_distribution/src/lib.rs
@@ -1,0 +1,204 @@
+#![no_std]
+
+mod errors;
+mod events;
+mod types;
+
+#[cfg(test)]
+mod test;
+
+use errors::AirdropError;
+use soroban_sdk::{
+    contract, contractimpl,
+    token::Client as TokenClient,
+    Address, Bytes, BytesN, Env, Vec,
+};
+use types::{CampaignRecord, DataKey, RECORD_TTL};
+
+fn get_admin(env: &Env) -> Result<Address, AirdropError> {
+    env.storage()
+        .instance()
+        .get(&DataKey::Admin)
+        .ok_or(AirdropError::Unauthorized)
+}
+
+fn load_campaign(env: &Env, id: &BytesN<32>) -> Result<CampaignRecord, AirdropError> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::Campaign(id.clone()))
+        .ok_or(AirdropError::CampaignNotFound)
+}
+
+fn save_campaign(env: &Env, id: &BytesN<32>, record: &CampaignRecord) {
+    env.storage()
+        .persistent()
+        .set(&DataKey::Campaign(id.clone()), record);
+    env.storage()
+        .persistent()
+        .extend_ttl(&DataKey::Campaign(id.clone()), RECORD_TTL, RECORD_TTL);
+}
+
+/// Compute SHA-256 of two 32-byte nodes (sorted) for Merkle tree.
+fn hash_pair(env: &Env, a: &BytesN<32>, b: &BytesN<32>) -> BytesN<32> {
+    let (lo, hi) = if a.to_array() <= b.to_array() { (a, b) } else { (b, a) };
+    let mut buf = Bytes::new(env);
+    buf.append(&Bytes::from_array(env, &lo.to_array()));
+    buf.append(&Bytes::from_array(env, &hi.to_array()));
+    env.crypto().sha256(&buf)
+}
+
+pub fn verify_merkle_proof(
+    env: &Env,
+    proof: &Vec<BytesN<32>>,
+    root: &BytesN<32>,
+    leaf: &BytesN<32>,
+) -> bool {
+    let mut current = leaf.clone();
+    for node in proof.iter() {
+        current = hash_pair(env, &current, &node);
+    }
+    &current == root
+}
+
+#[contract]
+pub struct AirdropContract;
+
+#[contractimpl]
+impl AirdropContract {
+    pub fn initialize(env: Env, admin: Address) -> Result<(), AirdropError> {
+        if env.storage().instance().has(&DataKey::Admin) {
+            return Err(AirdropError::AlreadyInitialized);
+        }
+        env.storage().instance().set(&DataKey::Admin, &admin);
+        Ok(())
+    }
+
+    pub fn create_campaign(
+        env: Env,
+        token: Address,
+        total_amount: i128,
+        merkle_root: BytesN<32>,
+        start: u64,
+        end: u64,
+    ) -> Result<BytesN<32>, AirdropError> {
+        let admin = get_admin(&env)?;
+        admin.require_auth();
+
+        if end <= start {
+            return Err(AirdropError::InvalidTimeRange);
+        }
+
+        // Transfer tokens from admin to contract
+        TokenClient::new(&env, &token).transfer(&admin, &env.current_contract_address(), &total_amount);
+
+        // Derive campaign id from merkle root + start + end
+        let mut id_bytes = Bytes::new(&env);
+        id_bytes.append(&Bytes::from_array(&env, &merkle_root.to_array()));
+        id_bytes.append(&Bytes::from_array(&env, &start.to_be_bytes()));
+        id_bytes.append(&Bytes::from_array(&env, &end.to_be_bytes()));
+        let campaign_id = env.crypto().sha256(&id_bytes);
+
+        let record = CampaignRecord {
+            token: token.clone(),
+            total_amount,
+            claimed_amount: 0,
+            merkle_root,
+            start,
+            end,
+            is_active: true,
+        };
+        save_campaign(&env, &campaign_id, &record);
+
+        events::emit_campaign_created(&env, &campaign_id, &token, total_amount);
+        Ok(campaign_id)
+    }
+
+    pub fn claim(
+        env: Env,
+        claimer: Address,
+        campaign_id: BytesN<32>,
+        amount: i128,
+        merkle_proof: Vec<BytesN<32>>,
+    ) -> Result<(), AirdropError> {
+        claimer.require_auth();
+
+        let mut campaign = load_campaign(&env, &campaign_id)?;
+
+        if !campaign.is_active {
+            return Err(AirdropError::CampaignNotActive);
+        }
+        let now = env.ledger().timestamp();
+        if now < campaign.start {
+            return Err(AirdropError::CampaignNotStarted);
+        }
+        if now > campaign.end {
+            return Err(AirdropError::CampaignExpired);
+        }
+
+        let claimed_key = DataKey::Claimed(campaign_id.clone(), claimer.clone());
+        if env.storage().persistent().has(&claimed_key) {
+            return Err(AirdropError::AlreadyClaimed);
+        }
+
+        // Build leaf: sha256(claimer_bytes || amount_bytes)
+        let claimer_bytes = claimer.to_xdr(&env);
+        let mut leaf_input = Bytes::new(&env);
+        leaf_input.append(&claimer_bytes);
+        leaf_input.append(&Bytes::from_array(&env, &amount.to_be_bytes()));
+        let leaf = env.crypto().sha256(&leaf_input);
+
+        if !verify_merkle_proof(&env, &merkle_proof, &campaign.merkle_root, &leaf) {
+            return Err(AirdropError::InvalidMerkleProof);
+        }
+
+        env.storage().persistent().set(&claimed_key, &true);
+        env.storage().persistent().extend_ttl(&claimed_key, RECORD_TTL, RECORD_TTL);
+
+        campaign.claimed_amount += amount;
+        save_campaign(&env, &campaign_id, &campaign);
+
+        TokenClient::new(&env, &campaign.token).transfer(
+            &env.current_contract_address(),
+            &claimer,
+            &amount,
+        );
+
+        events::emit_claimed(&env, &campaign_id, &claimer, amount);
+        Ok(())
+    }
+
+    pub fn cancel_campaign(env: Env, campaign_id: BytesN<32>) -> Result<(), AirdropError> {
+        let admin = get_admin(&env)?;
+        admin.require_auth();
+
+        let mut campaign = load_campaign(&env, &campaign_id)?;
+        if !campaign.is_active {
+            return Err(AirdropError::CampaignNotActive);
+        }
+
+        let unclaimed = campaign.total_amount - campaign.claimed_amount;
+        campaign.is_active = false;
+        save_campaign(&env, &campaign_id, &campaign);
+
+        if unclaimed > 0 {
+            TokenClient::new(&env, &campaign.token).transfer(
+                &env.current_contract_address(),
+                &admin,
+                &unclaimed,
+            );
+        }
+
+        events::emit_campaign_cancelled(&env, &campaign_id, unclaimed);
+        Ok(())
+    }
+
+    pub fn get_campaign(env: Env, campaign_id: BytesN<32>) -> Result<CampaignRecord, AirdropError> {
+        load_campaign(&env, &campaign_id)
+    }
+
+    pub fn has_claimed(env: Env, campaign_id: BytesN<32>, address: Address) -> bool {
+        env.storage()
+            .persistent()
+            .has(&DataKey::Claimed(campaign_id, address))
+    }
+}

--- a/contracts/contracts/airdrop_distribution/src/test.rs
+++ b/contracts/contracts/airdrop_distribution/src/test.rs
@@ -1,0 +1,125 @@
+#![cfg(test)]
+
+use super::*;
+use soroban_sdk::{
+    testutils::{Address as _, Ledger},
+    token::{Client as TokenClient, StellarAssetClient},
+    Address, BytesN, Env, Vec,
+};
+
+fn setup() -> (Env, Address, Address, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let contract_id = env.register_contract(None, AirdropContract);
+    let client = AirdropContractClient::new(&env, &contract_id);
+    client.initialize(&admin);
+
+    let token_admin = Address::generate(&env);
+    let token_id = env.register_stellar_asset_contract_v2(token_admin.clone()).address();
+    StellarAssetClient::new(&env, &token_id).mint(&admin, &1_000_000);
+
+    (env, contract_id, admin, token_id)
+}
+
+fn make_leaf(env: &Env, claimer: &Address, amount: i128) -> BytesN<32> {
+    use soroban_sdk::Bytes;
+    let claimer_bytes = claimer.to_xdr(env);
+    let mut leaf_input = Bytes::new(env);
+    leaf_input.append(&claimer_bytes);
+    leaf_input.append(&Bytes::from_array(env, &amount.to_be_bytes()));
+    env.crypto().sha256(&leaf_input)
+}
+
+#[test]
+fn test_create_and_claim() {
+    let (env, contract_id, admin, token_id) = setup();
+    let client = AirdropContractClient::new(&env, &contract_id);
+
+    let claimer = Address::generate(&env);
+    let amount: i128 = 100;
+
+    // Single-leaf merkle: root == leaf
+    let leaf = make_leaf(&env, &claimer, amount);
+    let proof: Vec<BytesN<32>> = Vec::new(&env);
+
+    env.ledger().set_timestamp(1000);
+    let campaign_id = client.create_campaign(&token_id, &1000, &leaf, &500u64, &2000u64);
+
+    env.ledger().set_timestamp(1000);
+    client.claim(&claimer, &campaign_id, &amount, &proof);
+
+    assert!(client.has_claimed(&campaign_id, &claimer));
+    let record = client.get_campaign(&campaign_id);
+    assert_eq!(record.claimed_amount, amount);
+}
+
+#[test]
+#[should_panic(expected = "AlreadyClaimed")]
+fn test_double_claim_rejected() {
+    let (env, contract_id, admin, token_id) = setup();
+    let client = AirdropContractClient::new(&env, &contract_id);
+
+    let claimer = Address::generate(&env);
+    let amount: i128 = 100;
+    let leaf = make_leaf(&env, &claimer, amount);
+    let proof: Vec<BytesN<32>> = Vec::new(&env);
+
+    env.ledger().set_timestamp(1000);
+    let campaign_id = client.create_campaign(&token_id, &1000, &leaf, &500u64, &2000u64);
+
+    client.claim(&claimer, &campaign_id, &amount, &proof);
+    client.claim(&claimer, &campaign_id, &amount, &proof); // should panic
+}
+
+#[test]
+#[should_panic(expected = "CampaignExpired")]
+fn test_expired_campaign_cannot_claim() {
+    let (env, contract_id, admin, token_id) = setup();
+    let client = AirdropContractClient::new(&env, &contract_id);
+
+    let claimer = Address::generate(&env);
+    let amount: i128 = 100;
+    let leaf = make_leaf(&env, &claimer, amount);
+    let proof: Vec<BytesN<32>> = Vec::new(&env);
+
+    env.ledger().set_timestamp(500);
+    let campaign_id = client.create_campaign(&token_id, &1000, &leaf, &100u64, &600u64);
+
+    env.ledger().set_timestamp(700); // after end
+    client.claim(&claimer, &campaign_id, &amount, &proof);
+}
+
+#[test]
+fn test_cancel_returns_unclaimed() {
+    let (env, contract_id, admin, token_id) = setup();
+    let client = AirdropContractClient::new(&env, &contract_id);
+
+    let leaf = BytesN::from_array(&env, &[1u8; 32]);
+    env.ledger().set_timestamp(500);
+    let campaign_id = client.create_campaign(&token_id, &1000, &leaf, &100u64, &2000u64);
+
+    let balance_before = TokenClient::new(&env, &token_id).balance(&admin);
+    client.cancel_campaign(&campaign_id);
+    let balance_after = TokenClient::new(&env, &token_id).balance(&admin);
+    assert_eq!(balance_after - balance_before, 1000);
+
+    let record = client.get_campaign(&campaign_id);
+    assert!(!record.is_active);
+}
+
+#[test]
+#[should_panic(expected = "InvalidMerkleProof")]
+fn test_invalid_proof_rejected() {
+    let (env, contract_id, admin, token_id) = setup();
+    let client = AirdropContractClient::new(&env, &contract_id);
+
+    let claimer = Address::generate(&env);
+    let leaf = BytesN::from_array(&env, &[1u8; 32]);
+    let proof: Vec<BytesN<32>> = Vec::new(&env);
+
+    env.ledger().set_timestamp(500);
+    let campaign_id = client.create_campaign(&token_id, &1000, &leaf, &100u64, &2000u64);
+
+    client.claim(&claimer, &campaign_id, &100, &proof);
+}

--- a/contracts/contracts/airdrop_distribution/src/types.rs
+++ b/contracts/contracts/airdrop_distribution/src/types.rs
@@ -1,0 +1,23 @@
+use soroban_sdk::{contracttype, Address, BytesN};
+
+pub const RECORD_TTL: u32 = 3_110_400; // ~180 days
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CampaignRecord {
+    pub token: Address,
+    pub total_amount: i128,
+    pub claimed_amount: i128,
+    pub merkle_root: BytesN<32>,
+    pub start: u64,
+    pub end: u64,
+    pub is_active: bool,
+}
+
+#[contracttype]
+#[derive(Clone)]
+pub enum DataKey {
+    Admin,
+    Campaign(BytesN<32>),
+    Claimed(BytesN<32>, Address), // (campaign_id, claimer)
+}


### PR DESCRIPTION
## Summary
Implements the Soroban airdrop and reward distribution contract for Gasless Gossip.

## Changes
- `AirdropCampaign` and `ClaimRecord` storage structures
- `create_campaign(token, total_amount, merkle_root, start, end)` — admin creates campaign, transfers tokens to contract
- `claim(claimer, campaign_id, amount, merkle_proof)` — user claims with merkle proof verification
- `cancel_campaign(campaign_id)` — admin cancels and recovers unclaimed funds
- `get_campaign` and `has_claimed` view functions
- Double-claim prevention via on-chain tracking
- Events emitted for campaign creation, claims, and cancellation
- Unit tests: happy path, double-claim rejection, expiry enforcement, cancellation, invalid proof

## Acceptance Criteria Met
- ✅ Merkle proof verification prevents unauthorized claims
- ✅ Double claims rejected with `AlreadyClaimed` error
- ✅ Expired campaigns cannot be claimed
- ✅ Unclaimed funds returnable to admin on cancellation
- ✅ Events emitted for all campaign state changes

Closes #564