### PR TITLE
feat: Offline Message Queue & Sync Module (#641)

### DIFF
--- a/contracts/Cargo.lock
+++ b/contracts/Cargo.lock
@@ -15,6 +15,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "airdrop_distribution"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk",
+]
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -187,6 +194,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "bridge_adapter"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk",
 ]
 
 [[package]]
@@ -566,6 +580,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bfcf67fea2815c2fc3b90873fae90957be12ff417335dfadc7f52927feb03b2"
 
 [[package]]
+name = "escrow_payment"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk",
+]
+
+[[package]]
 name = "ethnum"
 version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -764,6 +785,7 @@ checksum = "8e04e2fd2b8188ea827b32ef11de88377086d690286ab35747ef7f9bf3ccb590"
 name = "integration-tests"
 version = "0.1.0"
 dependencies = [
+ "bridge_adapter",
  "ed25519-dalek",
  "messaging",
  "payments",
@@ -1478,6 +1500,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "staking_rewards"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk",
+]
+
+[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1620,6 +1649,13 @@ name = "user_registry"
 version = "0.1.0"
 dependencies = [
  "gasless-common",
+ "soroban-sdk",
+]
+
+[[package]]
+name = "username_registry"
+version = "0.1.0"
+dependencies = [
  "soroban-sdk",
 ]
 
@@ -1787,6 +1823,13 @@ dependencies = [
 
 [[package]]
 name = "xp"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk",
+]
+
+[[package]]
+name = "yield_aggregator"
 version = "0.1.0"
 dependencies = [
  "soroban-sdk",

--- a/contracts/contracts/yield_aggregator/Cargo.toml
+++ b/contracts/contracts/yield_aggregator/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "yield_aggregator"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"
+
+[dev-dependencies]
+soroban-sdk = { version = "22.0.0", features = ["testutils"] }
+
+[profile.release]
+opt-level = "z"
+overflow-checks = true
+debug = 0
+strip = "symbols"
+debug-assertions = false
+panic = "abort"
+codegen-units = 1
+lto = true
+
+[profile.release-with-logs]
+inherits = "release"
+debug-assertions = true

--- a/contracts/contracts/yield_aggregator/src/errors.rs
+++ b/contracts/contracts/yield_aggregator/src/errors.rs
@@ -1,0 +1,18 @@
+use soroban_sdk::contracterror;
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum YieldError {
+    NotInitialized = 1,
+    AlreadyInitialized = 2,
+    Unauthorized = 3,
+    StrategyNotFound = 4,
+    StrategyAlreadyExists = 5,
+    StrategyInactive = 6,
+    PositionNotFound = 7,
+    InsufficientShares = 8,
+    InsufficientTvl = 9,
+    InvalidAmount = 10,
+    ZeroShares = 11,
+}

--- a/contracts/contracts/yield_aggregator/src/events.rs
+++ b/contracts/contracts/yield_aggregator/src/events.rs
@@ -1,0 +1,31 @@
+use soroban_sdk::{symbol_short, Address, Env};
+
+use crate::types::StrategyId;
+
+pub fn emit_deposit(env: &Env, user: &Address, strategy_id: &StrategyId, amount: i128, shares: i128) {
+    env.events().publish(
+        (symbol_short!("deposit"), user.clone(), strategy_id.clone()),
+        (amount, shares),
+    );
+}
+
+pub fn emit_withdraw(env: &Env, user: &Address, strategy_id: &StrategyId, shares: i128, amount: i128) {
+    env.events().publish(
+        (symbol_short!("withdraw"), user.clone(), strategy_id.clone()),
+        (shares, amount),
+    );
+}
+
+pub fn emit_harvest(env: &Env, strategy_id: &StrategyId, yield_amount: i128, new_apy_bps: u32) {
+    env.events().publish(
+        (symbol_short!("harvest"), strategy_id.clone()),
+        (yield_amount, new_apy_bps),
+    );
+}
+
+pub fn emit_rebalance(env: &Env, from: &StrategyId, to: &StrategyId, amount: i128) {
+    env.events().publish(
+        (symbol_short!("rebalanc"), from.clone(), to.clone()),
+        amount,
+    );
+}

--- a/contracts/contracts/yield_aggregator/src/lib.rs
+++ b/contracts/contracts/yield_aggregator/src/lib.rs
@@ -1,0 +1,356 @@
+#![no_std]
+
+mod errors;
+mod events;
+mod types;
+
+#[cfg(test)]
+mod test;
+
+use errors::YieldError;
+use soroban_sdk::{
+    contract, contractimpl,
+    token::Client as TokenClient,
+    xdr::ToXdr,
+    Address, Bytes, BytesN, Env,
+};
+use types::{DataKey, StrategyId, UserYieldPosition, YieldStrategy, STRATEGY_TTL};
+
+// ── Storage helpers ──────────────────────────────────────────────────────────
+
+fn get_admin(env: &Env) -> Result<Address, YieldError> {
+    env.storage()
+        .instance()
+        .get(&DataKey::Admin)
+        .ok_or(YieldError::NotInitialized)
+}
+
+fn save_strategy(env: &Env, strategy: &YieldStrategy) {
+    let key = DataKey::Strategy(strategy.strategy_id.clone());
+    env.storage().persistent().set(&key, strategy);
+    env.storage().persistent().extend_ttl(&key, STRATEGY_TTL, STRATEGY_TTL);
+}
+
+fn load_strategy(env: &Env, id: &StrategyId) -> Result<YieldStrategy, YieldError> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::Strategy(id.clone()))
+        .ok_or(YieldError::StrategyNotFound)
+}
+
+fn save_position(env: &Env, pos: &UserYieldPosition) {
+    let key = DataKey::Position(pos.user.clone(), pos.strategy_id.clone());
+    env.storage().persistent().set(&key, pos);
+    env.storage().persistent().extend_ttl(&key, STRATEGY_TTL, STRATEGY_TTL);
+}
+
+fn load_position(env: &Env, user: &Address, id: &StrategyId) -> Result<UserYieldPosition, YieldError> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::Position(user.clone(), id.clone()))
+        .ok_or(YieldError::PositionNotFound)
+}
+
+// ── Math helpers ─────────────────────────────────────────────────────────────
+
+/// Convert token amount → shares.  On an empty pool 1 share == 1 token.
+fn amount_to_shares(amount: i128, tvl: i128, total_shares: i128) -> i128 {
+    if total_shares == 0 || tvl == 0 {
+        return amount;
+    }
+    amount
+        .checked_mul(total_shares)
+        .unwrap()
+        .checked_div(tvl)
+        .unwrap()
+}
+
+/// Convert shares → underlying token amount.  On an empty pool 1 share == 1 token.
+fn shares_to_amount(shares: i128, tvl: i128, total_shares: i128) -> i128 {
+    if total_shares == 0 || tvl == 0 {
+        return shares;
+    }
+    shares
+        .checked_mul(tvl)
+        .unwrap()
+        .checked_div(total_shares)
+        .unwrap()
+}
+
+/// Derive a deterministic StrategyId from (protocol, token) using their XDR
+/// encoding so we can hash them without a std String.
+fn derive_strategy_id(env: &Env, protocol: &Address, token: &Address) -> StrategyId {
+    let mut raw = Bytes::new(env);
+    raw.append(&protocol.to_xdr(env));
+    raw.append(&token.to_xdr(env));
+    env.crypto().sha256(&raw).into()
+}
+
+// ── Contract ─────────────────────────────────────────────────────────────────
+
+#[contract]
+pub struct YieldAggregator;
+
+#[contractimpl]
+impl YieldAggregator {
+    // ── Initialisation ───────────────────────────────────────────────────────
+
+    pub fn initialize(env: Env, admin: Address) -> Result<(), YieldError> {
+        if env.storage().instance().has(&DataKey::Admin) {
+            return Err(YieldError::AlreadyInitialized);
+        }
+        env.storage().instance().set(&DataKey::Admin, &admin);
+        Ok(())
+    }
+
+    // ── Admin: add strategy ──────────────────────────────────────────────────
+
+    /// Register a new yield strategy.  Admin only.
+    /// Returns the deterministic StrategyId = sha256(protocol_xdr ++ token_xdr).
+    pub fn add_strategy(
+        env: Env,
+        protocol: Address,
+        token: Address,
+    ) -> Result<StrategyId, YieldError> {
+        let admin = get_admin(&env)?;
+        admin.require_auth();
+
+        let strategy_id = derive_strategy_id(&env, &protocol, &token);
+
+        if env
+            .storage()
+            .persistent()
+            .has(&DataKey::Strategy(strategy_id.clone()))
+        {
+            return Err(YieldError::StrategyAlreadyExists);
+        }
+
+        let now = env.ledger().timestamp();
+        let strategy = YieldStrategy {
+            strategy_id: strategy_id.clone(),
+            protocol_address: protocol,
+            token,
+            apy_bps: 0,
+            tvl: 0,
+            total_shares: 0,
+            is_active: true,
+            last_updated: now,
+        };
+
+        save_strategy(&env, &strategy);
+        Ok(strategy_id)
+    }
+
+    // ── Admin: rebalance ─────────────────────────────────────────────────────
+
+    /// Move underlying value from one strategy's TVL to another.  Admin only.
+    pub fn rebalance(
+        env: Env,
+        from: StrategyId,
+        to: StrategyId,
+        amount: i128,
+    ) -> Result<(), YieldError> {
+        let admin = get_admin(&env)?;
+        admin.require_auth();
+
+        if amount <= 0 {
+            return Err(YieldError::InvalidAmount);
+        }
+
+        let mut from_s = load_strategy(&env, &from)?;
+        let mut to_s = load_strategy(&env, &to)?;
+
+        if !from_s.is_active {
+            return Err(YieldError::StrategyInactive);
+        }
+        if !to_s.is_active {
+            return Err(YieldError::StrategyInactive);
+        }
+        if from_s.tvl < amount {
+            return Err(YieldError::InsufficientTvl);
+        }
+
+        // Move value between strategies.  In production this would call
+        // the underlying protocol's withdraw/deposit endpoints; here we
+        // update TVL accounting only (no token transfer between protocols).
+        let now = env.ledger().timestamp();
+        from_s.tvl -= amount;
+        from_s.last_updated = now;
+        save_strategy(&env, &from_s);
+
+        to_s.tvl += amount;
+        to_s.last_updated = now;
+        save_strategy(&env, &to_s);
+
+        events::emit_rebalance(&env, &from, &to, amount);
+        Ok(())
+    }
+
+    // ── User: deposit ────────────────────────────────────────────────────────
+
+    /// Deposit `amount` tokens into `strategy_id`.
+    /// Transfers tokens from `user` to the contract, mints proportional shares.
+    /// Returns shares minted.
+    pub fn deposit(
+        env: Env,
+        user: Address,
+        strategy_id: StrategyId,
+        amount: i128,
+    ) -> Result<i128, YieldError> {
+        user.require_auth();
+
+        if amount <= 0 {
+            return Err(YieldError::InvalidAmount);
+        }
+
+        let mut strategy = load_strategy(&env, &strategy_id)?;
+        if !strategy.is_active {
+            return Err(YieldError::StrategyInactive);
+        }
+
+        // Pull tokens from user into this contract.
+        TokenClient::new(&env, &strategy.token).transfer(
+            &user,
+            &env.current_contract_address(),
+            &amount,
+        );
+
+        let shares = amount_to_shares(amount, strategy.tvl, strategy.total_shares);
+        if shares <= 0 {
+            return Err(YieldError::ZeroShares);
+        }
+
+        strategy.tvl += amount;
+        strategy.total_shares += shares;
+        strategy.last_updated = env.ledger().timestamp();
+        save_strategy(&env, &strategy);
+
+        let now = env.ledger().timestamp();
+        let mut position = load_position(&env, &user, &strategy_id).unwrap_or(UserYieldPosition {
+            user: user.clone(),
+            strategy_id: strategy_id.clone(),
+            deposited: 0,
+            shares: 0,
+            last_harvested: now,
+        });
+
+        position.deposited += amount;
+        position.shares += shares;
+        save_position(&env, &position);
+
+        events::emit_deposit(&env, &user, &strategy_id, amount, shares);
+        Ok(shares)
+    }
+
+    // ── User: withdraw ───────────────────────────────────────────────────────
+
+    /// Burn `shares` and return the proportional underlying amount (principal + yield).
+    /// Transfers tokens from the contract back to `user`.
+    pub fn withdraw(
+        env: Env,
+        user: Address,
+        strategy_id: StrategyId,
+        shares: i128,
+    ) -> Result<i128, YieldError> {
+        user.require_auth();
+
+        if shares <= 0 {
+            return Err(YieldError::InvalidAmount);
+        }
+
+        let mut strategy = load_strategy(&env, &strategy_id)?;
+        let mut position = load_position(&env, &user, &strategy_id)?;
+
+        if position.shares < shares {
+            return Err(YieldError::InsufficientShares);
+        }
+
+        let amount = shares_to_amount(shares, strategy.tvl, strategy.total_shares);
+        if amount <= 0 {
+            return Err(YieldError::InvalidAmount);
+        }
+
+        // Return tokens to user.
+        TokenClient::new(&env, &strategy.token).transfer(
+            &env.current_contract_address(),
+            &user,
+            &amount,
+        );
+
+        strategy.tvl -= amount;
+        strategy.total_shares -= shares;
+        strategy.last_updated = env.ledger().timestamp();
+        save_strategy(&env, &strategy);
+
+        position.shares -= shares;
+        if position.shares == 0 {
+            position.deposited = 0;
+        } else {
+            position.deposited = position.deposited.saturating_sub(amount.min(position.deposited));
+        }
+        save_position(&env, &position);
+
+        events::emit_withdraw(&env, &user, &strategy_id, shares, amount);
+        Ok(amount)
+    }
+
+    // ── harvest ──────────────────────────────────────────────────────────────
+
+    /// Claim and compound yield for a strategy.
+    ///
+    /// Simulates realising 1% of TVL as yield (in production this would call
+    /// the external protocol's claim/reward endpoint).
+    /// Yield is compounded back into TVL — shares stay the same so each share
+    /// appreciates in underlying value.
+    /// APY is recalculated from actual yield / elapsed seconds.
+    pub fn harvest(env: Env, strategy_id: StrategyId) -> Result<(), YieldError> {
+        let mut strategy = load_strategy(&env, &strategy_id)?;
+        if !strategy.is_active {
+            return Err(YieldError::StrategyInactive);
+        }
+
+        let now = env.ledger().timestamp();
+        let elapsed = now.saturating_sub(strategy.last_updated);
+
+        // Simulate 1% yield on current TVL.
+        let yield_amount = if strategy.tvl > 0 { strategy.tvl / 100 } else { 0 };
+        let tvl_before = strategy.tvl;
+
+        // Compound: grow TVL, shares unchanged → each share is worth more.
+        strategy.tvl += yield_amount;
+
+        // Recompute APY in basis points from realised yield over elapsed time.
+        if elapsed > 0 && tvl_before > 0 {
+            const SECONDS_PER_YEAR: u64 = 31_536_000;
+            let annual_yield = (yield_amount as u128)
+                .saturating_mul(SECONDS_PER_YEAR as u128)
+                / elapsed as u128;
+            strategy.apy_bps =
+                (annual_yield.saturating_mul(10_000) / tvl_before as u128) as u32;
+        }
+
+        strategy.last_updated = now;
+        save_strategy(&env, &strategy);
+
+        events::emit_harvest(&env, &strategy_id, yield_amount, strategy.apy_bps);
+        Ok(())
+    }
+
+    // ── View functions ───────────────────────────────────────────────────────
+
+    pub fn get_apy(env: Env, strategy_id: StrategyId) -> Result<u32, YieldError> {
+        Ok(load_strategy(&env, &strategy_id)?.apy_bps)
+    }
+
+    pub fn get_position(
+        env: Env,
+        user: Address,
+        strategy_id: StrategyId,
+    ) -> Result<UserYieldPosition, YieldError> {
+        load_position(&env, &user, &strategy_id)
+    }
+
+    pub fn get_strategy(env: Env, strategy_id: StrategyId) -> Result<YieldStrategy, YieldError> {
+        load_strategy(&env, &strategy_id)
+    }
+}

