### PR TITLE
[Soroban] Escrow & Conditional Payment Contract

### DIFF
--- a/contracts/contracts/escrow_payment/Cargo.toml
+++ b/contracts/contracts/escrow_payment/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "escrow_payment"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"
+
+[dev-dependencies]
+soroban-sdk = { version = "22.0.0", features = ["testutils"] }
+
+[profile.release]
+opt-level = "z"
+overflow-checks = true
+debug = 0
+strip = "symbols"
+debug-assertions = false
+panic = "abort"
+codegen-units = 1
+lto = true
+
+[profile.release-with-logs]
+inherits = "release"
+debug-assertions = true

--- a/contracts/contracts/escrow_payment/src/errors.rs
+++ b/contracts/contracts/escrow_payment/src/errors.rs
@@ -1,0 +1,15 @@
+use soroban_sdk::contracterror;
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum EscrowError {
+    AlreadyInitialized = 1,
+    Unauthorized = 2,
+    EscrowNotFound = 3,
+    EscrowNotActive = 4,
+    TimeoutNotReached = 5,
+    InvalidCondition = 6,
+    NotDisputed = 7,
+    InvalidSplit = 8,
+}

--- a/contracts/contracts/escrow_payment/src/events.rs
+++ b/contracts/contracts/escrow_payment/src/events.rs
@@ -1,0 +1,36 @@
+use soroban_sdk::{symbol_short, Address, BytesN, Env};
+
+pub fn emit_escrow_created(env: &Env, escrow_id: &BytesN<32>, sender: &Address, recipient: &Address, amount: i128) {
+    env.events().publish(
+        (symbol_short!("esc_crt"), escrow_id.clone()),
+        (sender.clone(), recipient.clone(), amount),
+    );
+}
+
+pub fn emit_escrow_released(env: &Env, escrow_id: &BytesN<32>, recipient: &Address, amount: i128) {
+    env.events().publish(
+        (symbol_short!("esc_rel"), escrow_id.clone()),
+        (recipient.clone(), amount),
+    );
+}
+
+pub fn emit_escrow_refunded(env: &Env, escrow_id: &BytesN<32>, sender: &Address, amount: i128) {
+    env.events().publish(
+        (symbol_short!("esc_ref"), escrow_id.clone()),
+        (sender.clone(), amount),
+    );
+}
+
+pub fn emit_escrow_disputed(env: &Env, escrow_id: &BytesN<32>) {
+    env.events().publish(
+        (symbol_short!("esc_dis"), escrow_id.clone()),
+        (),
+    );
+}
+
+pub fn emit_dispute_resolved(env: &Env, escrow_id: &BytesN<32>, recipient_share: i128, sender_share: i128) {
+    env.events().publish(
+        (symbol_short!("dis_res"), escrow_id.clone()),
+        (recipient_share, sender_share),
+    );
+}

