### PR TITLE
[Soroban] Decentralized Username Registry Contract

### DIFF
--- a/contracts/contracts/username_registry/Cargo.toml
+++ b/contracts/contracts/username_registry/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "username_registry"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"
+
+[dev-dependencies]
+soroban-sdk = { version = "22.0.0", features = ["testutils"] }
+
+[profile.release]
+opt-level = "z"
+overflow-checks = true
+debug = 0
+strip = "symbols"
+debug-assertions = false
+panic = "abort"
+codegen-units = 1
+lto = true
+
+[profile.release-with-logs]
+inherits = "release"
+debug-assertions = true

--- a/contracts/contracts/username_registry/src/errors.rs
+++ b/contracts/contracts/username_registry/src/errors.rs
@@ -1,0 +1,16 @@
+use soroban_sdk::contracterror;
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum RegistryError {
+    AlreadyInitialized = 1,
+    Unauthorized = 2,
+    UsernameTaken = 3,
+    UsernameNotFound = 4,
+    UsernameExpired = 5,
+    InGracePeriod = 6,
+    InvalidUsername = 7,
+    NotOwner = 8,
+    NoPrimaryUsername = 9,
+}

--- a/contracts/contracts/username_registry/src/events.rs
+++ b/contracts/contracts/username_registry/src/events.rs
@@ -1,0 +1,29 @@
+use soroban_sdk::{symbol_short, Address, Env, String};
+
+pub fn emit_registered(env: &Env, username: &String, owner: &Address, expires_at: u64) {
+    env.events().publish(
+        (symbol_short!("reg"), username.clone()),
+        (owner.clone(), expires_at),
+    );
+}
+
+pub fn emit_renewed(env: &Env, username: &String, owner: &Address, new_expires: u64) {
+    env.events().publish(
+        (symbol_short!("renewed"), username.clone()),
+        (owner.clone(), new_expires),
+    );
+}
+
+pub fn emit_transferred(env: &Env, username: &String, from: &Address, to: &Address) {
+    env.events().publish(
+        (symbol_short!("xfer"), username.clone()),
+        (from.clone(), to.clone()),
+    );
+}
+
+pub fn emit_released(env: &Env, username: &String, owner: &Address) {
+    env.events().publish(
+        (symbol_short!("released"), username.clone()),
+        owner.clone(),
+    );
+}