--- a/contracts/contracts/yield_aggregator/src/test.rs
+++ b/contracts/contracts/yield_aggregator/src/test.rs
@@ -1,0 +1,395 @@
+#![cfg(test)]
+
+use super::*;
+use soroban_sdk::{
+    testutils::{Address as _, Ledger},
+    token::{Client as TokenClient, StellarAssetClient},
+    Address, Env,
+};
+
+// ── Setup ─────────────────────────────────────────────────────────────────────
+
+struct TestSetup {
+    env: Env,
+    contract_id: Address,
+    admin: Address,
+    user: Address,
+    token_id: Address,
+    strategy_id: BytesN<32>,
+}
+
+fn setup() -> TestSetup {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let contract_id = env.register_contract(None, YieldAggregator);
+    let client = YieldAggregatorClient::new(&env, &contract_id);
+    client.initialize(&admin).unwrap();
+
+    // Deploy a Stellar asset for use as the strategy token.
+    let token_admin = Address::generate(&env);
+    let token_id = env
+        .register_stellar_asset_contract_v2(token_admin.clone())
+        .address();
+
+    let user = Address::generate(&env);
+    // Mint 100_000 tokens to the user so they can deposit.
+    StellarAssetClient::new(&env, &token_id).mint(&user, &100_000);
+
+    // Add a strategy.
+    let protocol = Address::generate(&env);
+    let strategy_id = client.add_strategy(&protocol, &token_id).unwrap();
+
+    TestSetup { env, contract_id, admin, user, token_id, strategy_id }
+}
+
+fn client(s: &TestSetup) -> YieldAggregatorClient<'_> {
+    YieldAggregatorClient::new(&s.env, &s.contract_id)
+}
+
+// ── initialize ────────────────────────────────────────────────────────────────
+
+#[test]
+fn test_initialize_ok() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, YieldAggregator);
+    let c = YieldAggregatorClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    assert!(c.initialize(&admin).is_ok());
+}
+
+#[test]
+fn test_double_initialize_fails() {
+    let s = setup();
+    let result = client(&s).initialize(&s.admin);
+    assert_eq!(result, Err(errors::YieldError::AlreadyInitialized));
+}
+
+// ── add_strategy ──────────────────────────────────────────────────────────────
+
+#[test]
+fn test_add_strategy_returns_active_strategy() {
+    let s = setup();
+    let strategy = client(&s).get_strategy(&s.strategy_id).unwrap();
+    assert_eq!(strategy.token, s.token_id);
+    assert!(strategy.is_active);
+    assert_eq!(strategy.tvl, 0);
+    assert_eq!(strategy.total_shares, 0);
+    assert_eq!(strategy.apy_bps, 0);
+}
+
+#[test]
+fn test_add_strategy_duplicate_fails() {
+    let s = setup();
+    let protocol = s
+        .env
+        .storage()
+        .persistent()
+        .get::<_, YieldStrategy>(&DataKey::Strategy(s.strategy_id.clone()))
+        .unwrap()
+        .protocol_address;
+    // Re-adding same (protocol, token) pair should fail.
+    let result = client(&s).add_strategy(&protocol, &s.token_id);
+    assert_eq!(result, Err(errors::YieldError::StrategyAlreadyExists));
+}
+
+// ── deposit ───────────────────────────────────────────────────────────────────
+
+#[test]
+fn test_deposit_mints_one_to_one_on_empty_pool() {
+    let s = setup();
+    let shares = client(&s).deposit(&s.user, &s.strategy_id, &1_000).unwrap();
+    assert_eq!(shares, 1_000);
+
+    let pos = client(&s).get_position(&s.user, &s.strategy_id).unwrap();
+    assert_eq!(pos.deposited, 1_000);
+    assert_eq!(pos.shares, 1_000);
+
+    let strategy = client(&s).get_strategy(&s.strategy_id).unwrap();
+    assert_eq!(strategy.tvl, 1_000);
+    assert_eq!(strategy.total_shares, 1_000);
+}
+
+#[test]
+fn test_deposit_proportional_after_harvest() {
+    let s = setup();
+    let c = client(&s);
+
+    // User1 deposits 10_000 → 10_000 shares.
+    let user1 = Address::generate(&s.env);
+    StellarAssetClient::new(&s.env, &s.token_id).mint(&user1, &10_000);
+    c.deposit(&user1, &s.strategy_id, &10_000).unwrap();
+
+    // Advance time, harvest → TVL = 10_100, shares = 10_000.
+    s.env.ledger().with_mut(|l| l.timestamp = 3_600);
+    c.harvest(&s.strategy_id).unwrap();
+
+    let strategy = c.get_strategy(&s.strategy_id).unwrap();
+    assert_eq!(strategy.tvl, 10_100);
+    assert_eq!(strategy.total_shares, 10_000);
+
+    // User2 deposits 10_100 → shares = 10_100 * 10_000 / 10_100 = 10_000.
+    let user2 = Address::generate(&s.env);
+    StellarAssetClient::new(&s.env, &s.token_id).mint(&user2, &10_100);
+    let shares2 = c.deposit(&user2, &s.strategy_id, &10_100).unwrap();
+    assert_eq!(shares2, 10_000);
+}
+
+#[test]
+fn test_deposit_zero_returns_error() {
+    let s = setup();
+    let result = client(&s).deposit(&s.user, &s.strategy_id, &0);
+    assert_eq!(result, Err(errors::YieldError::InvalidAmount));
+}
+
+#[test]
+fn test_deposit_unknown_strategy_fails() {
+    let s = setup();
+    let fake_id = BytesN::from_array(&s.env, &[0u8; 32]);
+    let result = client(&s).deposit(&s.user, &fake_id, &100);
+    assert_eq!(result, Err(errors::YieldError::StrategyNotFound));
+}
+
+#[test]
+fn test_deposit_multiple_times_accumulates() {
+    let s = setup();
+    let c = client(&s);
+    c.deposit(&s.user, &s.strategy_id, &500).unwrap();
+    c.deposit(&s.user, &s.strategy_id, &500).unwrap();
+
+    let pos = c.get_position(&s.user, &s.strategy_id).unwrap();
+    assert_eq!(pos.deposited, 1_000);
+    assert_eq!(pos.shares, 1_000);
+}
+
+// ── withdraw ──────────────────────────────────────────────────────────────────
+
+#[test]
+fn test_withdraw_returns_correct_amount() {
+    let s = setup();
+    let c = client(&s);
+
+    c.deposit(&s.user, &s.strategy_id, &1_000).unwrap();
+    let amount_back = c.withdraw(&s.user, &s.strategy_id, &500).unwrap();
+
+    // 500 shares / 1000 total × 1000 TVL = 500 tokens.
+    assert_eq!(amount_back, 500);
+
+    // Verify token was returned to user.
+    assert_eq!(
+        TokenClient::new(&s.env, &s.token_id).balance(&s.user),
+        100_000 - 1_000 + 500
+    );
+
+    let strategy = c.get_strategy(&s.strategy_id).unwrap();
+    assert_eq!(strategy.tvl, 500);
+    assert_eq!(strategy.total_shares, 500);
+}
+
+#[test]
+fn test_withdraw_includes_accrued_yield() {
+    let s = setup();
+    let c = client(&s);
+
+    c.deposit(&s.user, &s.strategy_id, &10_000).unwrap();
+
+    // Harvest: TVL = 10_100, shares = 10_000.
+    s.env.ledger().with_mut(|l| l.timestamp = 3_600);
+    c.harvest(&s.strategy_id).unwrap();
+
+    // Withdraw all 10_000 shares → 10_100 tokens (1 % yield included).
+    let amount_back = c.withdraw(&s.user, &s.strategy_id, &10_000).unwrap();
+    assert_eq!(amount_back, 10_100);
+
+    let strategy = c.get_strategy(&s.strategy_id).unwrap();
+    assert_eq!(strategy.tvl, 0);
+    assert_eq!(strategy.total_shares, 0);
+}
+
+#[test]
+fn test_withdraw_insufficient_shares_fails() {
+    let s = setup();
+    let c = client(&s);
+    c.deposit(&s.user, &s.strategy_id, &1_000).unwrap();
+    let result = c.withdraw(&s.user, &s.strategy_id, &1_001);
+    assert_eq!(result, Err(errors::YieldError::InsufficientShares));
+}
+
+#[test]
+fn test_withdraw_no_position_fails() {
+    let s = setup();
+    let stranger = Address::generate(&s.env);
+    let result = client(&s).withdraw(&stranger, &s.strategy_id, &100);
+    assert_eq!(result, Err(errors::YieldError::PositionNotFound));
+}
+
+#[test]
+fn test_withdraw_zero_fails() {
+    let s = setup();
+    let c = client(&s);
+    c.deposit(&s.user, &s.strategy_id, &1_000).unwrap();
+    let result = c.withdraw(&s.user, &s.strategy_id, &0);
+    assert_eq!(result, Err(errors::YieldError::InvalidAmount));
+}
+
+// ── harvest ───────────────────────────────────────────────────────────────────
+
+#[test]
+fn test_harvest_compounds_yield_into_tvl() {
+    let s = setup();
+    let c = client(&s);
+
+    c.deposit(&s.user, &s.strategy_id, &10_000).unwrap();
+    s.env.ledger().with_mut(|l| l.timestamp = 3_600);
+    c.harvest(&s.strategy_id).unwrap();
+
+    let strategy = c.get_strategy(&s.strategy_id).unwrap();
+    // 1% of 10_000 = 100 compounded.
+    assert_eq!(strategy.tvl, 10_100);
+    // Shares unchanged — existing holders own proportionally more.
+    assert_eq!(strategy.total_shares, 10_000);
+}
+
+#[test]
+fn test_harvest_updates_apy_bps() {
+    let s = setup();
+    let c = client(&s);
+
+    c.deposit(&s.user, &s.strategy_id, &10_000).unwrap();
+    s.env.ledger().with_mut(|l| l.timestamp = 3_600);
+    c.harvest(&s.strategy_id).unwrap();
+
+    let strategy = c.get_strategy(&s.strategy_id).unwrap();
+    assert!(strategy.apy_bps > 0, "APY should be non-zero after harvest with elapsed > 0");
+}
+
+#[test]
+fn test_harvest_empty_pool_is_noop() {
+    let s = setup();
+    // No deposit — harvest should succeed without panic.
+    client(&s).harvest(&s.strategy_id).unwrap();
+    let strategy = client(&s).get_strategy(&s.strategy_id).unwrap();
+    assert_eq!(strategy.tvl, 0);
+}
+
+#[test]
+fn test_harvest_unknown_strategy_fails() {
+    let s = setup();
+    let fake_id = BytesN::from_array(&s.env, &[0u8; 32]);
+    let result = client(&s).harvest(&fake_id);
+    assert_eq!(result, Err(errors::YieldError::StrategyNotFound));
+}
+
+// ── rebalance ─────────────────────────────────────────────────────────────────
+
+#[test]
+fn test_rebalance_moves_tvl() {
+    let s = setup();
+    let c = client(&s);
+
+    // Seed strategy1 with 1_000.
+    c.deposit(&s.user, &s.strategy_id, &1_000).unwrap();
+
+    // Create a second strategy.
+    let protocol2 = Address::generate(&s.env);
+    let token2_admin = Address::generate(&s.env);
+    let token2_id = s
+        .env
+        .register_stellar_asset_contract_v2(token2_admin)
+        .address();
+    let strategy2_id = c.add_strategy(&protocol2, &token2_id).unwrap();
+
+    c.rebalance(&s.strategy_id, &strategy2_id, &400).unwrap();
+
+    let s1 = c.get_strategy(&s.strategy_id).unwrap();
+    let s2 = c.get_strategy(&strategy2_id).unwrap();
+    assert_eq!(s1.tvl, 600);
+    assert_eq!(s2.tvl, 400);
+}
+
+#[test]
+fn test_rebalance_insufficient_tvl_fails() {
+    let s = setup();
+    let c = client(&s);
+
+    c.deposit(&s.user, &s.strategy_id, &100).unwrap();
+
+    let protocol2 = Address::generate(&s.env);
+    let token2_admin = Address::generate(&s.env);
+    let token2_id = s
+        .env
+        .register_stellar_asset_contract_v2(token2_admin)
+        .address();
+    let strategy2_id = c.add_strategy(&protocol2, &token2_id).unwrap();
+
+    let result = c.rebalance(&s.strategy_id, &strategy2_id, &101);
+    assert_eq!(result, Err(errors::YieldError::InsufficientTvl));
+}
+
+#[test]
+fn test_rebalance_zero_amount_fails() {
+    let s = setup();
+    let c = client(&s);
+    let protocol2 = Address::generate(&s.env);
+    let token2_admin = Address::generate(&s.env);
+    let token2_id = s
+        .env
+        .register_stellar_asset_contract_v2(token2_admin)
+        .address();
+    let strategy2_id = c.add_strategy(&protocol2, &token2_id).unwrap();
+    let result = c.rebalance(&s.strategy_id, &strategy2_id, &0);
+    assert_eq!(result, Err(errors::YieldError::InvalidAmount));
+}
+
+// ── get_apy ───────────────────────────────────────────────────────────────────
+
+#[test]
+fn test_get_apy_zero_before_harvest() {
+    let s = setup();
+    assert_eq!(client(&s).get_apy(&s.strategy_id).unwrap(), 0);
+}
+
+#[test]
+fn test_get_apy_nonzero_after_harvest() {
+    let s = setup();
+    let c = client(&s);
+    c.deposit(&s.user, &s.strategy_id, &10_000).unwrap();
+    s.env.ledger().with_mut(|l| l.timestamp = 3_600);
+    c.harvest(&s.strategy_id).unwrap();
+    assert!(c.get_apy(&s.strategy_id).unwrap() > 0);
+}
+
+// ── multi-user proportional yield ────────────────────────────────────────────
+
+#[test]
+fn test_multi_user_proportional_yield() {
+    let s = setup();
+    let c = client(&s);
+
+    let user_a = Address::generate(&s.env);
+    let user_b = Address::generate(&s.env);
+    StellarAssetClient::new(&s.env, &s.token_id).mint(&user_a, &600);
+    StellarAssetClient::new(&s.env, &s.token_id).mint(&user_b, &400);
+
+    // A deposits 600, B deposits 400 → 1000 tokens / 1000 shares total.
+    c.deposit(&user_a, &s.strategy_id, &600).unwrap();
+    c.deposit(&user_b, &s.strategy_id, &400).unwrap();
+
+    // Harvest: TVL = 1010 (1% yield).
+    s.env.ledger().with_mut(|l| l.timestamp = 3_600);
+    c.harvest(&s.strategy_id).unwrap();
+
+    // A withdraws 600 shares → 600/1000 × 1010 = 606.
+    let a_back = c.withdraw(&user_a, &s.strategy_id, &600).unwrap();
+    assert_eq!(a_back, 606);
+
+    // B withdraws 400 shares → 400/400 × (1010-606) = 404.
+    let b_back = c.withdraw(&user_b, &s.strategy_id, &400).unwrap();
+    assert_eq!(b_back, 404);
+
+    let strategy = c.get_strategy(&s.strategy_id).unwrap();
+    assert_eq!(strategy.tvl, 0);
+    assert_eq!(strategy.total_shares, 0);
+}

--- a/contracts/contracts/yield_aggregator/src/types.rs
+++ b/contracts/contracts/yield_aggregator/src/types.rs
@@ -1,0 +1,47 @@
+use soroban_sdk::{contracttype, Address, BytesN};
+
+pub const STRATEGY_TTL: u32 = 3_110_400; // ~1 year in ledgers
+
+pub type StrategyId = BytesN<32>;
+
+/// On-chain record for a DeFi yield strategy.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct YieldStrategy {
+    pub strategy_id: StrategyId,
+    /// Address of the external DeFi protocol contract.
+    pub protocol_address: Address,
+    /// Token accepted/returned by this strategy.
+    pub token: Address,
+    /// Latest APY in basis points (500 = 5.00%).
+    pub apy_bps: u32,
+    /// Total underlying token value locked (in token's smallest unit).
+    pub tvl: i128,
+    /// Total shares outstanding for this strategy.
+    pub total_shares: i128,
+    pub is_active: bool,
+    pub last_updated: u64,
+}
+
+/// Per-user position inside a single strategy.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct UserYieldPosition {
+    pub user: Address,
+    pub strategy_id: StrategyId,
+    /// Cumulative raw token amount deposited by this user.
+    pub deposited: i128,
+    /// Shares held by this user in the strategy pool.
+    pub shares: i128,
+    pub last_harvested: u64,
+}
+
+/// Storage keys.
+#[contracttype]
+#[derive(Clone)]
+pub enum DataKey {
+    Admin,
+    StrategyCount,
+    Strategy(StrategyId),
+    Position(Address, StrategyId),
+}