--- a/contracts/contracts/escrow_payment/src/lib.rs
+++ b/contracts/contracts/escrow_payment/src/lib.rs
@@ -1,0 +1,194 @@
+#![no_std]
+
+mod errors;
+mod events;
+mod types;
+
+#[cfg(test)]
+mod test;
+
+use errors::EscrowError;
+use soroban_sdk::{
+    contract, contractimpl,
+    token::Client as TokenClient,
+    Address, Bytes, BytesN, Env,
+};
+use types::{DataKey, EscrowRecord, EscrowStatus, RECORD_TTL};
+
+fn get_admin(env: &Env) -> Result<Address, EscrowError> {
+    env.storage()
+        .instance()
+        .get(&DataKey::Admin)
+        .ok_or(EscrowError::Unauthorized)
+}
+
+fn load_escrow(env: &Env, id: &BytesN<32>) -> Result<EscrowRecord, EscrowError> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::Escrow(id.clone()))
+        .ok_or(EscrowError::EscrowNotFound)
+}
+
+fn save_escrow(env: &Env, id: &BytesN<32>, record: &EscrowRecord) {
+    env.storage()
+        .persistent()
+        .set(&DataKey::Escrow(id.clone()), record);
+    env.storage()
+        .persistent()
+        .extend_ttl(&DataKey::Escrow(id.clone()), RECORD_TTL, RECORD_TTL);
+}
+
+fn derive_escrow_id(env: &Env, sender: &Address, recipient: &Address, amount: i128, expires_at: u64) -> BytesN<32> {
+    let mut buf = Bytes::new(env);
+    buf.append(&sender.to_xdr(env));
+    buf.append(&recipient.to_xdr(env));
+    buf.append(&Bytes::from_array(env, &amount.to_be_bytes()));
+    buf.append(&Bytes::from_array(env, &expires_at.to_be_bytes()));
+    buf.append(&Bytes::from_array(env, &env.ledger().timestamp().to_be_bytes()));
+    env.crypto().sha256(&buf)
+}
+
+#[contract]
+pub struct EscrowContract;
+
+#[contractimpl]
+impl EscrowContract {
+    pub fn initialize(env: Env, admin: Address) -> Result<(), EscrowError> {
+        if env.storage().instance().has(&DataKey::Admin) {
+            return Err(EscrowError::AlreadyInitialized);
+        }
+        env.storage().instance().set(&DataKey::Admin, &admin);
+        Ok(())
+    }
+
+    pub fn create_escrow(
+        env: Env,
+        sender: Address,
+        recipient: Address,
+        token: Address,
+        amount: i128,
+        condition_hash: BytesN<32>,
+        timeout: u64,
+    ) -> Result<BytesN<32>, EscrowError> {
+        sender.require_auth();
+        let expires_at = env.ledger().timestamp() + timeout;
+        let escrow_id = derive_escrow_id(&env, &sender, &recipient, amount, expires_at);
+
+        TokenClient::new(&env, &token).transfer(&sender, &env.current_contract_address(), &amount);
+
+        let record = EscrowRecord {
+            sender: sender.clone(),
+            recipient: recipient.clone(),
+            token,
+            amount,
+            condition_hash,
+            expires_at,
+            status: EscrowStatus::Active,
+        };
+        save_escrow(&env, &escrow_id, &record);
+        events::emit_escrow_created(&env, &escrow_id, &sender, &recipient, amount);
+        Ok(escrow_id)
+    }
+
+    pub fn release_escrow(
+        env: Env,
+        escrow_id: BytesN<32>,
+        condition_preimage: Bytes,
+    ) -> Result<(), EscrowError> {
+        let mut record = load_escrow(&env, &escrow_id)?;
+        if record.status != EscrowStatus::Active {
+            return Err(EscrowError::EscrowNotActive);
+        }
+        record.recipient.require_auth();
+
+        let hash = env.crypto().sha256(&condition_preimage);
+        if hash != record.condition_hash {
+            return Err(EscrowError::InvalidCondition);
+        }
+
+        record.status = EscrowStatus::Released;
+        let recipient = record.recipient.clone();
+        let amount = record.amount;
+        let token = record.token.clone();
+        save_escrow(&env, &escrow_id, &record);
+
+        TokenClient::new(&env, &token).transfer(&env.current_contract_address(), &recipient, &amount);
+        events::emit_escrow_released(&env, &escrow_id, &recipient, amount);
+        Ok(())
+    }
+
+    pub fn refund_escrow(env: Env, escrow_id: BytesN<32>) -> Result<(), EscrowError> {
+        let mut record = load_escrow(&env, &escrow_id)?;
+        if record.status != EscrowStatus::Active {
+            return Err(EscrowError::EscrowNotActive);
+        }
+        if env.ledger().timestamp() <= record.expires_at {
+            return Err(EscrowError::TimeoutNotReached);
+        }
+        record.sender.require_auth();
+
+        record.status = EscrowStatus::Refunded;
+        let sender = record.sender.clone();
+        let amount = record.amount;
+        let token = record.token.clone();
+        save_escrow(&env, &escrow_id, &record);
+
+        TokenClient::new(&env, &token).transfer(&env.current_contract_address(), &sender, &amount);
+        events::emit_escrow_refunded(&env, &escrow_id, &sender, amount);
+        Ok(())
+    }
+
+    pub fn dispute_escrow(env: Env, disputer: Address, escrow_id: BytesN<32>) -> Result<(), EscrowError> {
+        let mut record = load_escrow(&env, &escrow_id)?;
+        if record.status != EscrowStatus::Active {
+            return Err(EscrowError::EscrowNotActive);
+        }
+        // Either sender or recipient can dispute
+        disputer.require_auth();
+        if disputer != record.sender && disputer != record.recipient {
+            return Err(EscrowError::Unauthorized);
+        }
+        record.status = EscrowStatus::Disputed;
+        save_escrow(&env, &escrow_id, &record);
+        events::emit_escrow_disputed(&env, &escrow_id);
+        Ok(())
+    }
+
+    pub fn resolve_dispute(
+        env: Env,
+        escrow_id: BytesN<32>,
+        recipient_share: i128,
+    ) -> Result<(), EscrowError> {
+        let admin = get_admin(&env)?;
+        admin.require_auth();
+
+        let mut record = load_escrow(&env, &escrow_id)?;
+        if record.status != EscrowStatus::Disputed {
+            return Err(EscrowError::NotDisputed);
+        }
+        if recipient_share > record.amount {
+            return Err(EscrowError::InvalidSplit);
+        }
+
+        let sender_share = record.amount - recipient_share;
+        let token = record.token.clone();
+        let recipient = record.recipient.clone();
+        let sender = record.sender.clone();
+        record.status = EscrowStatus::Released;
+        save_escrow(&env, &escrow_id, &record);
+
+        let contract = env.current_contract_address();
+        if recipient_share > 0 {
+            TokenClient::new(&env, &token).transfer(&contract, &recipient, &recipient_share);
+        }
+        if sender_share > 0 {
+            TokenClient::new(&env, &token).transfer(&contract, &sender, &sender_share);
+        }
+        events::emit_dispute_resolved(&env, &escrow_id, recipient_share, sender_share);
+        Ok(())
+    }
+
+    pub fn get_escrow(env: Env, escrow_id: BytesN<32>) -> Result<EscrowRecord, EscrowError> {
+        load_escrow(&env, &escrow_id)
+    }
+}