--- a/contracts/contracts/username_registry/src/lib.rs
+++ b/contracts/contracts/username_registry/src/lib.rs
@@ -1,0 +1,247 @@
+#![no_std]
+
+mod errors;
+mod events;
+mod types;
+
+#[cfg(test)]
+mod test;
+
+use errors::RegistryError;
+use soroban_sdk::{
+    contract, contractimpl,
+    token::Client as TokenClient,
+    Address, BytesN, Env, String,
+};
+use types::{DataKey, UsernameRecord, GRACE_PERIOD, RECORD_TTL, SECS_PER_YEAR};
+
+fn get_admin(env: &Env) -> Result<Address, RegistryError> {
+    env.storage()
+        .instance()
+        .get(&DataKey::Admin)
+        .ok_or(RegistryError::Unauthorized)
+}
+
+fn get_fee_token(env: &Env) -> Address {
+    env.storage().instance().get(&DataKey::FeeToken).unwrap()
+}
+
+fn load_record(env: &Env, username: &String) -> Option<UsernameRecord> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::Username(username.clone()))
+}
+
+fn save_record(env: &Env, record: &UsernameRecord) {
+    env.storage()
+        .persistent()
+        .set(&DataKey::Username(record.username.clone()), record);
+    env.storage().persistent().extend_ttl(
+        &DataKey::Username(record.username.clone()),
+        RECORD_TTL,
+        RECORD_TTL,
+    );
+}
+
+/// Validate username: min 3 chars, alphanumeric + hyphen only. Returns length.
+fn validate_username(username: &String) -> Result<u32, RegistryError> {
+    let len = username.len();
+    if len < 3 {
+        return Err(RegistryError::InvalidUsername);
+    }
+    let mut buf = [0u8; 64];
+    let copy_len = (len as usize).min(64);
+    username.copy_into_slice(&mut buf[..copy_len]);
+    for i in 0..copy_len {
+        let c = buf[i];
+        let valid = (c >= b'0' && c <= b'9')
+            || (c >= b'A' && c <= b'Z')
+            || (c >= b'a' && c <= b'z')
+            || c == b'-';
+        if !valid {
+            return Err(RegistryError::InvalidUsername);
+        }
+    }
+    Ok(len)
+}
+
+fn is_available_at(record: &Option<UsernameRecord>, now: u64) -> bool {
+    match record {
+        None => true,
+        Some(r) => now > r.expires_at + GRACE_PERIOD,
+    }
+}
+
+#[contract]
+pub struct UsernameRegistryContract;
+
+#[contractimpl]
+impl UsernameRegistryContract {
+    pub fn initialize(env: Env, admin: Address, fee_token: Address) -> Result<(), RegistryError> {
+        if env.storage().instance().has(&DataKey::Admin) {
+            return Err(RegistryError::AlreadyInitialized);
+        }
+        env.storage().instance().set(&DataKey::Admin, &admin);
+        env.storage().instance().set(&DataKey::FeeToken, &fee_token);
+        Ok(())
+    }
+
+    pub fn register(
+        env: Env,
+        owner: Address,
+        username: String,
+        duration_years: u32,
+    ) -> Result<(), RegistryError> {
+        owner.require_auth();
+        let len = validate_username(&username)?;
+        let now = env.ledger().timestamp();
+
+        let existing = load_record(&env, &username);
+        if !is_available_at(&existing, now) {
+            return Err(RegistryError::UsernameTaken);
+        }
+        if let Some(ref r) = existing {
+            if now > r.expires_at && now <= r.expires_at + GRACE_PERIOD {
+                return Err(RegistryError::InGracePeriod);
+            }
+        }
+
+        let fee = types::registration_fee(len, duration_years);
+        let fee_token = get_fee_token(&env);
+        let admin = get_admin(&env)?;
+        TokenClient::new(&env, &fee_token).transfer(&owner, &admin, &fee);
+
+        let expires_at = now + SECS_PER_YEAR * duration_years as u64;
+        let record = UsernameRecord {
+            owner: owner.clone(),
+            username: username.clone(),
+            registered_at: now,
+            expires_at,
+            metadata_hash: None,
+            is_locked: false,
+        };
+        save_record(&env, &record);
+
+        if !env.storage().persistent().has(&DataKey::AddressToPrimary(owner.clone())) {
+            env.storage()
+                .persistent()
+                .set(&DataKey::AddressToPrimary(owner.clone()), &username);
+            env.storage().persistent().extend_ttl(
+                &DataKey::AddressToPrimary(owner.clone()),
+                RECORD_TTL,
+                RECORD_TTL,
+            );
+        }
+
+        events::emit_registered(&env, &username, &owner, expires_at);
+        Ok(())
+    }
+
+    pub fn renew(
+        env: Env,
+        owner: Address,
+        username: String,
+        duration_years: u32,
+    ) -> Result<(), RegistryError> {
+        owner.require_auth();
+        let len = validate_username(&username)?;
+        let mut record = load_record(&env, &username).ok_or(RegistryError::UsernameNotFound)?;
+
+        if record.owner != owner {
+            return Err(RegistryError::NotOwner);
+        }
+
+        let fee = types::registration_fee(len, duration_years);
+        let fee_token = get_fee_token(&env);
+        let admin = get_admin(&env)?;
+        TokenClient::new(&env, &fee_token).transfer(&owner, &admin, &fee);
+
+        record.expires_at += SECS_PER_YEAR * duration_years as u64;
+        let new_expires = record.expires_at;
+        save_record(&env, &record);
+
+        events::emit_renewed(&env, &username, &owner, new_expires);
+        Ok(())
+    }
+
+    pub fn transfer(
+        env: Env,
+        username: String,
+        new_owner: Address,
+    ) -> Result<(), RegistryError> {
+        let mut record = load_record(&env, &username).ok_or(RegistryError::UsernameNotFound)?;
+        record.owner.require_auth();
+
+        let now = env.ledger().timestamp();
+        if now > record.expires_at {
+            return Err(RegistryError::UsernameExpired);
+        }
+
+        let old_owner = record.owner.clone();
+        record.owner = new_owner.clone();
+        save_record(&env, &record);
+
+        let primary_key = DataKey::AddressToPrimary(old_owner.clone());
+        if let Some(primary) = env.storage().persistent().get::<DataKey, String>(&primary_key) {
+            if primary == username {
+                env.storage().persistent().remove(&primary_key);
+            }
+        }
+
+        events::emit_transferred(&env, &username, &old_owner, &new_owner);
+        Ok(())
+    }
+
+    pub fn release(env: Env, username: String) -> Result<(), RegistryError> {
+        let record = load_record(&env, &username).ok_or(RegistryError::UsernameNotFound)?;
+        record.owner.require_auth();
+
+        let owner = record.owner.clone();
+        env.storage()
+            .persistent()
+            .remove(&DataKey::Username(username.clone()));
+
+        let primary_key = DataKey::AddressToPrimary(owner.clone());
+        if let Some(primary) = env.storage().persistent().get::<DataKey, String>(&primary_key) {
+            if primary == username {
+                env.storage().persistent().remove(&primary_key);
+            }
+        }
+
+        events::emit_released(&env, &username, &owner);
+        Ok(())
+    }
+
+    pub fn resolve(env: Env, username: String) -> Result<Address, RegistryError> {
+        let record = load_record(&env, &username).ok_or(RegistryError::UsernameNotFound)?;
+        let now = env.ledger().timestamp();
+        if now > record.expires_at {
+            return Err(RegistryError::UsernameExpired);
+        }
+        Ok(record.owner)
+    }
+
+    pub fn reverse_resolve(env: Env, address: Address) -> Result<String, RegistryError> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::AddressToPrimary(address))
+            .ok_or(RegistryError::NoPrimaryUsername)
+    }
+
+    pub fn is_available(env: Env, username: String) -> bool {
+        let now = env.ledger().timestamp();
+        is_available_at(&load_record(&env, &username), now)
+    }
+
+    pub fn set_metadata(
+        env: Env,
+        username: String,
+        metadata_hash: BytesN<32>,
+    ) -> Result<(), RegistryError> {
+        let mut record = load_record(&env, &username).ok_or(RegistryError::UsernameNotFound)?;
+        record.owner.require_auth();
+        record.metadata_hash = Some(metadata_hash);
+        save_record(&env, &record);
+        Ok(())
+    }
+}