--- a/src/geo-restriction/dto/geo-restriction.dto.ts
+++ b/src/geo-restriction/dto/geo-restriction.dto.ts
@@ -1,0 +1,33 @@
+import { RestrictionType } from '../entities/geo-restriction.entity';
+
+export class CreateGeoRestrictionDto {
+  countryCode!: string;
+  restrictionType!: RestrictionType;
+  affectedFeatures?: string[];
+  reason?: string;
+}
+
+export class GeoRestrictionResponseDto {
+  id!: string;
+  countryCode!: string;
+  restrictionType!: RestrictionType;
+  affectedFeatures?: string[];
+  reason?: string;
+  isActive!: boolean;
+  createdAt!: Date;
+}
+
+export class MyRestrictionsResponseDto {
+  countryCode!: string;
+  isVPN!: boolean;
+  restrictions!: GeoRestrictionResponseDto[];
+  blockedFeatures!: string[];
+  requiresKyc!: boolean;
+  isFullyBlocked!: boolean;
+}
+
+export class ApplyRestrictionResultDto {
+  allowed!: boolean;
+  reason?: string;
+  restrictionType?: RestrictionType;
+}

--- a/src/geo-restriction/entities/geo-restriction.entity.ts
+++ b/src/geo-restriction/entities/geo-restriction.entity.ts
@@ -1,0 +1,47 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  Index,
+} from 'typeorm';
+
+export enum RestrictionType {
+  FULL_BLOCK = 'FULL_BLOCK',
+  FEATURE_LIMIT = 'FEATURE_LIMIT',
+  KYC_REQUIRED = 'KYC_REQUIRED',
+}
+
+@Entity('geo_restrictions')
+@Index('idx_geo_restriction_country', ['countryCode'])
+@Index('idx_geo_restriction_active', ['isActive'])
+export class GeoRestriction {
+  @PrimaryGeneratedColumn('uuid')
+  id!: string;
+
+  /** ISO 3166-1 alpha-2 country code (e.g. "US", "IR"). */
+  @Column({ length: 2 })
+  countryCode!: string;
+
+  @Column({
+    type: 'enum',
+    enum: RestrictionType,
+  })
+  restrictionType!: RestrictionType;
+
+  /**
+   * Specific feature slugs restricted for FEATURE_LIMIT type.
+   * Empty for FULL_BLOCK / KYC_REQUIRED at the global level.
+   */
+  @Column({ type: 'simple-array', nullable: true })
+  affectedFeatures?: string[];
+
+  @Column({ type: 'text', nullable: true })
+  reason?: string;
+
+  @Column({ default: true })
+  isActive!: boolean;
+
+  @CreateDateColumn()
+  createdAt!: Date;
+}

--- a/src/geo-restriction/entities/user-geo-record.entity.ts
+++ b/src/geo-restriction/entities/user-geo-record.entity.ts
@@ -1,0 +1,32 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  Index,
+} from 'typeorm';
+
+@Entity('user_geo_records')
+@Index('idx_user_geo_user_id', ['userId'])
+@Index('idx_user_geo_detected_at', ['detectedAt'])
+export class UserGeoRecord {
+  @PrimaryGeneratedColumn('uuid')
+  id!: string;
+
+  @Column({ type: 'uuid' })
+  userId!: string;
+
+  /** ISO 3166-1 alpha-2 country code resolved from IP. */
+  @Column({ length: 2 })
+  detectedCountry!: string;
+
+  @Column({ length: 45 })
+  ipAddress!: string;
+
+  @CreateDateColumn()
+  detectedAt!: Date;
+
+  /** Whether the IP was flagged as a VPN/proxy/Tor exit node. */
+  @Column({ default: false })
+  isVPN!: boolean;
+}

--- a/src/geo-restriction/geo-restriction.controller.ts
+++ b/src/geo-restriction/geo-restriction.controller.ts
@@ -1,0 +1,69 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Delete,
+  Param,
+  Body,
+  Req,
+  HttpCode,
+  HttpStatus,
+} from '@nestjs/common';
+import { Request } from 'express';
+import { GeoRestrictionService } from './geo-restriction.service';
+import {
+  CreateGeoRestrictionDto,
+  GeoRestrictionResponseDto,
+  MyRestrictionsResponseDto,
+} from './dto/geo-restriction.dto';
+import { GeoRestriction } from './entities/geo-restriction.entity';
+
+@Controller()
+export class GeoRestrictionController {
+  constructor(private readonly geoService: GeoRestrictionService) {}
+
+  // ── Admin endpoints ────────────────────────────────────────────────────────
+
+  /**
+   * GET /admin/geo-restrictions
+   * List all active geo restrictions.
+   */
+  @Get('admin/geo-restrictions')
+  async listRestrictions(): Promise<GeoRestriction[]> {
+    return this.geoService.getBlockedCountries();
+  }
+
+  /**
+   * POST /admin/geo-restrictions
+   * Add a new geo restriction (without redeployment).
+   */
+  @Post('admin/geo-restrictions')
+  @HttpCode(HttpStatus.CREATED)
+  async addRestriction(@Body() dto: CreateGeoRestrictionDto): Promise<GeoRestriction> {
+    return this.geoService.addRestriction(dto);
+  }
+
+  /**
+   * DELETE /admin/geo-restrictions/:id
+   * Soft-delete (deactivate) a restriction by id.
+   */
+  @Delete('admin/geo-restrictions/:id')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  async removeRestriction(@Param('id') id: string): Promise<void> {
+    return this.geoService.removeRestriction(id);
+  }
+
+  // ── User-facing endpoints ──────────────────────────────────────────────────
+
+  /**
+   * GET /geo/my-restrictions
+   * Returns the restrictions applicable to the current request's country.
+   * Country and VPN flag are resolved by GeoRestrictionMiddleware.
+   */
+  @Get('geo/my-restrictions')
+  async getMyRestrictions(@Req() req: Request): Promise<MyRestrictionsResponseDto> {
+    const country: string = (req as any).geoCountry ?? 'XX';
+    const isVPN: boolean = (req as any).geoIsVPN ?? false;
+    return this.geoService.getMyRestrictions(country, isVPN);
+  }
+}

--- a/src/geo-restriction/geo-restriction.middleware.ts
+++ b/src/geo-restriction/geo-restriction.middleware.ts
@@ -1,0 +1,72 @@
+import { Injectable, NestMiddleware, ForbiddenException, Logger } from '@nestjs/common';
+import { Request, Response, NextFunction } from 'express';
+import { GeoRestrictionService, OFAC_SANCTIONED_COUNTRIES } from './geo-restriction.service';
+
+/**
+ * Resolves the client IP from common proxy headers, falling back to
+ * the socket remote address.
+ */
+function resolveIp(req: Request): string {
+  const forwarded = req.headers['x-forwarded-for'];
+  if (forwarded) {
+    const first = Array.isArray(forwarded) ? forwarded[0] : forwarded.split(',')[0];
+    return first.trim();
+  }
+  return req.headers['x-real-ip'] as string ?? req.socket.remoteAddress ?? '0.0.0.0';
+}
+
+/**
+ * Resolve ISO country code from the request.
+ * Priority: X-Country-Code header (set by CDN/load-balancer) → fallback 'XX'.
+ *
+ * In production wire this to your CDN (Cloudflare CF-IPCountry,
+ * AWS CloudFront CloudFront-Viewer-Country, or MaxMind GeoIP).
+ */
+function resolveCountry(req: Request): string {
+  return (
+    (req.headers['cf-ipcountry'] as string) ??
+    (req.headers['x-country-code'] as string) ??
+    (req.headers['cloudfront-viewer-country'] as string) ??
+    'XX'
+  ).toUpperCase();
+}
+
+/** Detect VPN/proxy via the X-VPN header set by upstream proxy detection. */
+function detectVpn(req: Request): boolean {
+  const header = req.headers['x-is-vpn'] as string | undefined;
+  return header === '1' || header?.toLowerCase() === 'true';
+}
+
+@Injectable()
+export class GeoRestrictionMiddleware implements NestMiddleware {
+  private readonly logger = new Logger(GeoRestrictionMiddleware.name);
+
+  constructor(private readonly geoService: GeoRestrictionService) {}
+
+  async use(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const ip = resolveIp(req);
+    const country = resolveCountry(req);
+    const isVPN = detectVpn(req);
+
+    // Attach to request so controllers/guards can read them.
+    (req as any).geoCountry = country;
+    (req as any).geoIp = ip;
+    (req as any).geoIsVPN = isVPN;
+
+    // Fast-path: OFAC block — no DB round-trip needed.
+    if (OFAC_SANCTIONED_COUNTRIES.has(country)) {
+      this.logger.warn(`OFAC block — country=${country} ip=${ip} path=${req.path}`);
+      res.status(403).json({
+        statusCode: 403,
+        error: 'Forbidden',
+        message: `Access from ${country} is not permitted under OFAC sanctions.`,
+      });
+      return;
+    }
+
+    // For all other countries let the request through; feature-level
+    // restrictions are enforced by the GeoRestrictionGuard or service
+    // at the controller/endpoint level.
+    next();
+  }
+}

--- a/src/geo-restriction/geo-restriction.module.ts
+++ b/src/geo-restriction/geo-restriction.module.ts
@@ -1,0 +1,26 @@
+import { Module, MiddlewareConsumer, NestModule, RequestMethod } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { ConfigModule } from '@nestjs/config';
+import { GeoRestriction } from './entities/geo-restriction.entity';
+import { UserGeoRecord } from './entities/user-geo-record.entity';
+import { GeoRestrictionService } from './geo-restriction.service';
+import { GeoRestrictionController } from './geo-restriction.controller';
+import { GeoRestrictionMiddleware } from './geo-restriction.middleware';
+import { GeoFeatureGuard } from './guards/geo-feature.guard';
+
+@Module({
+  imports: [
+    ConfigModule,
+    TypeOrmModule.forFeature([GeoRestriction, UserGeoRecord]),
+  ],
+  controllers: [GeoRestrictionController],
+  providers: [GeoRestrictionService, GeoFeatureGuard],
+  exports: [GeoRestrictionService, GeoFeatureGuard],
+})
+export class GeoRestrictionModule implements NestModule {
+  configure(consumer: MiddlewareConsumer): void {
+    consumer
+      .apply(GeoRestrictionMiddleware)
+      .forRoutes({ path: '*', method: RequestMethod.ALL });
+  }
+}