--- a/contracts/contracts/escrow_payment/src/test.rs
+++ b/contracts/contracts/escrow_payment/src/test.rs
@@ -1,0 +1,110 @@
+#![cfg(test)]
+
+use super::*;
+use soroban_sdk::{
+    testutils::{Address as _, Ledger},
+    token::{Client as TokenClient, StellarAssetClient},
+    Address, Bytes, BytesN, Env,
+};
+
+fn setup() -> (Env, Address, Address, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let contract_id = env.register_contract(None, EscrowContract);
+    EscrowContractClient::new(&env, &contract_id).initialize(&admin);
+
+    let token_admin = Address::generate(&env);
+    let token_id = env.register_stellar_asset_contract_v2(token_admin.clone()).address();
+    (env, contract_id, admin, token_id)
+}
+
+fn make_condition(env: &Env, preimage: &[u8]) -> (Bytes, BytesN<32>) {
+    let b = Bytes::from_slice(env, preimage);
+    let h = env.crypto().sha256(&b);
+    (b, h)
+}
+
+#[test]
+fn test_create_and_release() {
+    let (env, contract_id, _admin, token_id) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+    let sender = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    StellarAssetClient::new(&env, &token_id).mint(&sender, &500);
+
+    let (preimage, hash) = make_condition(&env, b"secret");
+    env.ledger().set_timestamp(1000);
+    let eid = client.create_escrow(&sender, &recipient, &token_id, &500, &hash, &3600u64);
+
+    client.release_escrow(&eid, &preimage);
+    assert_eq!(TokenClient::new(&env, &token_id).balance(&recipient), 500);
+}
+
+#[test]
+#[should_panic(expected = "TimeoutNotReached")]
+fn test_refund_before_timeout_fails() {
+    let (env, contract_id, _admin, token_id) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+    let sender = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    StellarAssetClient::new(&env, &token_id).mint(&sender, &500);
+
+    let (_, hash) = make_condition(&env, b"secret");
+    env.ledger().set_timestamp(1000);
+    let eid = client.create_escrow(&sender, &recipient, &token_id, &500, &hash, &3600u64);
+    client.refund_escrow(&eid);
+}
+
+#[test]
+fn test_refund_after_timeout() {
+    let (env, contract_id, _admin, token_id) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+    let sender = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    StellarAssetClient::new(&env, &token_id).mint(&sender, &500);
+
+    let (_, hash) = make_condition(&env, b"secret");
+    env.ledger().set_timestamp(1000);
+    let eid = client.create_escrow(&sender, &recipient, &token_id, &500, &hash, &3600u64);
+
+    env.ledger().set_timestamp(5000); // past timeout
+    client.refund_escrow(&eid);
+    assert_eq!(TokenClient::new(&env, &token_id).balance(&sender), 500);
+}
+
+#[test]
+fn test_dispute_and_resolve() {
+    let (env, contract_id, admin, token_id) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+    let sender = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    StellarAssetClient::new(&env, &token_id).mint(&sender, &500);
+
+    let (_, hash) = make_condition(&env, b"secret");
+    env.ledger().set_timestamp(1000);
+    let eid = client.create_escrow(&sender, &recipient, &token_id, &500, &hash, &3600u64);
+
+    client.dispute_escrow(&sender, &eid);
+    client.resolve_dispute(&eid, &300);
+
+    assert_eq!(TokenClient::new(&env, &token_id).balance(&recipient), 300);
+    assert_eq!(TokenClient::new(&env, &token_id).balance(&sender), 200);
+}
+
+#[test]
+#[should_panic(expected = "InvalidCondition")]
+fn test_wrong_preimage_rejected() {
+    let (env, contract_id, _admin, token_id) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+    let sender = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    StellarAssetClient::new(&env, &token_id).mint(&sender, &500);
+
+    let (_, hash) = make_condition(&env, b"secret");
+    env.ledger().set_timestamp(1000);
+    let eid = client.create_escrow(&sender, &recipient, &token_id, &500, &hash, &3600u64);
+
+    let wrong = Bytes::from_slice(&env, b"wrong");
+    client.release_escrow(&eid, &wrong);
+}

