### PR TITLE
feat: implement email module (closes #415)

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -40,6 +40,7 @@ import { ReactionsModule } from './reactions/reactions.module';
 import { StickersModule } from './stickers/stickers.module';
 import { PrivacyModule } from './privacy/privacy.module';
 import { SpamDetectionModule } from './spam-detection/spam-detection.module';
+import { EmailModule } from './email/email.module';
 import { LeaderboardModule } from './leaderboard/leaderboard.module';
 import { PinnedMessagesModule } from './pinned-messages/pinned-messages.module';
 import { Sep10Module } from './sep10/sep10.module';
@@ -90,6 +91,7 @@ import { QrCodeModule } from './qr-code/qr-code.module';
     StickersModule,
     PrivacyModule,
     SpamDetectionModule,
+    EmailModule,
     LeaderboardModule,
     PinnedMessagesModule,
     Sep10Module,

--- a/src/config/env.validation.ts
+++ b/src/config/env.validation.ts
@@ -61,6 +61,14 @@ export const envValidationSchema = Joi.object({
     'image/jpeg,image/png,image/webp,image/gif,video/mp4,audio/mpeg,audio/wav,application/pdf',
   ),
 
+  // Email
+  EMAIL_PROVIDER: Joi.string().valid('sendgrid', 'zeptomail').default('sendgrid'),
+  EMAIL_FROM_ADDRESS: Joi.string().email().default('noreply@example.com'),
+  SENDGRID_API_KEY: Joi.string().allow('').optional(),
+  ZEPTOMAIL_API_KEY: Joi.string().allow('').optional(),
+  ZEPTOMAIL_API_URL: Joi.string().uri().optional(),
+  APP_PUBLIC_URL: Joi.string().uri().default('https://app.whspr.example'),
+
   // Soroban RPC
   SOROBAN_RPC_URL: Joi.string().uri().required(),
   SOROBAN_CONTRACT_IDS: Joi.string().default(''), // comma-separated contract addresses

--- a/src/email/constants.ts
+++ b/src/email/constants.ts
@@ -1,0 +1,3 @@
+export const EMAIL_QUEUE_NAME = 'email-delivery';
+export const EMAIL_DLQ_NAME = 'email-delivery-dlq';
+export const EMAIL_PROVIDER_TOKEN = 'EMAIL_PROVIDER';

--- a/src/email/email-queue.service.ts
+++ b/src/email/email-queue.service.ts
@@ -1,0 +1,73 @@
+import { Injectable, OnModuleDestroy } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { JobsOptions, Queue, Worker } from 'bullmq';
+import Redis from 'ioredis';
+import { EMAIL_DLQ_NAME, EMAIL_QUEUE_NAME } from './constants';
+
+export interface EmailJobPayload {
+  deliveryId: string;
+}
+
+@Injectable()
+export class EmailQueueService implements OnModuleDestroy {
+  private readonly connection: Redis;
+  private readonly queue: Queue<EmailJobPayload>;
+  private readonly dlq: Queue<EmailJobPayload>;
+  private worker: Worker<EmailJobPayload> | null = null;
+
+  constructor(private readonly configService: ConfigService) {
+    this.connection = new Redis({
+      host: this.configService.get<string>('REDIS_HOST', 'localhost'),
+      port: this.configService.get<number>('REDIS_PORT', 6379),
+      password: this.configService.get<string>('REDIS_PASSWORD') || undefined,
+      db: this.configService.get<number>('REDIS_DB', 0),
+    });
+
+    this.queue = new Queue<EmailJobPayload>(EMAIL_QUEUE_NAME, {
+      connection: this.connection,
+      defaultJobOptions: {
+        attempts: 3,
+        backoff: { type: 'exponential', delay: 1000 },
+        removeOnComplete: 100,
+        removeOnFail: 100,
+      },
+    });
+    this.dlq = new Queue<EmailJobPayload>(EMAIL_DLQ_NAME, {
+      connection: this.connection,
+    });
+  }
+
+  async enqueue(payload: EmailJobPayload, options?: JobsOptions): Promise<void> {
+    await this.queue.add('send-email', payload, options);
+  }
+
+  registerWorker(processor: (payload: EmailJobPayload) => Promise<void>): void {
+    if (this.worker) {
+      return;
+    }
+
+    this.worker = new Worker<EmailJobPayload>(
+      EMAIL_QUEUE_NAME,
+      async (job) => {
+        try {
+          await processor(job.data);
+        } catch (error) {
+          if (job.attemptsMade + 1 >= (job.opts.attempts ?? 1)) {
+            await this.dlq.add('send-email-dlq', job.data);
+          }
+          throw error;
+        }
+      },
+      { connection: this.connection },
+    );
+  }
+
+  async onModuleDestroy(): Promise<void> {
+    if (this.worker) {
+      await this.worker.close();
+    }
+    await this.queue.close();
+    await this.dlq.close();
+    await this.connection.quit();
+  }
+}

--- a/src/email/email-template.service.ts
+++ b/src/email/email-template.service.ts
@@ -1,0 +1,34 @@
+import { Injectable } from '@nestjs/common';
+import { EMAIL_TEMPLATE_REGISTRY } from './templates/email-template.registry';
+import { EmailType } from './enums/email-type.enum';
+
+export interface RenderedTemplate {
+  subject: string;
+  html: string;
+  text: string;
+}
+
+@Injectable()
+export class EmailTemplateService {
+  render(
+    type: EmailType,
+    variables: Record<string, string | number | null | undefined>,
+  ): RenderedTemplate {
+    const template = EMAIL_TEMPLATE_REGISTRY[type];
+    return {
+      subject: this.renderHandlebars(template.subject, variables),
+      html: this.renderHandlebars(template.html, variables),
+      text: this.renderHandlebars(template.text, variables),
+    };
+  }
+
+  private renderHandlebars(
+    input: string,
+    variables: Record<string, string | number | null | undefined>,
+  ): string {
+    return input.replace(/{{\s*([\w.]+)\s*}}/g, (_match, key: string) => {
+      const value = variables[key];
+      return value === null || value === undefined ? '' : String(value);
+    });
+  }
+}

--- a/src/email/email-worker.service.ts
+++ b/src/email/email-worker.service.ts
@@ -1,0 +1,17 @@
+import { Injectable, OnModuleInit } from '@nestjs/common';
+import { EmailService } from './email.service';
+import { EmailQueueService } from './email-queue.service';
+
+@Injectable()
+export class EmailWorkerService implements OnModuleInit {
+  constructor(
+    private readonly queueService: EmailQueueService,
+    private readonly emailService: EmailService,
+  ) {}
+
+  onModuleInit(): void {
+    this.queueService.registerWorker(async ({ deliveryId }) => {
+      await this.emailService.processDelivery(deliveryId);
+    });
+  }
+}

--- a/src/email/email.module.ts
+++ b/src/email/email.module.ts
@@ -1,0 +1,31 @@
+import { Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { EMAIL_PROVIDER_TOKEN } from './constants';
+import { EmailDeliveriesRepository, EmailUnsubscribesRepository } from './email.repository';
+import { EmailQueueService } from './email-queue.service';
+import { EmailService } from './email.service';
+import { EmailTemplateService } from './email-template.service';
+import { EmailWorkerService } from './email-worker.service';
+import { EmailDelivery } from './entities/email-delivery.entity';
+import { EmailUnsubscribe } from './entities/email-unsubscribe.entity';
+import { HttpEmailProvider } from './providers/http-email.provider';
+
+@Module({
+  imports: [ConfigModule, TypeOrmModule.forFeature([EmailDelivery, EmailUnsubscribe])],
+  providers: [
+    EmailDeliveriesRepository,
+    EmailUnsubscribesRepository,
+    EmailTemplateService,
+    EmailQueueService,
+    EmailWorkerService,
+    EmailService,
+    HttpEmailProvider,
+    {
+      provide: EMAIL_PROVIDER_TOKEN,
+      useExisting: HttpEmailProvider,
+    },
+  ],
+  exports: [EmailService],
+})
+export class EmailModule {}

--- a/src/email/email.repository.ts
+++ b/src/email/email.repository.ts
@@ -1,0 +1,22 @@
+import { Injectable } from '@nestjs/common';
+import { DataSource, Repository } from 'typeorm';
+import { EmailDelivery } from './entities/email-delivery.entity';
+import { EmailUnsubscribe } from './entities/email-unsubscribe.entity';
+
+@Injectable()
+export class EmailDeliveriesRepository extends Repository<EmailDelivery> {
+  constructor(private readonly dataSource: DataSource) {
+    super(EmailDelivery, dataSource.createEntityManager());
+  }
+}
+
+@Injectable()
+export class EmailUnsubscribesRepository extends Repository<EmailUnsubscribe> {
+  constructor(private readonly dataSource: DataSource) {
+    super(EmailUnsubscribe, dataSource.createEntityManager());
+  }
+
+  findByEmail(email: string): Promise<EmailUnsubscribe | null> {
+    return this.findOne({ where: { email: email.toLowerCase() } });
+  }
+}

--- a/src/email/email.service.spec.ts
+++ b/src/email/email.service.spec.ts
@@ -1,0 +1,152 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+import { EmailDeliveriesRepository, EmailUnsubscribesRepository } from './email.repository';
+import { EmailQueueService } from './email-queue.service';
+import { EmailService } from './email.service';
+import { EmailTemplateService } from './email-template.service';
+import { EmailDeliveryStatus, EmailType } from './enums/email-type.enum';
+import { EMAIL_PROVIDER_TOKEN } from './constants';
+
+describe('EmailService', () => {
+  let service: EmailService;
+  let deliveriesRepository: jest.Mocked<EmailDeliveriesRepository>;
+  let unsubscribesRepository: jest.Mocked<EmailUnsubscribesRepository>;
+  let queueService: jest.Mocked<EmailQueueService>;
+  let provider: { send: jest.Mock };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        EmailService,
+        EmailTemplateService,
+        {
+          provide: EmailDeliveriesRepository,
+          useValue: {
+            create: jest.fn((value) => value),
+            save: jest.fn(async (value) => ({
+              id: value.id ?? 'delivery-1',
+              createdAt: value.createdAt ?? new Date('2026-01-01T00:00:00.000Z'),
+              updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+              ...value,
+            })),
+            findOne: jest.fn(),
+          },
+        },
+        {
+          provide: EmailUnsubscribesRepository,
+          useValue: {
+            create: jest.fn((value) => value),
+            save: jest.fn(async (value) => value),
+            findByEmail: jest.fn(),
+          },
+        },
+        {
+          provide: EmailQueueService,
+          useValue: {
+            enqueue: jest.fn().mockResolvedValue(undefined),
+          },
+        },
+        {
+          provide: ConfigService,
+          useValue: {
+            get: jest.fn((key: string, fallback?: string) => {
+              if (key === 'APP_PUBLIC_URL') {
+                return 'https://app.whspr.example';
+              }
+              return fallback;
+            }),
+          },
+        },
+        {
+          provide: EMAIL_PROVIDER_TOKEN,
+          useValue: {
+            send: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get(EmailService);
+    deliveriesRepository = module.get(EmailDeliveriesRepository);
+    unsubscribesRepository = module.get(EmailUnsubscribesRepository);
+    queueService = module.get(EmailQueueService);
+    provider = module.get(EMAIL_PROVIDER_TOKEN);
+  });
+
+  it('queues a welcome email with rendered HTML', async () => {
+    unsubscribesRepository.findByEmail.mockResolvedValue(null);
+
+    const delivery = await service.sendWelcome({
+      to: 'user@example.com',
+      displayName: 'Ada',
+    });
+
+    expect(delivery.type).toBe(EmailType.WELCOME);
+    expect(delivery.status).toBe(EmailDeliveryStatus.QUEUED);
+    expect(delivery.html).toContain('Welcome, Ada');
+    expect(queueService.enqueue).toHaveBeenCalledWith({ deliveryId: 'delivery-1' });
+  });
+
+  it('suppresses unsubscribe-respecting emails', async () => {
+    unsubscribesRepository.findByEmail.mockResolvedValue({
+      id: 'unsub-1',
+      email: 'user@example.com',
+      reason: null,
+      createdAt: new Date(),
+    });
+
+    const delivery = await service.sendGroupInvite({
+      to: 'user@example.com',
+      inviterName: 'Grace',
+      groupName: 'Builders',
+      inviteUrl: 'https://example.com/invite',
+    });
+
+    expect(delivery.status).toBe(EmailDeliveryStatus.FAILED);
+    expect(queueService.enqueue).not.toHaveBeenCalled();
+  });
+
+  it('processes queued deliveries with a mocked provider', async () => {
+    deliveriesRepository.findOne.mockResolvedValue({
+      id: 'delivery-1',
+      type: EmailType.SECURITY_ALERT,
+      to: 'user@example.com',
+      subject: 'Security alert',
+      html: '<p>Alert</p>',
+      text: 'Alert',
+      status: EmailDeliveryStatus.QUEUED,
+      providerMessageId: null,
+      metadata: {},
+      failureReason: null,
+      attempts: 0,
+      sentAt: null,
+      deliveredAt: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+    provider.send.mockResolvedValue({
+      messageId: 'provider-1',
+      deliveredAt: new Date('2026-01-01T00:00:00.000Z'),
+    });
+
+    const result = await service.processDelivery('delivery-1');
+
+    expect(result.status).toBe(EmailDeliveryStatus.DELIVERED);
+    expect(result.providerMessageId).toBe('provider-1');
+  });
+
+  it('renders generic handlebars-style templates', async () => {
+    unsubscribesRepository.findByEmail.mockResolvedValue(null);
+
+    const delivery = await service.sendGeneric({
+      to: 'user@example.com',
+      subject: 'Update',
+      heading: 'Hello',
+      body: 'A generic message',
+    });
+
+    expect(delivery.subject).toBe('Update');
+    expect(delivery.html).toContain('Hello');
+    expect(delivery.text).toContain('A generic message');
+  });
+});

--- a/src/email/email.service.ts
+++ b/src/email/email.service.ts
@@ -1,0 +1,245 @@
+import { Inject, Injectable, NotFoundException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { EMAIL_PROVIDER_TOKEN } from './constants';
+import { EmailDeliveriesRepository, EmailUnsubscribesRepository } from './email.repository';
+import { EmailQueueService } from './email-queue.service';
+import { EmailTemplateService } from './email-template.service';
+import { EmailDeliveryStatus, EmailType } from './enums/email-type.enum';
+import { EmailDelivery } from './entities/email-delivery.entity';
+import { EmailProvider } from './interfaces/email-provider.interface';
+
+interface QueueEmailOptions {
+  type: EmailType;
+  to: string;
+  variables: Record<string, string | number | null | undefined>;
+  metadata?: Record<string, unknown>;
+  respectUnsubscribe?: boolean;
+}
+
+@Injectable()
+export class EmailService {
+  constructor(
+    private readonly deliveriesRepository: EmailDeliveriesRepository,
+    private readonly unsubscribesRepository: EmailUnsubscribesRepository,
+    private readonly templateService: EmailTemplateService,
+    private readonly queueService: EmailQueueService,
+    private readonly configService: ConfigService,
+    @Inject(EMAIL_PROVIDER_TOKEN)
+    private readonly provider: EmailProvider,
+  ) {}
+
+  sendWelcome(input: { to: string; displayName?: string | null }): Promise<EmailDelivery> {
+    return this.queueTemplatedEmail({
+      type: EmailType.WELCOME,
+      to: input.to,
+      variables: {
+        displayName: input.displayName ?? 'there',
+        appUrl: this.configService.get<string>('APP_PUBLIC_URL', 'https://app.whspr.example'),
+        unsubscribeLink: this.unsubscribeHtml(input.to),
+        unsubscribeText: this.unsubscribeText(input.to),
+      },
+      respectUnsubscribe: true,
+    });
+  }
+
+  sendVerification(input: {
+    to: string;
+    displayName?: string | null;
+    verificationUrl: string;
+  }): Promise<EmailDelivery> {
+    return this.queueTemplatedEmail({
+      type: EmailType.VERIFICATION,
+      to: input.to,
+      variables: {
+        displayName: input.displayName ?? 'there',
+        verificationUrl: input.verificationUrl,
+      },
+      respectUnsubscribe: false,
+    });
+  }
+
+  sendTransactionReceipt(input: {
+    to: string;
+    displayName?: string | null;
+    amount: string;
+    asset: string;
+    reference: string;
+  }): Promise<EmailDelivery> {
+    return this.queueTemplatedEmail({
+      type: EmailType.TRANSACTION_RECEIPT,
+      to: input.to,
+      variables: {
+        displayName: input.displayName ?? 'there',
+        amount: input.amount,
+        asset: input.asset,
+        reference: input.reference,
+      },
+      metadata: { reference: input.reference },
+      respectUnsubscribe: false,
+    });
+  }
+
+  sendGroupInvite(input: {
+    to: string;
+    inviterName: string;
+    groupName: string;
+    inviteUrl: string;
+  }): Promise<EmailDelivery> {
+    return this.queueTemplatedEmail({
+      type: EmailType.GROUP_INVITE,
+      to: input.to,
+      variables: {
+        inviterName: input.inviterName,
+        groupName: input.groupName,
+        inviteUrl: input.inviteUrl,
+        unsubscribeLink: this.unsubscribeHtml(input.to),
+        unsubscribeText: this.unsubscribeText(input.to),
+      },
+      respectUnsubscribe: true,
+    });
+  }
+
+  sendSecurityAlert(input: {
+    to: string;
+    displayName?: string | null;
+    message: string;
+    actionUrl: string;
+  }): Promise<EmailDelivery> {
+    return this.queueTemplatedEmail({
+      type: EmailType.SECURITY_ALERT,
+      to: input.to,
+      variables: {
+        displayName: input.displayName ?? 'there',
+        message: input.message,
+        actionUrl: input.actionUrl,
+      },
+      metadata: { actionUrl: input.actionUrl },
+      respectUnsubscribe: false,
+    });
+  }
+
+  sendGeneric(input: {
+    to: string;
+    subject: string;
+    heading: string;
+    body: string;
+    respectUnsubscribe?: boolean;
+  }): Promise<EmailDelivery> {
+    return this.queueTemplatedEmail({
+      type: EmailType.GENERIC,
+      to: input.to,
+      variables: {
+        subject: input.subject,
+        heading: input.heading,
+        body: input.body,
+        unsubscribeLink: this.unsubscribeHtml(input.to),
+        unsubscribeText: this.unsubscribeText(input.to),
+      },
+      respectUnsubscribe: input.respectUnsubscribe ?? true,
+    });
+  }
+
+  async unsubscribe(email: string, reason?: string): Promise<void> {
+    const normalized = email.toLowerCase();
+    const existing = await this.unsubscribesRepository.findByEmail(normalized);
+    if (existing) {
+      return;
+    }
+
+    await this.unsubscribesRepository.save(
+      this.unsubscribesRepository.create({ email: normalized, reason: reason ?? null }),
+    );
+  }
+
+  async processDelivery(deliveryId: string): Promise<EmailDelivery> {
+    const delivery = await this.deliveriesRepository.findOne({ where: { id: deliveryId } });
+    if (!delivery) {
+      throw new NotFoundException(`Email delivery ${deliveryId} not found`);
+    }
+
+    try {
+      const result = await this.provider.send({
+        deliveryId: delivery.id,
+        to: delivery.to,
+        subject: delivery.subject,
+        html: delivery.html,
+        text: delivery.text,
+        type: delivery.type,
+        metadata: delivery.metadata,
+      });
+
+      delivery.status = result.deliveredAt
+        ? EmailDeliveryStatus.DELIVERED
+        : EmailDeliveryStatus.SENT;
+      delivery.providerMessageId = result.messageId;
+      delivery.sentAt = new Date();
+      delivery.deliveredAt = result.deliveredAt ?? null;
+      delivery.failureReason = null;
+      delivery.attempts += 1;
+    } catch (error) {
+      delivery.status = EmailDeliveryStatus.FAILED;
+      delivery.failureReason = error instanceof Error ? error.message : 'Unknown email failure';
+      delivery.attempts += 1;
+      await this.deliveriesRepository.save(delivery);
+      throw error;
+    }
+
+    return this.deliveriesRepository.save(delivery);
+  }
+
+  private async queueTemplatedEmail(options: QueueEmailOptions): Promise<EmailDelivery> {
+    if (options.respectUnsubscribe && (await this.isUnsubscribed(options.to))) {
+      return this.deliveriesRepository.save(
+        this.deliveriesRepository.create({
+          type: options.type,
+          to: options.to.toLowerCase(),
+          subject: `Suppressed ${options.type} email`,
+          html: '',
+          text: '',
+          status: EmailDeliveryStatus.FAILED,
+          failureReason: 'Recipient has unsubscribed from email delivery',
+          metadata: options.metadata ?? {},
+          providerMessageId: null,
+          attempts: 0,
+          sentAt: null,
+          deliveredAt: null,
+        }),
+      );
+    }
+
+    const rendered = this.templateService.render(options.type, options.variables);
+    const delivery = await this.deliveriesRepository.save(
+      this.deliveriesRepository.create({
+        type: options.type,
+        to: options.to.toLowerCase(),
+        subject: rendered.subject,
+        html: rendered.html,
+        text: rendered.text,
+        status: EmailDeliveryStatus.QUEUED,
+        metadata: options.metadata ?? {},
+        providerMessageId: null,
+        failureReason: null,
+        attempts: 0,
+        sentAt: null,
+        deliveredAt: null,
+      }),
+    );
+
+    await this.queueService.enqueue({ deliveryId: delivery.id });
+    return delivery;
+  }
+
+  private async isUnsubscribed(email: string): Promise<boolean> {
+    return !!(await this.unsubscribesRepository.findByEmail(email.toLowerCase()));
+  }
+
+  private unsubscribeHtml(email: string): string {
+    const baseUrl = this.configService.get<string>('APP_PUBLIC_URL', 'https://app.whspr.example');
+    return `<p><a href="${baseUrl}/unsubscribe?email=${encodeURIComponent(email)}">Unsubscribe</a></p>`;
+  }
+
+  private unsubscribeText(email: string): string {
+    const baseUrl = this.configService.get<string>('APP_PUBLIC_URL', 'https://app.whspr.example');
+    return `Unsubscribe: ${baseUrl}/unsubscribe?email=${encodeURIComponent(email)}`;
+  }
+}

--- a/src/email/entities/email-delivery.entity.ts
+++ b/src/email/entities/email-delivery.entity.ts
@@ -1,0 +1,60 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  Index,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+import { EmailDeliveryStatus, EmailType } from '../enums/email-type.enum';
+
+@Entity('email_deliveries')
+export class EmailDelivery {
+  @PrimaryGeneratedColumn('uuid')
+  id!: string;
+
+  @Column({ type: 'varchar', length: 40 })
+  @Index('idx_email_deliveries_type')
+  type!: EmailType;
+
+  @Column({ type: 'varchar', length: 320 })
+  @Index('idx_email_deliveries_to')
+  to!: string;
+
+  @Column({ type: 'varchar', length: 255 })
+  subject!: string;
+
+  @Column({ type: 'text' })
+  html!: string;
+
+  @Column({ type: 'text', nullable: true })
+  text!: string | null;
+
+  @Column({ type: 'varchar', length: 20, default: EmailDeliveryStatus.QUEUED })
+  @Index('idx_email_deliveries_status')
+  status!: EmailDeliveryStatus;
+
+  @Column({ type: 'varchar', length: 120, nullable: true })
+  providerMessageId!: string | null;
+
+  @Column({ type: 'jsonb', default: () => "'{}'" })
+  metadata!: Record<string, unknown>;
+
+  @Column({ type: 'text', nullable: true })
+  failureReason!: string | null;
+
+  @Column({ type: 'int', default: 0 })
+  attempts!: number;
+
+  @Column({ type: 'timestamp with time zone', nullable: true })
+  sentAt!: Date | null;
+
+  @Column({ type: 'timestamp with time zone', nullable: true })
+  deliveredAt!: Date | null;
+
+  @CreateDateColumn({ type: 'timestamp with time zone' })
+  createdAt!: Date;
+
+  @UpdateDateColumn({ type: 'timestamp with time zone' })
+  updatedAt!: Date;
+}

--- a/src/email/entities/email-unsubscribe.entity.ts
+++ b/src/email/entities/email-unsubscribe.entity.ts
@@ -1,0 +1,17 @@
+import { Column, CreateDateColumn, Entity, Index, PrimaryGeneratedColumn } from 'typeorm';
+
+@Entity('email_unsubscribes')
+export class EmailUnsubscribe {
+  @PrimaryGeneratedColumn('uuid')
+  id!: string;
+
+  @Column({ type: 'varchar', length: 320, unique: true })
+  @Index('idx_email_unsubscribes_email')
+  email!: string;
+
+  @Column({ type: 'text', nullable: true })
+  reason!: string | null;
+
+  @CreateDateColumn({ type: 'timestamp with time zone' })
+  createdAt!: Date;
+}

--- a/src/email/enums/email-type.enum.ts
+++ b/src/email/enums/email-type.enum.ts
@@ -1,0 +1,15 @@
+export enum EmailType {
+  WELCOME = 'welcome',
+  VERIFICATION = 'verification',
+  TRANSACTION_RECEIPT = 'transaction_receipt',
+  GROUP_INVITE = 'group_invite',
+  SECURITY_ALERT = 'security_alert',
+  GENERIC = 'generic',
+}
+
+export enum EmailDeliveryStatus {
+  QUEUED = 'queued',
+  SENT = 'sent',
+  DELIVERED = 'delivered',
+  FAILED = 'failed',
+}

--- a/src/email/interfaces/email-provider.interface.ts
+++ b/src/email/interfaces/email-provider.interface.ts
@@ -1,0 +1,20 @@
+import { EmailType } from '../enums/email-type.enum';
+
+export interface SendEmailInput {
+  deliveryId: string;
+  to: string;
+  subject: string;
+  html: string;
+  text?: string | null;
+  type: EmailType;
+  metadata?: Record<string, unknown>;
+}
+
+export interface SendEmailResult {
+  messageId: string | null;
+  deliveredAt?: Date | null;
+}
+
+export interface EmailProvider {
+  send(input: SendEmailInput): Promise<SendEmailResult>;
+}

--- a/src/email/providers/http-email.provider.ts
+++ b/src/email/providers/http-email.provider.ts
@@ -1,0 +1,88 @@
+import { Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import {
+  EmailProvider,
+  SendEmailInput,
+  SendEmailResult,
+} from '../interfaces/email-provider.interface';
+
+@Injectable()
+export class HttpEmailProvider implements EmailProvider {
+  constructor(private readonly configService: ConfigService) {}
+
+  async send(input: SendEmailInput): Promise<SendEmailResult> {
+    const provider = this.configService.get<string>('EMAIL_PROVIDER', 'sendgrid');
+    const from = this.configService.get<string>('EMAIL_FROM_ADDRESS', 'noreply@example.com');
+
+    if (provider === 'zeptomail') {
+      return this.sendWithZeptoMail(input, from);
+    }
+
+    return this.sendWithSendGrid(input, from);
+  }
+
+  private async sendWithSendGrid(input: SendEmailInput, from: string): Promise<SendEmailResult> {
+    const apiKey = this.configService.get<string>('SENDGRID_API_KEY', '');
+    const response = await fetch('https://api.sendgrid.com/v3/mail/send', {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        from: { email: from },
+        personalizations: [{ to: [{ email: input.to }] }],
+        subject: input.subject,
+        content: [
+          { type: 'text/plain', value: input.text ?? '' },
+          { type: 'text/html', value: input.html },
+        ],
+        custom_args: {
+          deliveryId: input.deliveryId,
+          type: input.type,
+        },
+      }),
+    });
+
+    if (!response.ok) {
+      throw new Error(`SendGrid delivery failed with status ${response.status}`);
+    }
+
+    return {
+      messageId: response.headers.get('x-message-id'),
+      deliveredAt: new Date(),
+    };
+  }
+
+  private async sendWithZeptoMail(input: SendEmailInput, from: string): Promise<SendEmailResult> {
+    const apiKey = this.configService.get<string>('ZEPTOMAIL_API_KEY', '');
+    const endpoint = this.configService.get<string>(
+      'ZEPTOMAIL_API_URL',
+      'https://api.zeptomail.com/v1.1/email',
+    );
+
+    const response = await fetch(endpoint, {
+      method: 'POST',
+      headers: {
+        Authorization: `Zoho-enczapikey ${apiKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        from: { address: from },
+        to: [{ email_address: { address: input.to } }],
+        subject: input.subject,
+        htmlbody: input.html,
+        textbody: input.text ?? '',
+      }),
+    });
+
+    if (!response.ok) {
+      throw new Error(`ZeptoMail delivery failed with status ${response.status}`);
+    }
+
+    return {
+      messageId: response.headers.get('x-message-id'),
+      deliveredAt: new Date(),
+    };
+  }
+}

--- a/src/email/templates/email-template.registry.ts
+++ b/src/email/templates/email-template.registry.ts
@@ -1,0 +1,40 @@
+import { EmailType } from '../enums/email-type.enum';
+
+export interface EmailTemplateDefinition {
+  subject: string;
+  html: string;
+  text: string;
+}
+
+export const EMAIL_TEMPLATE_REGISTRY: Record<EmailType, EmailTemplateDefinition> = {
+  [EmailType.WELCOME]: {
+    subject: 'Welcome to WHSPR Stellar, {{displayName}}',
+    html: '<html><body><h1>Welcome, {{displayName}}</h1><p>Your account is ready to use.</p><p><a href="{{appUrl}}">Open WHSPR Stellar</a></p>{{unsubscribeLink}}</body></html>',
+    text: 'Welcome, {{displayName}}. Your account is ready. Visit {{appUrl}}. {{unsubscribeText}}',
+  },
+  [EmailType.VERIFICATION]: {
+    subject: 'Verify your email address',
+    html: '<html><body><h1>Verify your email</h1><p>Hi {{displayName}}, click below to verify your email address.</p><p><a href="{{verificationUrl}}">Verify email</a></p></body></html>',
+    text: 'Hi {{displayName}}, verify your email here: {{verificationUrl}}',
+  },
+  [EmailType.TRANSACTION_RECEIPT]: {
+    subject: 'Your transaction receipt',
+    html: '<html><body><h1>Transaction receipt</h1><p>{{displayName}}, we processed {{amount}} {{asset}}.</p><p>Transaction reference: {{reference}}</p></body></html>',
+    text: '{{displayName}}, we processed {{amount}} {{asset}}. Transaction reference: {{reference}}',
+  },
+  [EmailType.GROUP_INVITE]: {
+    subject: 'You were invited to join {{groupName}}',
+    html: '<html><body><h1>Group invitation</h1><p>{{inviterName}} invited you to {{groupName}}.</p><p><a href="{{inviteUrl}}">Accept invite</a></p>{{unsubscribeLink}}</body></html>',
+    text: '{{inviterName}} invited you to {{groupName}}. Accept invite: {{inviteUrl}} {{unsubscribeText}}',
+  },
+  [EmailType.SECURITY_ALERT]: {
+    subject: 'Security alert for your account',
+    html: '<html><body><h1>Security alert</h1><p>{{displayName}}, {{message}}</p><p><a href="{{actionUrl}}">Review activity</a></p></body></html>',
+    text: '{{displayName}}, {{message}} Review activity: {{actionUrl}}',
+  },
+  [EmailType.GENERIC]: {
+    subject: '{{subject}}',
+    html: '<html><body><h1>{{heading}}</h1><p>{{body}}</p>{{unsubscribeLink}}</body></html>',
+    text: '{{heading}} {{body}} {{unsubscribeText}}',
+  },
+};

--- a/src/migrations/1760000000002-EmailModuleSchema.ts
+++ b/src/migrations/1760000000002-EmailModuleSchema.ts
@@ -1,0 +1,54 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class EmailModuleSchema1760000000002 implements MigrationInterface {
+  name = 'EmailModuleSchema1760000000002';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE "email_deliveries" (
+        "id" uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
+        "type" varchar(40) NOT NULL,
+        "to" varchar(320) NOT NULL,
+        "subject" varchar(255) NOT NULL,
+        "html" text NOT NULL,
+        "text" text,
+        "status" varchar(20) NOT NULL DEFAULT 'queued',
+        "providerMessageId" varchar(120),
+        "metadata" jsonb NOT NULL DEFAULT '{}',
+        "failureReason" text,
+        "attempts" integer NOT NULL DEFAULT 0,
+        "sentAt" TIMESTAMP WITH TIME ZONE,
+        "deliveredAt" TIMESTAMP WITH TIME ZONE,
+        "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+        "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now()
+      )
+    `);
+    await queryRunner.query(`
+      CREATE TABLE "email_unsubscribes" (
+        "id" uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
+        "email" varchar(320) NOT NULL UNIQUE,
+        "reason" text,
+        "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now()
+      )
+    `);
+    await queryRunner.query(
+      `CREATE INDEX "idx_email_deliveries_type" ON "email_deliveries"("type")`,
+    );
+    await queryRunner.query(`CREATE INDEX "idx_email_deliveries_to" ON "email_deliveries"("to")`);
+    await queryRunner.query(
+      `CREATE INDEX "idx_email_deliveries_status" ON "email_deliveries"("status")`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "idx_email_unsubscribes_email" ON "email_unsubscribes"("email")`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX "idx_email_unsubscribes_email"`);
+    await queryRunner.query(`DROP INDEX "idx_email_deliveries_status"`);
+    await queryRunner.query(`DROP INDEX "idx_email_deliveries_to"`);
+    await queryRunner.query(`DROP INDEX "idx_email_deliveries_type"`);
+    await queryRunner.query(`DROP TABLE "email_unsubscribes"`);
+    await queryRunner.query(`DROP TABLE "email_deliveries"`);
+  }
+}


### PR DESCRIPTION
Implements transactional email module with async delivery.

- Adds EmailService with multiple email types
- Integrates provider (SendGrid/ZeptoMail)
- Uses BullMQ for async processing
- Adds retry + DLQ handling
- Includes templates and tracking

closes #415

Explanation (max 3 lines):
Enables reliable async email delivery.
Supports templating and retries.
Tracks delivery status and handles failures.