--- a/contracts/contracts/username_registry/src/test.rs
+++ b/contracts/contracts/username_registry/src/test.rs
@@ -1,0 +1,134 @@
+#![cfg(test)]
+
+use super::*;
+use soroban_sdk::{
+    testutils::{Address as _, Ledger},
+    token::StellarAssetClient,
+    Address, Env, String,
+};
+
+fn setup() -> (Env, Address, Address, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let contract_id = env.register_contract(None, UsernameRegistryContract);
+
+    let token_admin = Address::generate(&env);
+    let fee_token = env.register_stellar_asset_contract_v2(token_admin.clone()).address();
+
+    UsernameRegistryContractClient::new(&env, &contract_id).initialize(&admin, &fee_token);
+    (env, contract_id, admin, fee_token)
+}
+
+fn fund(env: &Env, token: &Address, user: &Address) {
+    StellarAssetClient::new(env, token).mint(user, &1_000_000_000);
+}
+
+#[test]
+fn test_register_and_resolve() {
+    let (env, contract_id, _admin, fee_token) = setup();
+    let client = UsernameRegistryContractClient::new(&env, &contract_id);
+    let owner = Address::generate(&env);
+    fund(&env, &fee_token, &owner);
+
+    env.ledger().set_timestamp(1000);
+    let name = String::from_str(&env, "alice");
+    client.register(&owner, &name, &1u32);
+
+    let resolved = client.resolve(&name);
+    assert_eq!(resolved, owner);
+}
+
+#[test]
+fn test_reverse_resolve() {
+    let (env, contract_id, _admin, fee_token) = setup();
+    let client = UsernameRegistryContractClient::new(&env, &contract_id);
+    let owner = Address::generate(&env);
+    fund(&env, &fee_token, &owner);
+
+    env.ledger().set_timestamp(1000);
+    let name = String::from_str(&env, "alice");
+    client.register(&owner, &name, &1u32);
+
+    let primary = client.reverse_resolve(&owner);
+    assert_eq!(primary, name);
+}
+
+#[test]
+#[should_panic(expected = "UsernameTaken")]
+fn test_duplicate_registration_fails() {
+    let (env, contract_id, _admin, fee_token) = setup();
+    let client = UsernameRegistryContractClient::new(&env, &contract_id);
+    let owner = Address::generate(&env);
+    let owner2 = Address::generate(&env);
+    fund(&env, &fee_token, &owner);
+    fund(&env, &fee_token, &owner2);
+
+    env.ledger().set_timestamp(1000);
+    let name = String::from_str(&env, "alice");
+    client.register(&owner, &name, &1u32);
+    client.register(&owner2, &name, &1u32);
+}
+
+#[test]
+fn test_transfer() {
+    let (env, contract_id, _admin, fee_token) = setup();
+    let client = UsernameRegistryContractClient::new(&env, &contract_id);
+    let owner = Address::generate(&env);
+    let new_owner = Address::generate(&env);
+    fund(&env, &fee_token, &owner);
+
+    env.ledger().set_timestamp(1000);
+    let name = String::from_str(&env, "alice");
+    client.register(&owner, &name, &1u32);
+    client.transfer(&name, &new_owner);
+
+    let resolved = client.resolve(&name);
+    assert_eq!(resolved, new_owner);
+}
+
+#[test]
+fn test_is_available_after_grace_period() {
+    let (env, contract_id, _admin, fee_token) = setup();
+    let client = UsernameRegistryContractClient::new(&env, &contract_id);
+    let owner = Address::generate(&env);
+    fund(&env, &fee_token, &owner);
+
+    env.ledger().set_timestamp(1000);
+    let name = String::from_str(&env, "alice");
+    client.register(&owner, &name, &1u32);
+
+    let expiry = 1000 + types::SECS_PER_YEAR;
+    env.ledger().set_timestamp(expiry + types::GRACE_PERIOD + 1);
+    assert!(client.is_available(&name));
+}
+
+#[test]
+#[should_panic(expected = "InvalidUsername")]
+fn test_short_username_rejected() {
+    let (env, contract_id, _admin, fee_token) = setup();
+    let client = UsernameRegistryContractClient::new(&env, &contract_id);
+    let owner = Address::generate(&env);
+    fund(&env, &fee_token, &owner);
+
+    env.ledger().set_timestamp(1000);
+    let name = String::from_str(&env, "ab"); // 2 chars, too short
+    client.register(&owner, &name, &1u32);
+}
+
+#[test]
+fn test_release() {
+    let (env, contract_id, _admin, fee_token) = setup();
+    let client = UsernameRegistryContractClient::new(&env, &contract_id);
+    let owner = Address::generate(&env);
+    fund(&env, &fee_token, &owner);
+
+    env.ledger().set_timestamp(1000);
+    let name = String::from_str(&env, "alice");
+    client.register(&owner, &name, &1u32);
+    client.release(&name);
+
+    env.ledger().set_timestamp(1000 + types::GRACE_PERIOD + 1);
+    assert!(client.is_available(&name));
+}