--- a/contracts/contracts/escrow_payment/src/types.rs
+++ b/contracts/contracts/escrow_payment/src/types.rs
@@ -1,0 +1,31 @@
+use soroban_sdk::{contracttype, Address, BytesN};
+
+pub const RECORD_TTL: u32 = 3_110_400;
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum EscrowStatus {
+    Active,
+    Released,
+    Refunded,
+    Disputed,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct EscrowRecord {
+    pub sender: Address,
+    pub recipient: Address,
+    pub token: Address,
+    pub amount: i128,
+    pub condition_hash: BytesN<32>,
+    pub expires_at: u64,
+    pub status: EscrowStatus,
+}
+
+#[contracttype]
+#[derive(Clone)]
+pub enum DataKey {
+    Admin,
+    Escrow(BytesN<32>),
+}


### PR DESCRIPTION
## Summary
Implements the Soroban escrow contract for conditional payments within Gasless Gossip.

## Changes
- `EscrowRecord` storage: sender, recipient, token, amount, condition_hash, expiresAt, status (ACTIVE/RELEASED/REFUNDED/DISPUTED)
- `create_escrow(sender, recipient, token, amount, condition_hash, timeout)` — locks funds in contract
- `release_escrow(escrow_id, condition_preimage)` — recipient reveals preimage, sha256 verified against stored hash
- `refund_escrow(escrow_id)` — sender reclaims after timeout
- `dispute_escrow(disputer, escrow_id)` — either party triggers admin arbitration
- `resolve_dispute(escrow_id, recipient_share)` — admin splits funds between parties
- `get_escrow` view function
- Events emitted for all state transitions

## Acceptance Criteria Met
- ✅ Funds locked until condition preimage revealed or timeout
- ✅ Condition verified by hashing preimage and comparing to stored hash
- ✅ Refund only available after timeout has passed
- ✅ Disputed escrows require admin resolution
- ✅ Admin can split disputed funds between parties

Closes #565