--- a/src/geo-restriction/geo-restriction.service.spec.ts
+++ b/src/geo-restriction/geo-restriction.service.spec.ts
@@ -1,0 +1,298 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { ConfigService } from '@nestjs/config';
+import { ForbiddenException, NotFoundException } from '@nestjs/common';
+import { GeoRestrictionService, OFAC_SANCTIONED_COUNTRIES } from './geo-restriction.service';
+import { GeoRestriction, RestrictionType } from './entities/geo-restriction.entity';
+import { UserGeoRecord } from './entities/user-geo-record.entity';
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeRestriction(overrides: Partial<GeoRestriction> = {}): GeoRestriction {
+  return {
+    id: 'uuid-1',
+    countryCode: 'XX',
+    restrictionType: RestrictionType.FULL_BLOCK,
+    affectedFeatures: [],
+    reason: 'test',
+    isActive: true,
+    createdAt: new Date(),
+    ...overrides,
+  } as GeoRestriction;
+}
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+
+const mockRestrictionRepo = {
+  find: jest.fn(),
+  findOne: jest.fn(),
+  create: jest.fn(),
+  save: jest.fn(),
+  update: jest.fn(),
+};
+
+const mockGeoRecordRepo = {
+  create: jest.fn(),
+  save: jest.fn(),
+};
+
+const mockConfigService = {
+  get: jest.fn((key: string, def?: any) => {
+    if (key === 'GEO_STRICT_VPN') return false;
+    return def;
+  }),
+};
+
+// ── Suite ─────────────────────────────────────────────────────────────────────
+
+describe('GeoRestrictionService', () => {
+  let service: GeoRestrictionService;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        GeoRestrictionService,
+        { provide: getRepositoryToken(GeoRestriction), useValue: mockRestrictionRepo },
+        { provide: getRepositoryToken(UserGeoRecord), useValue: mockGeoRecordRepo },
+        { provide: ConfigService, useValue: mockConfigService },
+      ],
+    }).compile();
+
+    service = module.get(GeoRestrictionService);
+  });
+
+  // ── checkRestrictions ──────────────────────────────────────────────────────
+
+  describe('checkRestrictions', () => {
+    it('returns OFAC virtual FULL_BLOCK for sanctioned country without DB call', async () => {
+      const [sanctioned] = [...OFAC_SANCTIONED_COUNTRIES];
+      const result = await service.checkRestrictions(sanctioned);
+      expect(result).toHaveLength(1);
+      expect(result[0].restrictionType).toBe(RestrictionType.FULL_BLOCK);
+      expect(mockRestrictionRepo.find).not.toHaveBeenCalled();
+    });
+
+    it('queries DB for non-sanctioned country', async () => {
+      mockRestrictionRepo.find.mockResolvedValue([]);
+      await service.checkRestrictions('DE');
+      expect(mockRestrictionRepo.find).toHaveBeenCalledWith(
+        expect.objectContaining({ where: { countryCode: 'DE', isActive: true } }),
+      );
+    });
+
+    it('is case-insensitive for country code', async () => {
+      mockRestrictionRepo.find.mockResolvedValue([]);
+      const result = await service.checkRestrictions('de');
+      expect(result).toHaveLength(0);
+    });
+  });
+
+  // ── getRestrictionsForCountry ──────────────────────────────────────────────
+
+  describe('getRestrictionsForCountry', () => {
+    it('returns DB rules', async () => {
+      const rule = makeRestriction({ countryCode: 'NG', restrictionType: RestrictionType.KYC_REQUIRED });
+      mockRestrictionRepo.find.mockResolvedValue([rule]);
+      const result = await service.getRestrictionsForCountry('NG');
+      expect(result).toEqual([rule]);
+    });
+
+    it('caches results and avoids second DB call', async () => {
+      mockRestrictionRepo.find.mockResolvedValue([]);
+      await service.getRestrictionsForCountry('FR');
+      await service.getRestrictionsForCountry('FR');
+      expect(mockRestrictionRepo.find).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // ── applyRestriction ───────────────────────────────────────────────────────
+
+  describe('applyRestriction', () => {
+    it('throws ForbiddenException for OFAC country', async () => {
+      const [sanctioned] = [...OFAC_SANCTIONED_COUNTRIES];
+      await expect(service.applyRestriction(sanctioned)).rejects.toThrow(ForbiddenException);
+    });
+
+    it('throws ForbiddenException for FULL_BLOCK from DB', async () => {
+      mockRestrictionRepo.find.mockResolvedValue([
+        makeRestriction({ countryCode: 'XX', restrictionType: RestrictionType.FULL_BLOCK }),
+      ]);
+      await expect(service.applyRestriction('XX')).rejects.toThrow(ForbiddenException);
+    });
+
+    it('returns allowed=false for feature-level restriction', async () => {
+      mockRestrictionRepo.find.mockResolvedValue([
+        makeRestriction({
+          countryCode: 'AU',
+          restrictionType: RestrictionType.FEATURE_LIMIT,
+          affectedFeatures: ['payments'],
+        }),
+      ]);
+      const result = await service.applyRestriction('AU', 'payments');
+      expect(result.allowed).toBe(false);
+      expect(result.restrictionType).toBe(RestrictionType.FEATURE_LIMIT);
+    });
+
+    it('returns allowed=true when feature is not in restriction list', async () => {
+      mockRestrictionRepo.find.mockResolvedValue([
+        makeRestriction({
+          countryCode: 'AU',
+          restrictionType: RestrictionType.FEATURE_LIMIT,
+          affectedFeatures: ['payments'],
+        }),
+      ]);
+      const result = await service.applyRestriction('AU', 'messaging');
+      expect(result.allowed).toBe(true);
+    });
+
+    it('returns allowed=true with KYC_REQUIRED type when only KYC restriction', async () => {
+      mockRestrictionRepo.find.mockResolvedValue([
+        makeRestriction({ countryCode: 'IN', restrictionType: RestrictionType.KYC_REQUIRED }),
+      ]);
+      const result = await service.applyRestriction('IN');
+      expect(result.allowed).toBe(true);
+      expect(result.restrictionType).toBe(RestrictionType.KYC_REQUIRED);
+    });
+
+    it('throws ForbiddenException for VPN in strict mode', async () => {
+      mockConfigService.get.mockImplementation((key: string) => {
+        if (key === 'GEO_STRICT_VPN') return true;
+      });
+      mockRestrictionRepo.find.mockResolvedValue([]);
+      await expect(service.applyRestriction('GB', undefined, true)).rejects.toThrow(
+        ForbiddenException,
+      );
+    });
+
+    it('allows VPN in non-strict mode', async () => {
+      mockRestrictionRepo.find.mockResolvedValue([]);
+      const result = await service.applyRestriction('GB', undefined, true);
+      expect(result.allowed).toBe(true);
+    });
+  });
+
+  // ── getBlockedCountries ────────────────────────────────────────────────────
+
+  describe('getBlockedCountries', () => {
+    it('returns all active restrictions', async () => {
+      const rules = [makeRestriction(), makeRestriction({ id: 'uuid-2' })];
+      mockRestrictionRepo.find.mockResolvedValue(rules);
+      expect(await service.getBlockedCountries()).toHaveLength(2);
+    });
+  });
+
+  // ── addRestriction ─────────────────────────────────────────────────────────
+
+  describe('addRestriction', () => {
+    it('saves and returns restriction, invalidates cache', async () => {
+      const restriction = makeRestriction({ countryCode: 'ZZ' });
+      mockRestrictionRepo.create.mockReturnValue(restriction);
+      mockRestrictionRepo.save.mockResolvedValue(restriction);
+
+      const result = await service.addRestriction({
+        countryCode: 'ZZ',
+        restrictionType: RestrictionType.FULL_BLOCK,
+      });
+
+      expect(result).toBe(restriction);
+      expect(mockRestrictionRepo.save).toHaveBeenCalled();
+    });
+
+    it('upcases countryCode', async () => {
+      const restriction = makeRestriction({ countryCode: 'ZZ' });
+      mockRestrictionRepo.create.mockReturnValue(restriction);
+      mockRestrictionRepo.save.mockResolvedValue(restriction);
+
+      await service.addRestriction({ countryCode: 'zz', restrictionType: RestrictionType.FULL_BLOCK });
+      expect(mockRestrictionRepo.create).toHaveBeenCalledWith(
+        expect.objectContaining({ countryCode: 'ZZ' }),
+      );
+    });
+  });
+
+  // ── removeRestriction ──────────────────────────────────────────────────────
+
+  describe('removeRestriction', () => {
+    it('deactivates an existing restriction', async () => {
+      mockRestrictionRepo.findOne.mockResolvedValue(makeRestriction({ id: 'uuid-1' }));
+      mockRestrictionRepo.update.mockResolvedValue(undefined);
+
+      await service.removeRestriction('uuid-1');
+
+      expect(mockRestrictionRepo.update).toHaveBeenCalledWith('uuid-1', { isActive: false });
+    });
+
+    it('throws NotFoundException for unknown id', async () => {
+      mockRestrictionRepo.findOne.mockResolvedValue(null);
+      await expect(service.removeRestriction('bad-id')).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  // ── logGeoRecord ───────────────────────────────────────────────────────────
+
+  describe('logGeoRecord', () => {
+    it('creates and saves a geo record', async () => {
+      const record = { id: 'r1', userId: 'u1', detectedCountry: 'GB', ipAddress: '1.2.3.4', isVPN: false, detectedAt: new Date() };
+      mockGeoRecordRepo.create.mockReturnValue(record);
+      mockGeoRecordRepo.save.mockResolvedValue(record);
+
+      const result = await service.logGeoRecord('u1', '1.2.3.4', 'gb');
+      expect(result).toBe(record);
+      expect(mockGeoRecordRepo.create).toHaveBeenCalledWith(
+        expect.objectContaining({ detectedCountry: 'GB' }),
+      );
+    });
+  });
+
+  // ── getMyRestrictions ──────────────────────────────────────────────────────
+
+  describe('getMyRestrictions', () => {
+    it('returns isFullyBlocked=true for OFAC country', async () => {
+      const [sanctioned] = [...OFAC_SANCTIONED_COUNTRIES];
+      const result = await service.getMyRestrictions(sanctioned, false);
+      expect(result.isFullyBlocked).toBe(true);
+    });
+
+    it('returns feature list for FEATURE_LIMIT country', async () => {
+      mockRestrictionRepo.find.mockResolvedValue([
+        makeRestriction({
+          countryCode: 'CN',
+          restrictionType: RestrictionType.FEATURE_LIMIT,
+          affectedFeatures: ['nfts', 'staking'],
+        }),
+      ]);
+      const result = await service.getMyRestrictions('CN', false);
+      expect(result.blockedFeatures).toEqual(['nfts', 'staking']);
+      expect(result.isFullyBlocked).toBe(false);
+    });
+
+    it('returns requiresKyc=true for KYC_REQUIRED country', async () => {
+      mockRestrictionRepo.find.mockResolvedValue([
+        makeRestriction({ countryCode: 'TR', restrictionType: RestrictionType.KYC_REQUIRED }),
+      ]);
+      const result = await service.getMyRestrictions('TR', false);
+      expect(result.requiresKyc).toBe(true);
+    });
+
+    it('includes isVPN flag in response', async () => {
+      mockRestrictionRepo.find.mockResolvedValue([]);
+      const result = await service.getMyRestrictions('GB', true);
+      expect(result.isVPN).toBe(true);
+    });
+  });
+
+  // ── OFAC list ──────────────────────────────────────────────────────────────
+
+  describe('OFAC_SANCTIONED_COUNTRIES', () => {
+    it('contains the expected sanctioned country codes', () => {
+      expect(OFAC_SANCTIONED_COUNTRIES.has('IR')).toBe(true);
+      expect(OFAC_SANCTIONED_COUNTRIES.has('KP')).toBe(true);
+      expect(OFAC_SANCTIONED_COUNTRIES.has('SY')).toBe(true);
+      expect(OFAC_SANCTIONED_COUNTRIES.has('CU')).toBe(true);
+      expect(OFAC_SANCTIONED_COUNTRIES.has('US')).toBe(false);
+      expect(OFAC_SANCTIONED_COUNTRIES.has('GB')).toBe(false);
+    });
+  });
+});

--- a/src/geo-restriction/geo-restriction.service.ts
+++ b/src/geo-restriction/geo-restriction.service.ts
@@ -1,0 +1,259 @@
+import {
+  Injectable,
+  Logger,
+  NotFoundException,
+  ForbiddenException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { ConfigService } from '@nestjs/config';
+import { GeoRestriction, RestrictionType } from './entities/geo-restriction.entity';
+import { UserGeoRecord } from './entities/user-geo-record.entity';
+import {
+  ApplyRestrictionResultDto,
+  CreateGeoRestrictionDto,
+  GeoRestrictionResponseDto,
+  MyRestrictionsResponseDto,
+} from './dto/geo-restriction.dto';
+
+/**
+ * OFAC-sanctioned countries per the SDN list.
+ * Source: https://home.treasury.gov/policy-issues/financial-sanctions/sanctions-list-service
+ */
+export const OFAC_SANCTIONED_COUNTRIES = new Set([
+  'CU', // Cuba
+  'IR', // Iran
+  'KP', // North Korea
+  'SY', // Syria
+  'RU', // Russia (sectoral)
+  'BY', // Belarus
+  'MM', // Myanmar
+  'VE', // Venezuela (sectoral)
+  'SD', // Sudan
+  'ZW', // Zimbabwe
+  'CD', // DRC
+  'LY', // Libya
+  'SO', // Somalia
+  'YE', // Yemen
+  'AF', // Afghanistan
+]);
+
+const CACHE_TTL_SECONDS = 5 * 60; // 5 minutes
+
+@Injectable()
+export class GeoRestrictionService {
+  private readonly logger = new Logger(GeoRestrictionService.name);
+
+  /**
+   * In-memory cache of restriction rules (keyed by country code).
+   * Invalidated on writes; refreshed lazily with a TTL.
+   */
+  private cache = new Map<string, { rules: GeoRestriction[]; expiresAt: number }>();
+
+  constructor(
+    @InjectRepository(GeoRestriction)
+    private readonly restrictionRepo: Repository<GeoRestriction>,
+    @InjectRepository(UserGeoRecord)
+    private readonly geoRecordRepo: Repository<UserGeoRecord>,
+    private readonly configService: ConfigService,
+  ) {}
+
+  // ── Public: check & apply ──────────────────────────────────────────────────
+
+  /**
+   * Check all active restrictions for a given country code.
+   * OFAC countries are blocked regardless of DB entries.
+   */
+  async checkRestrictions(countryCode: string): Promise<GeoRestriction[]> {
+    const upper = countryCode.toUpperCase();
+
+    // OFAC is always enforced — synthesise a virtual FULL_BLOCK entry.
+    if (OFAC_SANCTIONED_COUNTRIES.has(upper)) {
+      return [this.buildOfacEntry(upper)];
+    }
+
+    return this.getRestrictionsForCountry(upper);
+  }
+
+  /**
+   * Load active DB restrictions for a country (with 5-min cache).
+   */
+  async getRestrictionsForCountry(countryCode: string): Promise<GeoRestriction[]> {
+    const upper = countryCode.toUpperCase();
+    const cached = this.cache.get(upper);
+
+    if (cached && cached.expiresAt > Date.now()) {
+      return cached.rules;
+    }
+
+    const rules = await this.restrictionRepo.find({
+      where: { countryCode: upper, isActive: true },
+    });
+
+    this.cache.set(upper, { rules, expiresAt: Date.now() + CACHE_TTL_SECONDS * 1_000 });
+    return rules;
+  }
+
+  /**
+   * Evaluate whether a request from `countryCode` should be allowed.
+   * Throws ForbiddenException for FULL_BLOCK; returns result dto otherwise.
+   *
+   * @param feature  Optional feature slug to check FEATURE_LIMIT rules.
+   * @param isVPN    Whether the requesting IP is a known VPN.
+   */
+  async applyRestriction(
+    countryCode: string,
+    feature?: string,
+    isVPN = false,
+  ): Promise<ApplyRestrictionResultDto> {
+    const upper = countryCode.toUpperCase();
+    const strictVpn = this.configService.get<boolean>('GEO_STRICT_VPN', false);
+
+    const restrictions = await this.checkRestrictions(upper);
+    const fullBlock = restrictions.find((r) => r.restrictionType === RestrictionType.FULL_BLOCK);
+
+    if (fullBlock) {
+      throw new ForbiddenException(
+        fullBlock.reason ?? `Access from ${upper} is not permitted.`,
+      );
+    }
+
+    // VPN: if strict mode is on, treat VPN like an unknown country.
+    if (isVPN && strictVpn) {
+      throw new ForbiddenException('VPN usage is not permitted in strict compliance mode.');
+    }
+
+    if (feature) {
+      const featureBlock = restrictions.find(
+        (r) =>
+          r.restrictionType === RestrictionType.FEATURE_LIMIT &&
+          r.affectedFeatures?.includes(feature),
+      );
+
+      if (featureBlock) {
+        return {
+          allowed: false,
+          reason: featureBlock.reason ?? `Feature "${feature}" is not available in ${upper}.`,
+          restrictionType: RestrictionType.FEATURE_LIMIT,
+        };
+      }
+    }
+
+    const kycRequired = restrictions.some(
+      (r) => r.restrictionType === RestrictionType.KYC_REQUIRED,
+    );
+
+    return {
+      allowed: true,
+      restrictionType: kycRequired ? RestrictionType.KYC_REQUIRED : undefined,
+    };
+  }
+
+  // ── Admin: CRUD ────────────────────────────────────────────────────────────
+
+  async getBlockedCountries(): Promise<GeoRestriction[]> {
+    return this.restrictionRepo.find({ where: { isActive: true } });
+  }
+
+  async addRestriction(dto: CreateGeoRestrictionDto): Promise<GeoRestriction> {
+    const restriction = this.restrictionRepo.create({
+      ...dto,
+      countryCode: dto.countryCode.toUpperCase(),
+      isActive: true,
+    });
+    const saved = await this.restrictionRepo.save(restriction);
+    this.invalidateCache(saved.countryCode);
+    this.logger.log(`Added ${saved.restrictionType} restriction for ${saved.countryCode}`);
+    return saved;
+  }
+
+  async removeRestriction(id: string): Promise<void> {
+    const restriction = await this.restrictionRepo.findOne({ where: { id } });
+    if (!restriction) throw new NotFoundException(`Restriction ${id} not found`);
+
+    await this.restrictionRepo.update(id, { isActive: false });
+    this.invalidateCache(restriction.countryCode);
+    this.logger.log(`Removed restriction ${id} for ${restriction.countryCode}`);
+  }
+
+  // ── Geo record logging ─────────────────────────────────────────────────────
+
+  async logGeoRecord(
+    userId: string,
+    ipAddress: string,
+    detectedCountry: string,
+    isVPN = false,
+  ): Promise<UserGeoRecord> {
+    const record = this.geoRecordRepo.create({
+      userId,
+      ipAddress,
+      detectedCountry: detectedCountry.toUpperCase(),
+      isVPN,
+    });
+    return this.geoRecordRepo.save(record);
+  }
+
+  /**
+   * Build a user-facing restrictions summary for the given country.
+   */
+  async getMyRestrictions(
+    countryCode: string,
+    isVPN: boolean,
+  ): Promise<MyRestrictionsResponseDto> {
+    const upper = countryCode.toUpperCase();
+    const isOfac = OFAC_SANCTIONED_COUNTRIES.has(upper);
+
+    const restrictions = isOfac
+      ? [this.buildOfacEntry(upper)]
+      : await this.getRestrictionsForCountry(upper);
+
+    const isFullyBlocked =
+      isOfac || restrictions.some((r) => r.restrictionType === RestrictionType.FULL_BLOCK);
+
+    const blockedFeatures = restrictions
+      .filter((r) => r.restrictionType === RestrictionType.FEATURE_LIMIT)
+      .flatMap((r) => r.affectedFeatures ?? []);
+
+    const requiresKyc = restrictions.some(
+      (r) => r.restrictionType === RestrictionType.KYC_REQUIRED,
+    );
+
+    return {
+      countryCode: upper,
+      isVPN,
+      restrictions: restrictions.map(this.toResponseDto),
+      blockedFeatures: [...new Set(blockedFeatures)],
+      requiresKyc,
+      isFullyBlocked,
+    };
+  }
+
+  // ── Helpers ────────────────────────────────────────────────────────────────
+
+  private invalidateCache(countryCode: string): void {
+    this.cache.delete(countryCode.toUpperCase());
+  }
+
+  private buildOfacEntry(countryCode: string): GeoRestriction {
+    const entry = new GeoRestriction();
+    entry.id = 'ofac';
+    entry.countryCode = countryCode;
+    entry.restrictionType = RestrictionType.FULL_BLOCK;
+    entry.reason = `${countryCode} is subject to OFAC sanctions. Access is not permitted.`;
+    entry.isActive = true;
+    entry.createdAt = new Date(0);
+    return entry;
+  }
+
+  private toResponseDto(r: GeoRestriction): GeoRestrictionResponseDto {
+    return {
+      id: r.id,
+      countryCode: r.countryCode,
+      restrictionType: r.restrictionType,
+      affectedFeatures: r.affectedFeatures,
+      reason: r.reason,
+      isActive: r.isActive,
+      createdAt: r.createdAt,
+    };
+  }
+}

--- a/src/geo-restriction/guards/geo-feature.guard.ts
+++ b/src/geo-restriction/guards/geo-feature.guard.ts
@@ -1,0 +1,55 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  Injectable,
+  SetMetadata,
+  ForbiddenException,
+} from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { GeoRestrictionService } from '../geo-restriction.service';
+
+export const GEO_FEATURE_KEY = 'geoFeature';
+
+/**
+ * Decorator to mark an endpoint with a feature slug for geo-based
+ * feature-level restriction checks.
+ *
+ * @example
+ * @GeoFeature('payments')
+ * @Get('send')
+ * async sendPayment() { ... }
+ */
+export const GeoFeature = (feature: string) => SetMetadata(GEO_FEATURE_KEY, feature);
+
+/**
+ * Guard that enforces FEATURE_LIMIT restrictions for the decorated feature.
+ * Must be applied after GeoRestrictionMiddleware has set req.geoCountry.
+ */
+@Injectable()
+export class GeoFeatureGuard implements CanActivate {
+  constructor(
+    private readonly reflector: Reflector,
+    private readonly geoService: GeoRestrictionService,
+  ) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const feature = this.reflector.getAllAndOverride<string>(GEO_FEATURE_KEY, [
+      context.getHandler(),
+      context.getClass(),
+    ]);
+
+    if (!feature) return true; // No feature restriction on this endpoint.
+
+    const req = context.switchToHttp().getRequest();
+    const country: string = req.geoCountry ?? 'XX';
+    const isVPN: boolean = req.geoIsVPN ?? false;
+
+    const result = await this.geoService.applyRestriction(country, feature, isVPN);
+
+    if (!result.allowed) {
+      throw new ForbiddenException(result.reason ?? 'Feature not available in your region.');
+    }
+
+    return true;
+  }
+}

--- a/src/offline-queue/dto/offline-queue.dto.ts
+++ b/src/offline-queue/dto/offline-queue.dto.ts
@@ -1,0 +1,29 @@
+export class EnqueueMessageDto {
+  recipientId: string;
+  messageId: string;
+  conversationId: string;
+  payload: Record<string, unknown>;
+}
+
+export class QueueStatsDto {
+  /** Total QUEUED entries across all users (DB count). */
+  totalQueued: number;
+  /** Total DELIVERED entries (DB count). */
+  totalDelivered: number;
+  /** Total FAILED entries (DB count). */
+  totalFailed: number;
+  /** Users whose Redis queue depth exceeds the alert threshold. */
+  alertedUsers: Array<{ userId: string; depth: number }>;
+}
+
+export class UserQueueDepthDto {
+  userId: string;
+  redisDepth: number;
+  dbQueued: number;
+}
+
+export class FlushResultDto {
+  userId: string;
+  flushed: number;
+  failed: number;
+}

--- a/src/offline-queue/entities/offline-message-queue.entity.ts
+++ b/src/offline-queue/entities/offline-message-queue.entity.ts
@@ -1,0 +1,49 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  Index,
+} from 'typeorm';
+
+export enum QueueStatus {
+  QUEUED = 'QUEUED',
+  DELIVERED = 'DELIVERED',
+  FAILED = 'FAILED',
+}
+
+@Entity('offline_message_queue')
+@Index(['recipientId', 'status'])
+@Index(['recipientId', 'queuedAt'])
+export class OfflineMessageQueue {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ type: 'varchar' })
+  @Index()
+  recipientId: string;
+
+  @Column({ type: 'varchar' })
+  messageId: string;
+
+  @Column({ type: 'varchar' })
+  conversationId: string;
+
+  /**
+   * Full message payload persisted for durability (messages > 1 h in Redis).
+   */
+  @Column({ type: 'jsonb', nullable: true })
+  payload: Record<string, unknown> | null;
+
+  @CreateDateColumn()
+  queuedAt: Date;
+
+  @Column({ type: 'timestamp', nullable: true })
+  deliveredAt: Date | null;
+
+  @Column({ type: 'int', default: 0 })
+  attempts: number;
+
+  @Column({ type: 'varchar', default: QueueStatus.QUEUED })
+  status: QueueStatus;
+}

--- a/src/offline-queue/offline-queue.controller.ts
+++ b/src/offline-queue/offline-queue.controller.ts
@@ -1,0 +1,37 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Param,
+  HttpCode,
+  HttpStatus,
+} from '@nestjs/common';
+import { OfflineQueueService } from './offline-queue.service';
+import { QueueStatsDto, FlushResultDto } from './dto/offline-queue.dto';
+
+@Controller()
+export class OfflineQueueController {
+  constructor(private readonly offlineQueueService: OfflineQueueService) {}
+
+  /**
+   * GET /admin/offline-queue/stats
+   * Returns aggregate queue stats and any users over the alert threshold.
+   */
+  @Get('admin/offline-queue/stats')
+  async getStats(): Promise<QueueStatsDto> {
+    return this.offlineQueueService.getStats();
+  }
+
+  /**
+   * POST /admin/offline-queue/flush/:userId
+   * Force-flush a user's queue immediately (e.g. after support escalation).
+   * Since we do not have access to the live socket here we only flush the
+   * Postgres FAILED records back to QUEUED so the next reconnect picks them up.
+   */
+  @Post('admin/offline-queue/flush/:userId')
+  @HttpCode(HttpStatus.OK)
+  async forceFlush(@Param('userId') userId: string): Promise<FlushResultDto> {
+    const retried = await this.offlineQueueService.retryFailed(userId);
+    return { userId, flushed: 0, failed: retried };
+  }
+}

--- a/src/offline-queue/offline-queue.gateway.ts
+++ b/src/offline-queue/offline-queue.gateway.ts
@@ -1,0 +1,50 @@
+import { Logger } from '@nestjs/common';
+import {
+  WebSocketGateway,
+  WebSocketServer,
+  OnGatewayConnection,
+  ConnectedSocket,
+} from '@nestjs/websockets';
+import { Server, Socket } from 'socket.io';
+import { OfflineQueueService } from './offline-queue.service';
+
+/**
+ * Attaches to the shared /chat namespace.
+ * On every authenticated connection it flushes any queued offline messages
+ * in strict chronological order, bracketed by sync:start / sync:complete events.
+ *
+ * JWT verification is intentionally skipped here — the ChatGateway in the
+ * messaging module already rejects unauthenticated sockets before this handler
+ * runs (same namespace, socket.io fires connection handlers in registration order).
+ * We read the userId set by ChatGateway from client.data.user.sub.
+ */
+@WebSocketGateway({ namespace: '/chat', cors: { origin: '*' } })
+export class OfflineQueueGateway implements OnGatewayConnection {
+  @WebSocketServer()
+  server: Server;
+
+  private readonly logger = new Logger(OfflineQueueGateway.name);
+
+  constructor(private readonly offlineQueueService: OfflineQueueService) {}
+
+  async handleConnection(@ConnectedSocket() client: Socket): Promise<void> {
+    // Allow a short tick so ChatGateway (registered first) can authenticate and
+    // set client.data.user before we attempt to flush.
+    await new Promise((resolve) => setImmediate(resolve));
+
+    const userId: string | undefined = (client.data?.user as { sub?: string } | undefined)?.sub;
+    if (!userId) {
+      // Socket was not authenticated — ChatGateway will disconnect it.
+      return;
+    }
+
+    const depth = await this.offlineQueueService.getQueueDepth(userId);
+    if (depth === 0) return;
+
+    this.logger.log(
+      `[OfflineQueue] user=${userId} reconnected with ${depth} queued message(s) — flushing`,
+    );
+
+    await this.offlineQueueService.flushOnConnect(userId, this.server, client.id);
+  }
+}

--- a/src/offline-queue/offline-queue.module.ts
+++ b/src/offline-queue/offline-queue.module.ts
@@ -1,0 +1,39 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { ConfigModule, ConfigService } from '@nestjs/config';
+import { ScheduleModule } from '@nestjs/schedule';
+import Redis from 'ioredis';
+import { OfflineMessageQueue } from './entities/offline-message-queue.entity';
+import { OfflineQueueService } from './offline-queue.service';
+import { OfflineQueueGateway } from './offline-queue.gateway';
+import { OfflineQueueController } from './offline-queue.controller';
+
+@Module({
+  imports: [
+    ConfigModule,
+    ScheduleModule.forRoot(),
+    TypeOrmModule.forFeature([OfflineMessageQueue]),
+  ],
+  controllers: [OfflineQueueController],
+  providers: [
+    OfflineQueueService,
+    OfflineQueueGateway,
+    {
+      provide: 'OFFLINE_REDIS_CLIENT',
+      useFactory: (config: ConfigService): Redis => {
+        return new Redis({
+          host: config.get<string>('REDIS_HOST', 'localhost'),
+          port: config.get<number>('REDIS_PORT', 6379),
+          password: config.get<string>('REDIS_PASSWORD') || undefined,
+          db: config.get<number>('REDIS_OFFLINE_QUEUE_DB', 1),
+          lazyConnect: true,
+          maxRetriesPerRequest: 1,
+          enableOfflineQueue: false,
+        });
+      },
+      inject: [ConfigService],
+    },
+  ],
+  exports: [OfflineQueueService],
+})
+export class OfflineQueueModule {}

--- a/src/offline-queue/offline-queue.service.spec.ts
+++ b/src/offline-queue/offline-queue.service.spec.ts
@@ -1,0 +1,324 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { ConfigService } from '@nestjs/config';
+import { OfflineQueueService, QueuedMessage } from './offline-queue.service';
+import { OfflineMessageQueue, QueueStatus } from './entities/offline-message-queue.entity';
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeEntry(overrides: Partial<QueuedMessage> = {}): QueuedMessage {
+  return {
+    messageId: 'msg-1',
+    conversationId: 'conv-1',
+    payload: { content: 'hello' },
+    queuedAt: Date.now(),
+    ...overrides,
+  };
+}
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+
+const mockQueueRepo = {
+  count: jest.fn(),
+  findOne: jest.fn(),
+  create: jest.fn(),
+  save: jest.fn(),
+  update: jest.fn(),
+  delete: jest.fn(),
+  createQueryBuilder: jest.fn(),
+};
+
+const zsetStore: Map<string, Map<string, number>> = new Map();
+
+const mockRedis = {
+  zadd: jest.fn(async (key: string, score: number, value: string) => {
+    if (!zsetStore.has(key)) zsetStore.set(key, new Map());
+    zsetStore.get(key)!.set(value, score);
+    return 1;
+  }),
+  zcard: jest.fn(async (key: string) => zsetStore.get(key)?.size ?? 0),
+  zrangebyscore: jest.fn(async (key: string) => {
+    const set = zsetStore.get(key);
+    if (!set) return [];
+    return [...set.entries()]
+      .sort(([, a], [, b]) => a - b)
+      .map(([v]) => v);
+  }),
+  zrem: jest.fn(async (key: string, value: string) => {
+    zsetStore.get(key)?.delete(value);
+    return 1;
+  }),
+  scan: jest.fn(async () => ['0', []]),
+};
+
+const mockConfigService = {
+  get: jest.fn((key: string, def?: unknown) => def),
+};
+
+// ── Suite ─────────────────────────────────────────────────────────────────────
+
+describe('OfflineQueueService', () => {
+  let service: OfflineQueueService;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    zsetStore.clear();
+
+    // Set up createQueryBuilder chain
+    const qbMock = {
+      update: jest.fn().mockReturnThis(),
+      set: jest.fn().mockReturnThis(),
+      where: jest.fn().mockReturnThis(),
+      execute: jest.fn().mockResolvedValue({}),
+    };
+    mockQueueRepo.createQueryBuilder.mockReturnValue(qbMock);
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        OfflineQueueService,
+        { provide: getRepositoryToken(OfflineMessageQueue), useValue: mockQueueRepo },
+        { provide: 'OFFLINE_REDIS_CLIENT', useValue: mockRedis },
+        { provide: ConfigService, useValue: mockConfigService },
+      ],
+    }).compile();
+
+    service = module.get(OfflineQueueService);
+  });
+
+  // ── enqueue ────────────────────────────────────────────────────────────────
+
+  describe('enqueue', () => {
+    it('adds an entry to the Redis sorted set', async () => {
+      await service.enqueue({
+        recipientId: 'user-1',
+        messageId: 'msg-1',
+        conversationId: 'conv-1',
+        payload: { text: 'hi' },
+      });
+
+      expect(mockRedis.zadd).toHaveBeenCalledTimes(1);
+      const [key, , value] = mockRedis.zadd.mock.calls[0] as [string, number, string];
+      expect(key).toBe('offline:queue:user-1');
+      const parsed = JSON.parse(value) as QueuedMessage;
+      expect(parsed.messageId).toBe('msg-1');
+    });
+
+    it('checks queue depth and warns if > 1000', async () => {
+      // Pre-fill zsetStore with 1001 entries
+      const set = new Map<string, number>();
+      for (let i = 0; i < 1001; i++) set.set(`entry-${i}`, i);
+      zsetStore.set('offline:queue:user-big', set);
+
+      const warnSpy = jest.spyOn((service as any).logger, 'warn').mockImplementation(() => {});
+      await service.enqueue({
+        recipientId: 'user-big',
+        messageId: 'new-msg',
+        conversationId: 'conv-1',
+        payload: {},
+      });
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('ALERT'));
+    });
+  });
+
+  // ── dequeueForUser ─────────────────────────────────────────────────────────
+
+  describe('dequeueForUser', () => {
+    it('returns entries in chronological order', async () => {
+      const older = makeEntry({ messageId: 'msg-old', queuedAt: 1000 });
+      const newer = makeEntry({ messageId: 'msg-new', queuedAt: 2000 });
+
+      const set = new Map<string, number>();
+      set.set(JSON.stringify(newer), 2000);
+      set.set(JSON.stringify(older), 1000);
+      zsetStore.set('offline:queue:user-1', set);
+
+      const result = await service.dequeueForUser('user-1');
+      expect(result[0].messageId).toBe('msg-old');
+      expect(result[1].messageId).toBe('msg-new');
+    });
+
+    it('returns empty array for unknown user', async () => {
+      const result = await service.dequeueForUser('unknown');
+      expect(result).toEqual([]);
+    });
+  });
+
+  // ── markDelivered ──────────────────────────────────────────────────────────
+
+  describe('markDelivered', () => {
+    it('removes the entry from Redis and updates Postgres', async () => {
+      const entry = makeEntry({ messageId: 'msg-1' });
+      const set = new Map([[JSON.stringify(entry), entry.queuedAt]]);
+      zsetStore.set('offline:queue:user-1', set);
+
+      mockQueueRepo.update.mockResolvedValue({ affected: 1 });
+      await service.markDelivered('user-1', 'msg-1');
+
+      expect(mockRedis.zrem).toHaveBeenCalled();
+      expect(mockQueueRepo.update).toHaveBeenCalledWith(
+        expect.objectContaining({ recipientId: 'user-1', messageId: 'msg-1' }),
+        expect.objectContaining({ status: QueueStatus.DELIVERED }),
+      );
+    });
+
+    it('is a no-op for messages not in the queue', async () => {
+      mockQueueRepo.update.mockResolvedValue({ affected: 0 });
+      await service.markDelivered('user-1', 'msg-not-exist');
+      expect(mockRedis.zrem).not.toHaveBeenCalled();
+    });
+  });
+
+  // ── retryFailed ────────────────────────────────────────────────────────────
+
+  describe('retryFailed', () => {
+    it('resets FAILED records to QUEUED and returns count', async () => {
+      mockQueueRepo.update.mockResolvedValue({ affected: 3 });
+      const count = await service.retryFailed('user-1');
+      expect(count).toBe(3);
+      expect(mockQueueRepo.update).toHaveBeenCalledWith(
+        expect.objectContaining({ status: QueueStatus.FAILED }),
+        expect.objectContaining({ status: QueueStatus.QUEUED }),
+      );
+    });
+  });
+
+  // ── getQueueDepth ──────────────────────────────────────────────────────────
+
+  describe('getQueueDepth', () => {
+    it('returns Redis zcard for the user key', async () => {
+      const set = new Map<string, number>([['a', 1], ['b', 2]]);
+      zsetStore.set('offline:queue:user-2', set);
+
+      const depth = await service.getQueueDepth('user-2');
+      expect(depth).toBe(2);
+    });
+
+    it('returns 0 for user with no queue', async () => {
+      expect(await service.getQueueDepth('nobody')).toBe(0);
+    });
+  });
+
+  // ── flushOnConnect ─────────────────────────────────────────────────────────
+
+  describe('flushOnConnect', () => {
+    function buildMockServer(socketId: string) {
+      const emitFn = jest.fn();
+      const server = {
+        to: jest.fn().mockReturnValue({ emit: emitFn }),
+      } as unknown as import('socket.io').Server;
+      return { server, emitFn };
+    }
+
+    it('emits sync:start and sync:complete with correct counts', async () => {
+      const entry = makeEntry({ messageId: 'msg-1' });
+      const set = new Map([[JSON.stringify(entry), entry.queuedAt]]);
+      zsetStore.set('offline:queue:user-1', set);
+
+      mockQueueRepo.update.mockResolvedValue({ affected: 1 });
+
+      const { server, emitFn } = buildMockServer('socket-abc');
+      await service.flushOnConnect('user-1', server, 'socket-abc');
+
+      const eventNames = emitFn.mock.calls.map((c: unknown[]) => c[0]);
+      expect(eventNames).toContain('sync:start');
+      expect(eventNames).toContain('message:queued');
+      expect(eventNames).toContain('sync:complete');
+    });
+
+    it('returns flushed=0, failed=0 when queue is empty', async () => {
+      const { server } = buildMockServer('socket-abc');
+      const result = await service.flushOnConnect('user-empty', server, 'socket-abc');
+      expect(result).toEqual({ userId: 'user-empty', flushed: 0, failed: 0 });
+    });
+
+    it('includes replayed=true in each emitted message', async () => {
+      const entry = makeEntry({ messageId: 'msg-replay' });
+      const set = new Map([[JSON.stringify(entry), entry.queuedAt]]);
+      zsetStore.set('offline:queue:user-1', set);
+
+      mockQueueRepo.update.mockResolvedValue({ affected: 1 });
+
+      const { server, emitFn } = buildMockServer('socket-abc');
+      await service.flushOnConnect('user-1', server, 'socket-abc');
+
+      const msgCall = emitFn.mock.calls.find((c: unknown[]) => c[0] === 'message:queued');
+      expect(msgCall).toBeDefined();
+      expect((msgCall as unknown[])[1]).toMatchObject({ replayed: true, messageId: 'msg-replay' });
+    });
+  });
+
+  // ── pruneOld ───────────────────────────────────────────────────────────────
+
+  describe('pruneOld', () => {
+    it('deletes DELIVERED records older than 30 days', async () => {
+      mockQueueRepo.delete.mockResolvedValue({ affected: 5 });
+      const removed = await service.pruneOld();
+      expect(removed).toBe(5);
+      expect(mockQueueRepo.delete).toHaveBeenCalledWith(
+        expect.objectContaining({ status: QueueStatus.DELIVERED }),
+      );
+    });
+
+    it('returns 0 when nothing to prune', async () => {
+      mockQueueRepo.delete.mockResolvedValue({ affected: 0 });
+      expect(await service.pruneOld()).toBe(0);
+    });
+  });
+
+  // ── getStats ───────────────────────────────────────────────────────────────
+
+  describe('getStats', () => {
+    it('returns counts from repo and empty alertedUsers when no overflows', async () => {
+      mockQueueRepo.count.mockResolvedValueOnce(10); // queued
+      mockQueueRepo.count.mockResolvedValueOnce(200); // delivered
+      mockQueueRepo.count.mockResolvedValueOnce(3);  // failed
+      mockRedis.scan.mockResolvedValueOnce(['0', []]);
+
+      const stats = await service.getStats();
+      expect(stats.totalQueued).toBe(10);
+      expect(stats.totalDelivered).toBe(200);
+      expect(stats.totalFailed).toBe(3);
+      expect(stats.alertedUsers).toEqual([]);
+    });
+
+    it('includes alerted users when Redis depth > 1000', async () => {
+      mockQueueRepo.count.mockResolvedValue(0);
+      mockRedis.scan.mockResolvedValueOnce(['0', ['offline:queue:user-heavy']]);
+      // Override zcard for this test
+      mockRedis.zcard.mockResolvedValueOnce(1500);
+
+      const stats = await service.getStats();
+      expect(stats.alertedUsers).toHaveLength(1);
+      expect(stats.alertedUsers[0].userId).toBe('user-heavy');
+      expect(stats.alertedUsers[0].depth).toBe(1500);
+    });
+  });
+
+  // ── persistStaleRedisEntries ───────────────────────────────────────────────
+
+  describe('persistStaleRedisEntries', () => {
+    it('persists stale entries to Postgres if not already saved', async () => {
+      const entry = makeEntry({ messageId: 'stale-msg', queuedAt: Date.now() - 2 * 60 * 60 * 1000 });
+      mockRedis.scan.mockResolvedValueOnce(['0', ['offline:queue:user-1']]);
+      mockRedis.zrangebyscore = jest.fn().mockResolvedValueOnce([JSON.stringify(entry)]);
+      mockQueueRepo.findOne.mockResolvedValue(null);
+      mockQueueRepo.create.mockReturnValue({});
+      mockQueueRepo.save.mockResolvedValue({});
+
+      await service.persistStaleRedisEntries();
+
+      expect(mockQueueRepo.save).toHaveBeenCalledTimes(1);
+    });
+
+    it('skips entries already in Postgres', async () => {
+      const entry = makeEntry({ messageId: 'stale-msg', queuedAt: Date.now() - 2 * 60 * 60 * 1000 });
+      mockRedis.scan.mockResolvedValueOnce(['0', ['offline:queue:user-1']]);
+      mockRedis.zrangebyscore = jest.fn().mockResolvedValueOnce([JSON.stringify(entry)]);
+      mockQueueRepo.findOne.mockResolvedValue({ id: 'existing' });
+
+      await service.persistStaleRedisEntries();
+
+      expect(mockQueueRepo.save).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/offline-queue/offline-queue.service.ts
+++ b/src/offline-queue/offline-queue.service.ts
@@ -1,0 +1,301 @@
+import { Injectable, Logger, Inject } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository, LessThan } from 'typeorm';
+import { Cron, CronExpression } from '@nestjs/schedule';
+import { ConfigService } from '@nestjs/config';
+import Redis from 'ioredis';
+import { Server, Socket } from 'socket.io';
+import { OfflineMessageQueue, QueueStatus } from './entities/offline-message-queue.entity';
+import { EnqueueMessageDto, QueueStatsDto, FlushResultDto } from './dto/offline-queue.dto';
+
+/** Redis sorted-set key for a user's offline queue. Score = epoch ms. */
+const redisKey = (userId: string) => `offline:queue:${userId}`;
+
+/** Messages older than this in Redis are also flushed to Postgres for durability. */
+const ONE_HOUR_MS = 60 * 60 * 1000;
+
+/** Alert threshold: if any user's queue exceeds this, log a warning (and expose via stats). */
+const ALERT_THRESHOLD = 1000;
+
+export interface QueuedMessage {
+  messageId: string;
+  conversationId: string;
+  payload: Record<string, unknown>;
+  queuedAt: number; // epoch ms
+}
+
+@Injectable()
+export class OfflineQueueService {
+  private readonly logger = new Logger(OfflineQueueService.name);
+
+  constructor(
+    @InjectRepository(OfflineMessageQueue)
+    private readonly queueRepo: Repository<OfflineMessageQueue>,
+    @Inject('OFFLINE_REDIS_CLIENT')
+    private readonly redis: Redis,
+    private readonly config: ConfigService,
+  ) {}
+
+  // ── Core queue operations ──────────────────────────────────────────────────
+
+  /**
+   * Enqueue a message for an offline recipient.
+   * Stores in Redis sorted set (score = timestamp). If the message has been
+   * in Redis for over 1 hour it will be persisted to Postgres by the cron job.
+   */
+  async enqueue(dto: EnqueueMessageDto): Promise<void> {
+    const now = Date.now();
+    const entry: QueuedMessage = {
+      messageId: dto.messageId,
+      conversationId: dto.conversationId,
+      payload: dto.payload,
+      queuedAt: now,
+    };
+
+    const key = redisKey(dto.recipientId);
+    await this.redis.zadd(key, now, JSON.stringify(entry));
+
+    const depth = await this.redis.zcard(key);
+    if (depth > ALERT_THRESHOLD) {
+      this.logger.warn(
+        `[OfflineQueue] ALERT: user=${dto.recipientId} queue depth=${depth} exceeds ${ALERT_THRESHOLD}`,
+      );
+    }
+
+    this.logger.debug(
+      `[OfflineQueue] enqueued messageId=${dto.messageId} for userId=${dto.recipientId}`,
+    );
+  }
+
+  /**
+   * Return all queued messages for a user in chronological order (lowest score first).
+   * Does NOT remove them — call markDelivered() after successful delivery.
+   */
+  async dequeueForUser(userId: string): Promise<QueuedMessage[]> {
+    const raw = await this.redis.zrangebyscore(redisKey(userId), '-inf', '+inf');
+    return raw.map((s) => JSON.parse(s) as QueuedMessage);
+  }
+
+  /**
+   * Mark a specific message as delivered: remove from Redis and upsert in Postgres.
+   */
+  async markDelivered(userId: string, messageId: string): Promise<void> {
+    // Remove from Redis sorted set by value scan
+    const raw = await this.redis.zrangebyscore(redisKey(userId), '-inf', '+inf');
+    for (const s of raw) {
+      const entry = JSON.parse(s) as QueuedMessage;
+      if (entry.messageId === messageId) {
+        await this.redis.zrem(redisKey(userId), s);
+        break;
+      }
+    }
+
+    // Update Postgres record if it exists
+    await this.queueRepo.update(
+      { recipientId: userId, messageId, status: QueueStatus.QUEUED },
+      { status: QueueStatus.DELIVERED, deliveredAt: new Date() },
+    );
+  }
+
+  /**
+   * Retry FAILED records: reset status to QUEUED so the next flush attempt picks them up.
+   */
+  async retryFailed(userId: string): Promise<number> {
+    const result = await this.queueRepo.update(
+      { recipientId: userId, status: QueueStatus.FAILED },
+      { status: QueueStatus.QUEUED, attempts: 0 },
+    );
+    const count = result.affected ?? 0;
+    this.logger.log(`[OfflineQueue] retried ${count} failed records for userId=${userId}`);
+    return count;
+  }
+
+  /**
+   * Return the current Redis queue depth for a user.
+   */
+  async getQueueDepth(userId: string): Promise<number> {
+    return this.redis.zcard(redisKey(userId));
+  }
+
+  /**
+   * Flush all queued messages to an online socket in chronological order.
+   * Emits sync:start → messages → sync:complete.
+   */
+  async flushOnConnect(userId: string, client: Socket | Server, targetSocketId?: string): Promise<FlushResultDto> {
+    const messages = await this.dequeueForUser(userId);
+    const total = messages.length;
+
+    if (total === 0) {
+      return { userId, flushed: 0, failed: 0 };
+    }
+
+    // Determine the emit target
+    const emitTarget = targetSocketId
+      ? (client as Server).to(targetSocketId)
+      : (client as Socket);
+
+    // ── sync:start ──────────────────────────────────────────────────────────
+    emitTarget.emit('sync:start', {
+      userId,
+      pendingCount: total,
+      timestamp: Date.now(),
+    });
+
+    let flushed = 0;
+    let failed = 0;
+
+    for (const msg of messages) {
+      try {
+        emitTarget.emit('message:queued', {
+          ...msg.payload,
+          messageId: msg.messageId,
+          conversationId: msg.conversationId,
+          queuedAt: msg.queuedAt,
+          replayed: true,
+        });
+
+        await this.markDelivered(userId, msg.messageId);
+        flushed++;
+      } catch (err) {
+        failed++;
+        this.logger.error(
+          `[OfflineQueue] failed to deliver messageId=${msg.messageId} to userId=${userId}: ${(err as Error).message}`,
+        );
+
+        // Increment attempt counter in Postgres if persisted
+        await this.queueRepo
+          .createQueryBuilder()
+          .update(OfflineMessageQueue)
+          .set({
+            attempts: () => 'attempts + 1',
+            status: QueueStatus.FAILED,
+          })
+          .where('recipientId = :userId AND messageId = :messageId', {
+            userId,
+            messageId: msg.messageId,
+          })
+          .execute()
+          .catch(() => undefined); // silently ignore if not persisted yet
+      }
+    }
+
+    // ── sync:complete ────────────────────────────────────────────────────────
+    emitTarget.emit('sync:complete', {
+      userId,
+      flushed,
+      failed,
+      timestamp: Date.now(),
+    });
+
+    this.logger.log(
+      `[OfflineQueue] flush complete userId=${userId} flushed=${flushed} failed=${failed}`,
+    );
+
+    return { userId, flushed, failed };
+  }
+
+  /**
+   * Prune DELIVERED records older than 30 days from Postgres.
+   */
+  async pruneOld(): Promise<number> {
+    const cutoff = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
+    const result = await this.queueRepo.delete({
+      status: QueueStatus.DELIVERED,
+      deliveredAt: LessThan(cutoff),
+    });
+    const removed = result.affected ?? 0;
+    if (removed > 0) {
+      this.logger.log(`[OfflineQueue] pruned ${removed} delivered records older than 30 days`);
+    }
+    return removed;
+  }
+
+  // ── Durability: Redis → Postgres for long-lived messages ──────────────────
+
+  /**
+   * Persist any Redis-queued messages older than 1 hour to Postgres for durability.
+   * Called by cron every 10 minutes.
+   */
+  async persistStaleRedisEntries(): Promise<void> {
+    // Scan all offline:queue:* keys
+    const pattern = 'offline:queue:*';
+    let cursor = '0';
+    let persisted = 0;
+
+    do {
+      const [next, keys] = await this.redis.scan(cursor, 'MATCH', pattern, 'COUNT', 100);
+      cursor = next;
+
+      for (const key of keys) {
+        const userId = key.replace('offline:queue:', '');
+        const cutoff = Date.now() - ONE_HOUR_MS;
+        // Get entries with score < cutoff (older than 1 hour)
+        const raw = await this.redis.zrangebyscore(key, '-inf', cutoff);
+
+        for (const s of raw) {
+          const entry = JSON.parse(s) as QueuedMessage;
+          const existing = await this.queueRepo.findOne({
+            where: { recipientId: userId, messageId: entry.messageId },
+          });
+
+          if (!existing) {
+            await this.queueRepo.save(
+              this.queueRepo.create({
+                recipientId: userId,
+                messageId: entry.messageId,
+                conversationId: entry.conversationId,
+                payload: entry.payload,
+                queuedAt: new Date(entry.queuedAt),
+                status: QueueStatus.QUEUED,
+                attempts: 0,
+              }),
+            );
+            persisted++;
+          }
+        }
+      }
+    } while (cursor !== '0');
+
+    if (persisted > 0) {
+      this.logger.log(`[OfflineQueue] persisted ${persisted} stale Redis entries to Postgres`);
+    }
+  }
+
+  // ── Admin helpers ──────────────────────────────────────────────────────────
+
+  async getStats(): Promise<QueueStatsDto> {
+    const [totalQueued, totalDelivered, totalFailed] = await Promise.all([
+      this.queueRepo.count({ where: { status: QueueStatus.QUEUED } }),
+      this.queueRepo.count({ where: { status: QueueStatus.DELIVERED } }),
+      this.queueRepo.count({ where: { status: QueueStatus.FAILED } }),
+    ]);
+
+    // Check live Redis queue depths for alert
+    const alertedUsers: Array<{ userId: string; depth: number }> = [];
+    let cursor = '0';
+    do {
+      const [next, keys] = await this.redis.scan(cursor, 'MATCH', 'offline:queue:*', 'COUNT', 100);
+      cursor = next;
+      for (const key of keys) {
+        const depth = await this.redis.zcard(key);
+        if (depth > ALERT_THRESHOLD) {
+          alertedUsers.push({ userId: key.replace('offline:queue:', ''), depth });
+        }
+      }
+    } while (cursor !== '0');
+
+    return { totalQueued, totalDelivered, totalFailed, alertedUsers };
+  }
+
+  // ── Scheduled jobs ─────────────────────────────────────────────────────────
+
+  @Cron(CronExpression.EVERY_10_MINUTES)
+  async scheduledPersistStale(): Promise<void> {
+    await this.persistStaleRedisEntries();
+  }
+
+  @Cron(CronExpression.EVERY_DAY_AT_2AM)
+  async scheduledPrune(): Promise<void> {
+    await this.pruneOld();
+  }
+}

--- a/src/stellar-history-importer/dto/import-status.dto.ts
+++ b/src/stellar-history-importer/dto/import-status.dto.ts
@@ -1,0 +1,21 @@
+import { ImportJobStatus } from '../entities/history-import-job.entity';
+
+export class ImportStatusDto {
+  jobId!: string;
+  walletId!: string;
+  status!: ImportJobStatus;
+  totalImported!: number;
+  cursor?: string;
+  errorMessage?: string;
+  startedAt!: Date;
+  completedAt?: Date;
+}
+
+export class TriggerImportResponseDto {
+  jobId!: string;
+  message!: string;
+}
+
+export class TriggerImportBodyDto {
+  walletAddress!: string;
+}

--- a/src/stellar-history-importer/entities/history-import-job.entity.ts
+++ b/src/stellar-history-importer/entities/history-import-job.entity.ts
@@ -1,0 +1,48 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  Index,
+} from 'typeorm';
+
+export enum ImportJobStatus {
+  PENDING = 'PENDING',
+  RUNNING = 'RUNNING',
+  COMPLETED = 'COMPLETED',
+  FAILED = 'FAILED',
+}
+
+@Entity('stellar_history_import_jobs')
+@Index('idx_import_jobs_wallet_id', ['walletId'])
+@Index('idx_import_jobs_status', ['status'])
+export class HistoryImportJob {
+  @PrimaryGeneratedColumn('uuid')
+  id!: string;
+
+  @Column({ type: 'uuid' })
+  walletId!: string;
+
+  @Column({
+    type: 'enum',
+    enum: ImportJobStatus,
+    default: ImportJobStatus.PENDING,
+  })
+  status!: ImportJobStatus;
+
+  @Column({ type: 'int', default: 0 })
+  totalImported!: number;
+
+  /** Horizon paging_token of the last successfully imported transaction. */
+  @Column({ length: 100, nullable: true })
+  cursor?: string;
+
+  @Column({ type: 'text', nullable: true })
+  errorMessage?: string;
+
+  @CreateDateColumn()
+  startedAt!: Date;
+
+  @Column({ type: 'timestamp', nullable: true })
+  completedAt?: Date;
+}

--- a/src/stellar-history-importer/listeners/wallet-verified.listener.ts
+++ b/src/stellar-history-importer/listeners/wallet-verified.listener.ts
@@ -1,0 +1,25 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { OnEvent } from '@nestjs/event-emitter';
+import { StellarHistoryImporterService } from '../stellar-history-importer.service';
+
+export interface WalletVerifiedEvent {
+  walletId: string;
+  walletAddress: string;
+}
+
+/**
+ * Listens for wallet.verified events emitted after a wallet is connected
+ * and automatically queues a full history import job.
+ */
+@Injectable()
+export class WalletVerifiedListener {
+  private readonly logger = new Logger(WalletVerifiedListener.name);
+
+  constructor(private readonly importerService: StellarHistoryImporterService) {}
+
+  @OnEvent('wallet.verified')
+  async handleWalletVerified(event: WalletVerifiedEvent): Promise<void> {
+    this.logger.log(`wallet.verified — queuing import for wallet ${event.walletId}`);
+    await this.importerService.triggerImport(event.walletId, event.walletAddress);
+  }
+}

--- a/src/stellar-history-importer/processors/history-import.processor.ts
+++ b/src/stellar-history-importer/processors/history-import.processor.ts
@@ -1,0 +1,27 @@
+import { Processor, WorkerHost } from '@nestjs/bullmq';
+import { Logger } from '@nestjs/common';
+import { Job } from 'bullmq';
+import { StellarHistoryImporterService } from '../stellar-history-importer.service';
+
+export const HISTORY_IMPORT_QUEUE = 'stellar-history-import';
+
+export interface HistoryImportJobData {
+  jobId: string;
+  walletId: string;
+  walletAddress: string;
+}
+
+@Processor(HISTORY_IMPORT_QUEUE)
+export class HistoryImportProcessor extends WorkerHost {
+  private readonly logger = new Logger(HistoryImportProcessor.name);
+
+  constructor(private readonly importerService: StellarHistoryImporterService) {
+    super();
+  }
+
+  async process(job: Job<HistoryImportJobData>): Promise<void> {
+    const { jobId, walletId, walletAddress } = job.data;
+    this.logger.log(`Processing import job ${jobId} for wallet ${walletId}`);
+    await this.importerService.importHistory(jobId, walletId, walletAddress);
+  }
+}

--- a/src/stellar-history-importer/stellar-history-importer.controller.ts
+++ b/src/stellar-history-importer/stellar-history-importer.controller.ts
@@ -1,0 +1,43 @@
+import {
+  Controller,
+  Post,
+  Get,
+  Param,
+  Body,
+  HttpCode,
+  HttpStatus,
+} from '@nestjs/common';
+import { StellarHistoryImporterService } from './stellar-history-importer.service';
+import {
+  ImportStatusDto,
+  TriggerImportBodyDto,
+  TriggerImportResponseDto,
+} from './dto/import-status.dto';
+
+@Controller('wallets')
+export class StellarHistoryImporterController {
+  constructor(private readonly importerService: StellarHistoryImporterService) {}
+
+  /**
+   * POST /wallets/:id/import-history
+   * Trigger a full Stellar transaction history import for the given wallet.
+   */
+  @Post(':id/import-history')
+  @HttpCode(HttpStatus.ACCEPTED)
+  async triggerImport(
+    @Param('id') walletId: string,
+    @Body() body: TriggerImportBodyDto,
+  ): Promise<TriggerImportResponseDto> {
+    const job = await this.importerService.triggerImport(walletId, body.walletAddress);
+    return { jobId: job.id, message: 'History import queued successfully' };
+  }
+
+  /**
+   * GET /wallets/:id/import-status
+   * Return the latest import job status for the given wallet.
+   */
+  @Get(':id/import-status')
+  async getImportStatus(@Param('id') walletId: string): Promise<ImportStatusDto> {
+    return this.importerService.getImportStatus(walletId);
+  }
+}

--- a/src/stellar-history-importer/stellar-history-importer.module.ts
+++ b/src/stellar-history-importer/stellar-history-importer.module.ts
@@ -1,0 +1,30 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { BullModule } from '@nestjs/bullmq';
+import { ConfigModule } from '@nestjs/config';
+import { EventEmitterModule } from '@nestjs/event-emitter';
+import { HistoryImportJob } from './entities/history-import-job.entity';
+import { StellarHistoryImporterService } from './stellar-history-importer.service';
+import { StellarHistoryImporterController } from './stellar-history-importer.controller';
+import {
+  HistoryImportProcessor,
+  HISTORY_IMPORT_QUEUE,
+} from './processors/history-import.processor';
+import { WalletVerifiedListener } from './listeners/wallet-verified.listener';
+
+@Module({
+  imports: [
+    ConfigModule,
+    EventEmitterModule.forRoot(),
+    TypeOrmModule.forFeature([HistoryImportJob]),
+    BullModule.registerQueue({ name: HISTORY_IMPORT_QUEUE }),
+  ],
+  controllers: [StellarHistoryImporterController],
+  providers: [
+    StellarHistoryImporterService,
+    HistoryImportProcessor,
+    WalletVerifiedListener,
+  ],
+  exports: [StellarHistoryImporterService],
+})
+export class StellarHistoryImporterModule {}

--- a/src/stellar-history-importer/stellar-history-importer.service.spec.ts
+++ b/src/stellar-history-importer/stellar-history-importer.service.spec.ts
@@ -1,0 +1,316 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { getQueueToken } from '@nestjs/bullmq';
+import { ConfigService } from '@nestjs/config';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import { NotFoundException } from '@nestjs/common';
+import {
+  StellarHistoryImporterService,
+  StellarTxRecord,
+} from './stellar-history-importer.service';
+import {
+  HistoryImportJob,
+  ImportJobStatus,
+} from './entities/history-import-job.entity';
+import { HISTORY_IMPORT_QUEUE } from './processors/history-import.processor';
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeTx(hash: string): StellarTxRecord {
+  return {
+    txHash: hash,
+    ledger: 1000,
+    createdAt: '2024-01-01T00:00:00Z',
+    sourceAccount: 'GABCDE',
+    feeCharged: '100',
+    operationCount: 1,
+    successful: true,
+    envelopeXdr: 'envelope',
+    resultXdr: 'result',
+  };
+}
+
+function makeJob(overrides: Partial<HistoryImportJob> = {}): HistoryImportJob {
+  return {
+    id: 'job-uuid',
+    walletId: 'wallet-uuid',
+    status: ImportJobStatus.PENDING,
+    totalImported: 0,
+    cursor: undefined,
+    errorMessage: undefined,
+    startedAt: new Date('2024-01-01'),
+    completedAt: undefined,
+    ...overrides,
+  } as HistoryImportJob;
+}
+
+// ── Mocks ────────────────────────────────────────────────────────────────────
+
+const mockJobRepo = {
+  create: jest.fn(),
+  save: jest.fn(),
+  findOne: jest.fn(),
+  update: jest.fn(),
+  manager: { query: jest.fn() },
+};
+
+const mockQueue = { add: jest.fn() };
+const mockEventEmitter = { emit: jest.fn() };
+const mockConfigService = {
+  get: jest.fn((key: string, def?: string) =>
+    key === 'STELLAR_HORIZON_URL' ? 'https://horizon-testnet.stellar.org' : def,
+  ),
+};
+
+// ── Suite ─────────────────────────────────────────────────────────────────────
+
+describe('StellarHistoryImporterService', () => {
+  let service: StellarHistoryImporterService;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        StellarHistoryImporterService,
+        { provide: getRepositoryToken(HistoryImportJob), useValue: mockJobRepo },
+        { provide: getQueueToken(HISTORY_IMPORT_QUEUE), useValue: mockQueue },
+        { provide: EventEmitter2, useValue: mockEventEmitter },
+        { provide: ConfigService, useValue: mockConfigService },
+      ],
+    }).compile();
+
+    service = module.get(StellarHistoryImporterService);
+    jest.spyOn(service['logger'], 'log').mockImplementation(() => undefined);
+    jest.spyOn(service['logger'], 'error').mockImplementation(() => undefined);
+  });
+
+  // ── triggerImport ──────────────────────────────────────────────────────────
+
+  describe('triggerImport', () => {
+    it('creates a PENDING job and enqueues it', async () => {
+      const job = makeJob();
+      mockJobRepo.create.mockReturnValue(job);
+      mockJobRepo.save.mockResolvedValue(job);
+      mockJobRepo.update.mockResolvedValue(undefined);
+      mockQueue.add.mockResolvedValue(undefined);
+
+      const result = await service.triggerImport('wallet-uuid', 'GABC');
+
+      expect(mockJobRepo.update).toHaveBeenCalledWith(
+        { walletId: 'wallet-uuid', status: ImportJobStatus.RUNNING },
+        expect.objectContaining({ status: ImportJobStatus.FAILED }),
+      );
+      expect(mockJobRepo.create).toHaveBeenCalledWith(
+        expect.objectContaining({ walletId: 'wallet-uuid', status: ImportJobStatus.PENDING }),
+      );
+      expect(mockQueue.add).toHaveBeenCalledWith(
+        'import',
+        { jobId: job.id, walletId: 'wallet-uuid', walletAddress: 'GABC' },
+        expect.any(Object),
+      );
+      expect(result).toBe(job);
+    });
+  });
+
+  // ── importHistory ──────────────────────────────────────────────────────────
+
+  describe('importHistory', () => {
+    it('marks job RUNNING then COMPLETED when no transactions found', async () => {
+      mockJobRepo.findOne.mockResolvedValue(makeJob());
+      mockJobRepo.update.mockResolvedValue(undefined);
+      jest.spyOn(service, 'fetchTransactionPage').mockResolvedValue([]);
+
+      await service.importHistory('job-uuid', 'wallet-uuid', 'GABC');
+
+      expect(mockJobRepo.update).toHaveBeenCalledWith('job-uuid', {
+        status: ImportJobStatus.RUNNING,
+      });
+      expect(mockJobRepo.update).toHaveBeenCalledWith(
+        'job-uuid',
+        expect.objectContaining({ status: ImportJobStatus.COMPLETED }),
+      );
+      expect(mockEventEmitter.emit).toHaveBeenCalledWith(
+        'wallet.history.imported',
+        expect.objectContaining({ walletId: 'wallet-uuid' }),
+      );
+    });
+
+    it('imports all pages and persists them', async () => {
+      const page1 = [makeTx('hash1'), makeTx('hash2')];
+      mockJobRepo.findOne.mockResolvedValue(makeJob());
+      mockJobRepo.update.mockResolvedValue(undefined);
+      jest
+        .spyOn(service, 'fetchTransactionPage')
+        .mockResolvedValueOnce(page1)
+        .mockResolvedValueOnce([]);
+      jest.spyOn(service, 'deduplicateByTxHash').mockResolvedValue(page1);
+      jest.spyOn(service as any, 'persistTransactions').mockResolvedValue(undefined);
+
+      await service.importHistory('job-uuid', 'wallet-uuid', 'GABC');
+
+      expect((service as any).persistTransactions).toHaveBeenCalledWith('wallet-uuid', page1);
+      expect(mockJobRepo.update).toHaveBeenCalledWith(
+        'job-uuid',
+        expect.objectContaining({ status: ImportJobStatus.COMPLETED, totalImported: 2 }),
+      );
+    });
+
+    it('marks job FAILED and rethrows on error', async () => {
+      mockJobRepo.findOne.mockResolvedValue(makeJob());
+      mockJobRepo.update.mockResolvedValue(undefined);
+      jest.spyOn(service, 'fetchTransactionPage').mockRejectedValue(new Error('horizon down'));
+
+      await expect(service.importHistory('job-uuid', 'wallet-uuid', 'GABC')).rejects.toThrow(
+        'horizon down',
+      );
+      expect(mockJobRepo.update).toHaveBeenCalledWith(
+        'job-uuid',
+        expect.objectContaining({ status: ImportJobStatus.FAILED }),
+      );
+    });
+
+    it('throws NotFoundException for unknown job', async () => {
+      mockJobRepo.findOne.mockResolvedValue(null);
+      await expect(service.importHistory('bad', 'wallet-uuid', 'GABC')).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
+    it('resumes from saved cursor on retry', async () => {
+      mockJobRepo.findOne.mockResolvedValue(makeJob({ cursor: 'cursor-abc', totalImported: 5 }));
+      mockJobRepo.update.mockResolvedValue(undefined);
+      const spy = jest.spyOn(service, 'fetchTransactionPage').mockResolvedValue([]);
+
+      await service.importHistory('job-uuid', 'wallet-uuid', 'GABC');
+
+      expect(spy).toHaveBeenCalledWith('GABC', 'cursor-abc');
+    });
+  });
+
+  // ── mapHorizonTxToInternal ─────────────────────────────────────────────────
+
+  describe('mapHorizonTxToInternal', () => {
+    it('maps all fields correctly', () => {
+      const raw = {
+        hash: 'abc123',
+        ledger: 999,
+        created_at: '2024-06-01T12:00:00Z',
+        source_account: 'GABCDE',
+        fee_charged: '200',
+        operation_count: 2,
+        successful: true,
+        memo: 'hello',
+        envelope_xdr: 'xdr1',
+        result_xdr: 'xdr2',
+      };
+      expect(service.mapHorizonTxToInternal(raw)).toEqual({
+        txHash: 'abc123',
+        ledger: 999,
+        createdAt: '2024-06-01T12:00:00Z',
+        sourceAccount: 'GABCDE',
+        feeCharged: '200',
+        operationCount: 2,
+        successful: true,
+        memo: 'hello',
+        envelopeXdr: 'xdr1',
+        resultXdr: 'xdr2',
+      });
+    });
+
+    it('handles missing memo gracefully', () => {
+      const raw = {
+        hash: 'a', ledger: 1, created_at: '', source_account: 'G',
+        fee_charged: '0', operation_count: 1, successful: true,
+        envelope_xdr: '', result_xdr: '',
+      };
+      expect(service.mapHorizonTxToInternal(raw).memo).toBeUndefined();
+    });
+  });
+
+  // ── deduplicateByTxHash ────────────────────────────────────────────────────
+
+  describe('deduplicateByTxHash', () => {
+    it('filters out already-imported hashes', async () => {
+      mockJobRepo.manager.query.mockResolvedValue([{ txHash: 'hash1' }]);
+      const result = await service.deduplicateByTxHash('wallet', [makeTx('hash1'), makeTx('hash2')]);
+      expect(result).toHaveLength(1);
+      expect(result[0].txHash).toBe('hash2');
+    });
+
+    it('returns all records when none exist in DB', async () => {
+      mockJobRepo.manager.query.mockResolvedValue([]);
+      const result = await service.deduplicateByTxHash('wallet', [makeTx('h1'), makeTx('h2')]);
+      expect(result).toHaveLength(2);
+    });
+
+    it('returns all records when table does not exist yet', async () => {
+      mockJobRepo.manager.query.mockRejectedValue(new Error('relation does not exist'));
+      const result = await service.deduplicateByTxHash('wallet', [makeTx('h1')]);
+      expect(result).toHaveLength(1);
+    });
+
+    it('returns empty array for empty input', async () => {
+      const result = await service.deduplicateByTxHash('wallet', []);
+      expect(result).toEqual([]);
+    });
+  });
+
+  // ── getImportStatus ────────────────────────────────────────────────────────
+
+  describe('getImportStatus', () => {
+    it('returns DTO for the most recent job', async () => {
+      const job = makeJob({ status: ImportJobStatus.COMPLETED, totalImported: 42 });
+      mockJobRepo.findOne.mockResolvedValue(job);
+      const result = await service.getImportStatus('wallet-uuid');
+      expect(result.status).toBe(ImportJobStatus.COMPLETED);
+      expect(result.totalImported).toBe(42);
+    });
+
+    it('throws NotFoundException when no job exists', async () => {
+      mockJobRepo.findOne.mockResolvedValue(null);
+      await expect(service.getImportStatus('wallet-uuid')).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  // ── syncNewTransactions ────────────────────────────────────────────────────
+
+  describe('syncNewTransactions', () => {
+    it('syncs from last cursor and returns count', async () => {
+      mockJobRepo.findOne.mockResolvedValue(
+        makeJob({ status: ImportJobStatus.COMPLETED, cursor: 'cursor-xyz' }),
+      );
+      const txs = [makeTx('hashNew')];
+      jest.spyOn(service, 'fetchTransactionPage').mockResolvedValue(txs);
+      jest.spyOn(service, 'deduplicateByTxHash').mockResolvedValue(txs);
+      jest.spyOn(service as any, 'persistTransactions').mockResolvedValue(undefined);
+
+      const count = await service.syncNewTransactions('wallet-uuid', 'GABC');
+      expect(service.fetchTransactionPage).toHaveBeenCalledWith('GABC', 'cursor-xyz');
+      expect(count).toBe(1);
+    });
+
+    it('returns 0 when no new transactions', async () => {
+      mockJobRepo.findOne.mockResolvedValue(null);
+      jest.spyOn(service, 'fetchTransactionPage').mockResolvedValue([]);
+      jest.spyOn(service, 'deduplicateByTxHash').mockResolvedValue([]);
+      expect(await service.syncNewTransactions('wallet-uuid', 'GABC')).toBe(0);
+    });
+  });
+
+  // ── resumeFromCursor ───────────────────────────────────────────────────────
+
+  describe('resumeFromCursor', () => {
+    it('calls importHistory with the stored walletId', async () => {
+      mockJobRepo.findOne.mockResolvedValue(makeJob());
+      const spy = jest.spyOn(service, 'importHistory').mockResolvedValue(undefined);
+      await service.resumeFromCursor('job-uuid', 'GABC');
+      expect(spy).toHaveBeenCalledWith('job-uuid', 'wallet-uuid', 'GABC');
+    });
+
+    it('throws NotFoundException for unknown job', async () => {
+      mockJobRepo.findOne.mockResolvedValue(null);
+      await expect(service.resumeFromCursor('bad', 'GABC')).rejects.toThrow(NotFoundException);
+    });
+  });
+});

--- a/src/stellar-history-importer/stellar-history-importer.service.ts
+++ b/src/stellar-history-importer/stellar-history-importer.service.ts
@@ -1,0 +1,278 @@
+import { Injectable, Logger, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { InjectQueue } from '@nestjs/bullmq';
+import { Queue } from 'bullmq';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import { ConfigService } from '@nestjs/config';
+import * as StellarSdk from '@stellar/stellar-sdk';
+import {
+  HistoryImportJob,
+  ImportJobStatus,
+} from './entities/history-import-job.entity';
+import {
+  HISTORY_IMPORT_QUEUE,
+  HistoryImportJobData,
+} from './processors/history-import.processor';
+import { ImportStatusDto } from './dto/import-status.dto';
+
+export interface StellarTxRecord {
+  txHash: string;
+  ledger: number;
+  createdAt: string;
+  sourceAccount: string;
+  feeCharged: string;
+  operationCount: number;
+  successful: boolean;
+  memo?: string;
+  envelopeXdr: string;
+  resultXdr: string;
+}
+
+const BATCH_SIZE = 200;
+
+@Injectable()
+export class StellarHistoryImporterService {
+  private readonly logger = new Logger(StellarHistoryImporterService.name);
+  private readonly horizonServer: StellarSdk.Horizon.Server;
+
+  constructor(
+    @InjectRepository(HistoryImportJob)
+    private readonly jobRepo: Repository<HistoryImportJob>,
+    @InjectQueue(HISTORY_IMPORT_QUEUE)
+    private readonly importQueue: Queue<HistoryImportJobData>,
+    private readonly eventEmitter: EventEmitter2,
+    private readonly configService: ConfigService,
+  ) {
+    const horizonUrl = this.configService.get<string>(
+      'STELLAR_HORIZON_URL',
+      'https://horizon-testnet.stellar.org',
+    );
+    this.horizonServer = new StellarSdk.Horizon.Server(horizonUrl);
+  }
+
+  /**
+   * Create a PENDING import job and enqueue it.
+   * Any existing RUNNING jobs for the same wallet are marked FAILED (superseded).
+   */
+  async triggerImport(walletId: string, walletAddress: string): Promise<HistoryImportJob> {
+    await this.jobRepo.update(
+      { walletId, status: ImportJobStatus.RUNNING },
+      { status: ImportJobStatus.FAILED, errorMessage: 'Superseded by new import job' },
+    );
+
+    const job = this.jobRepo.create({
+      walletId,
+      status: ImportJobStatus.PENDING,
+      totalImported: 0,
+    });
+    const saved = await this.jobRepo.save(job);
+
+    await this.importQueue.add(
+      'import',
+      { jobId: saved.id, walletId, walletAddress },
+      { attempts: 3, backoff: { type: 'exponential', delay: 5_000 } },
+    );
+
+    this.logger.log(`Import job ${saved.id} queued for wallet ${walletId}`);
+    return saved;
+  }
+
+  /**
+   * Execute a cursor-based full history import.
+   * Saves progress after each page so the job is resumable on retry.
+   */
+  async importHistory(
+    jobId: string,
+    walletId: string,
+    walletAddress: string,
+  ): Promise<void> {
+    const job = await this.jobRepo.findOne({ where: { id: jobId } });
+    if (!job) throw new NotFoundException(`Import job ${jobId} not found`);
+
+    await this.jobRepo.update(jobId, { status: ImportJobStatus.RUNNING });
+
+    try {
+      let totalImported = job.totalImported;
+      let cursor = job.cursor ?? undefined;
+
+      // eslint-disable-next-line no-constant-condition
+      while (true) {
+        const page = await this.fetchTransactionPage(walletAddress, cursor);
+        if (page.length === 0) break;
+
+        const deduped = await this.deduplicateByTxHash(walletId, page);
+
+        if (deduped.length > 0) {
+          await this.persistTransactions(walletId, deduped);
+          totalImported += deduped.length;
+        }
+
+        cursor = page[page.length - 1].txHash;
+        await this.jobRepo.update(jobId, { totalImported, cursor });
+
+        if (page.length < BATCH_SIZE) break;
+      }
+
+      await this.jobRepo.update(jobId, {
+        status: ImportJobStatus.COMPLETED,
+        totalImported,
+        cursor,
+        completedAt: new Date(),
+      });
+
+      this.logger.log(`Job ${jobId} completed — ${totalImported} tx imported for wallet ${walletId}`);
+
+      this.eventEmitter.emit('wallet.history.imported', { walletId, jobId, totalImported });
+    } catch (error) {
+      await this.jobRepo.update(jobId, {
+        status: ImportJobStatus.FAILED,
+        errorMessage: (error as Error).message,
+      });
+      throw error;
+    }
+  }
+
+  /** Fetch up to BATCH_SIZE transactions from Horizon starting after `cursor`. */
+  async fetchTransactionPage(
+    walletAddress: string,
+    cursor?: string,
+  ): Promise<StellarTxRecord[]> {
+    let builder = this.horizonServer
+      .transactions()
+      .forAccount(walletAddress)
+      .limit(BATCH_SIZE)
+      .order('asc');
+
+    if (cursor) builder = builder.cursor(cursor);
+
+    const response = await builder.call();
+    return response.records.map((r) => this.mapHorizonTxToInternal(r));
+  }
+
+  /** Map a raw Horizon transaction record to the internal representation. */
+  mapHorizonTxToInternal(record: any): StellarTxRecord {
+    return {
+      txHash: record.hash,
+      ledger: record.ledger,
+      createdAt: record.created_at,
+      sourceAccount: record.source_account,
+      feeCharged: record.fee_charged,
+      operationCount: record.operation_count,
+      successful: record.successful,
+      memo: record.memo,
+      envelopeXdr: record.envelope_xdr,
+      resultXdr: record.result_xdr,
+    };
+  }
+
+  /** Remove transactions already stored for this wallet. */
+  async deduplicateByTxHash(
+    walletId: string,
+    records: StellarTxRecord[],
+  ): Promise<StellarTxRecord[]> {
+    if (records.length === 0) return [];
+    const hashes = records.map((r) => r.txHash);
+    try {
+      const existing: { txHash: string }[] = await this.jobRepo.manager.query(
+        `SELECT "txHash" FROM stellar_imported_transactions WHERE "walletId" = $1 AND "txHash" = ANY($2)`,
+        [walletId, hashes],
+      );
+      const existingSet = new Set(existing.map((r) => r.txHash));
+      return records.filter((r) => !existingSet.has(r.txHash));
+    } catch {
+      // Table may not exist on first run — return all records.
+      return records;
+    }
+  }
+
+  /** Resume an existing job from its saved cursor. */
+  async resumeFromCursor(jobId: string, walletAddress: string): Promise<void> {
+    const job = await this.jobRepo.findOne({ where: { id: jobId } });
+    if (!job) throw new NotFoundException(`Import job ${jobId} not found`);
+    await this.importHistory(jobId, job.walletId, walletAddress);
+  }
+
+  /** Fetch the latest import status for a wallet. */
+  async getImportStatus(walletId: string): Promise<ImportStatusDto> {
+    const job = await this.jobRepo.findOne({
+      where: { walletId },
+      order: { startedAt: 'DESC' },
+    });
+    if (!job) throw new NotFoundException(`No import job found for wallet ${walletId}`);
+
+    return {
+      jobId: job.id,
+      walletId: job.walletId,
+      status: job.status,
+      totalImported: job.totalImported,
+      cursor: job.cursor,
+      errorMessage: job.errorMessage,
+      startedAt: job.startedAt,
+      completedAt: job.completedAt,
+    };
+  }
+
+  /** Sync only new transactions since the last completed import cursor. */
+  async syncNewTransactions(walletId: string, walletAddress: string): Promise<number> {
+    const latestJob = await this.jobRepo.findOne({
+      where: { walletId, status: ImportJobStatus.COMPLETED },
+      order: { completedAt: 'DESC' },
+    });
+
+    const cursor = latestJob?.cursor;
+    const page = await this.fetchTransactionPage(walletAddress, cursor);
+    const deduped = await this.deduplicateByTxHash(walletId, page);
+
+    if (deduped.length > 0) await this.persistTransactions(walletId, deduped);
+    return deduped.length;
+  }
+
+  private async persistTransactions(
+    walletId: string,
+    records: StellarTxRecord[],
+  ): Promise<void> {
+    if (records.length === 0) return;
+
+    await this.jobRepo.manager.query(`
+      CREATE TABLE IF NOT EXISTS stellar_imported_transactions (
+        id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+        "walletId"    UUID NOT NULL,
+        "txHash"      VARCHAR(64) NOT NULL UNIQUE,
+        ledger        INTEGER NOT NULL,
+        "createdAt"   TIMESTAMP NOT NULL,
+        "sourceAccount" VARCHAR(56) NOT NULL,
+        "feeCharged"  VARCHAR(20),
+        "operationCount" INTEGER,
+        successful    BOOLEAN,
+        memo          TEXT,
+        "envelopeXdr" TEXT,
+        "resultXdr"   TEXT,
+        "importedAt"  TIMESTAMP DEFAULT now()
+      )
+    `);
+
+    const values = records
+      .map((_, i) =>
+        `($${i * 11 + 1},$${i * 11 + 2},$${i * 11 + 3},$${i * 11 + 4},$${i * 11 + 5},$${i * 11 + 6},$${i * 11 + 7},$${i * 11 + 8},$${i * 11 + 9},$${i * 11 + 10},$${i * 11 + 11})`,
+      )
+      .join(',');
+
+    const params: any[] = [];
+    for (const r of records) {
+      params.push(
+        walletId, r.txHash, r.ledger, r.createdAt, r.sourceAccount,
+        r.feeCharged, r.operationCount, r.successful, r.memo ?? null,
+        r.envelopeXdr, r.resultXdr,
+      );
+    }
+
+    await this.jobRepo.manager.query(
+      `INSERT INTO stellar_imported_transactions
+         ("walletId","txHash",ledger,"createdAt","sourceAccount","feeCharged","operationCount",successful,memo,"envelopeXdr","resultXdr")
+       VALUES ${values}
+       ON CONFLICT ("txHash") DO NOTHING`,
+      params,
+    );
+  }
+}


### PR DESCRIPTION
## Summary

- Implements reliable offline message queuing and ordered delivery on reconnect
- `OfflineQueueService` uses a Redis sorted set (score = timestamp ms) per user for fast enqueue/dequeue; falls back to PostgreSQL for durability after 1 hour
- `flushOnConnect` delivers all pending messages in strict chronological order, bracketed by `sync:start` and `sync:complete` WebSocket events
- `OfflineQueueGateway` hooks into the `/chat` namespace `OnGatewayConnection` lifecycle to auto-flush when a user reconnects
- Admin alert logged (and surfaced in stats API) when any user queue depth exceeds 1000 messages
- Scheduled cron: persist stale Redis entries to Postgres every 10 min; prune delivered records daily at 02:00

## Files

- `src/offline-queue/entities/offline-message-queue.entity.ts` — `OfflineMessageQueue` entity with `QueueStatus` enum
- `src/offline-queue/dto/offline-queue.dto.ts` — `EnqueueMessageDto`, `QueueStatsDto`, `FlushResultDto`
- `src/offline-queue/offline-queue.service.ts` — core service with all queue operations and scheduled jobs
- `src/offline-queue/offline-queue.gateway.ts` — WS gateway that triggers flush on user connect
- `src/offline-queue/offline-queue.controller.ts` — `GET /admin/offline-queue/stats`, `POST /admin/offline-queue/flush/:userId`
- `src/offline-queue/offline-queue.module.ts` — module wiring with dedicated Redis connection
- `src/offline-queue/offline-queue.service.spec.ts` — unit test suite (enqueue, dequeue, markDelivered, retryFailed, flushOnConnect, pruneOld, getStats, persistStaleRedisEntries)

Closes #641