--- a/contracts/contracts/username_registry/src/types.rs
+++ b/contracts/contracts/username_registry/src/types.rs
@@ -1,0 +1,39 @@
+use soroban_sdk::{contracttype, Address, BytesN, String};
+
+pub const RECORD_TTL: u32 = 3_110_400;
+pub const SECS_PER_YEAR: u64 = 365 * 24 * 3600;
+pub const GRACE_PERIOD: u64 = 30 * 24 * 3600; // 30 days
+
+/// Base fee per year in stroops
+pub const BASE_FEE_PER_YEAR: i128 = 1_000_000;
+/// Premium fee for short names (3-5 chars)
+pub const PREMIUM_FEE_PER_YEAR: i128 = 5_000_000;
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct UsernameRecord {
+    pub owner: Address,
+    pub username: String,
+    pub registered_at: u64,
+    pub expires_at: u64,
+    pub metadata_hash: Option<BytesN<32>>,
+    pub is_locked: bool,
+}
+
+#[contracttype]
+#[derive(Clone)]
+pub enum DataKey {
+    Admin,
+    FeeToken,
+    Username(String),           // username → UsernameRecord
+    AddressToPrimary(Address),  // address → primary username
+}
+
+pub fn registration_fee(username_len: u32, duration_years: u32) -> i128 {
+    let per_year = if username_len <= 5 {
+        PREMIUM_FEE_PER_YEAR
+    } else {
+        BASE_FEE_PER_YEAR
+    };
+    per_year * duration_years as i128
+}


### PR DESCRIPTION
## Summary
Implements the Soroban on-chain username registry contract providing decentralized, censorship-resistant username ownership.

## Changes
- `UsernameRecord` storage: owner, username, registeredAt, expiresAt, metadataHash, isLocked
- `register(owner, username, duration_years)` — paid registration, validates min 3 chars + alphanumeric+hyphen
- `renew(owner, username, duration_years)` — extends expiry
- `transfer(username, new_owner)` — transfers ownership, requires current owner auth
- `release(username)` — owner releases username
- `resolve(username)` — returns owner address
- `reverse_resolve(address)` — returns primary username for an address
- `is_available(username)` — respects 30-day grace period after expiry
- `set_metadata(username, metadata_hash)` — owner sets metadata hash
- Short usernames (3-5 chars) priced at 5x premium rate
- Events emitted for register, renew, transfer, release

## Acceptance Criteria Met
- ✅ Username registration requires payment (fee in XLM)
- ✅ Expired usernames enter 30-day grace period before becoming available
- ✅ Transfer requires current owner signature
- ✅ Reverse resolution returns primary username for an address
- ✅ Short usernames (3-5 chars) priced at premium rate

Closes #592